### PR TITLE
Fix remaining lexer issues

### DIFF
--- a/bbj-vscode/src/language/bbj-lexer.ts
+++ b/bbj-vscode/src/language/bbj-lexer.ts
@@ -1,0 +1,36 @@
+import { DefaultLexer, LexerResult } from "langium";
+
+export class BbjLexer extends DefaultLexer {
+
+    override tokenize(text: string): LexerResult {
+        text = this.prepareLineSplitter(text);
+        return super.tokenize(text);
+    }
+
+    private prepareLineSplitter(text: string): string {
+        const windowsEol = text.includes('\r\n');
+        const lines = text.split(/\r?\n/g);
+        for (let i = 0; i < lines.length - 1; i++) {
+            const start = i + 1;
+            let lineIndex = start;
+            let nextLine = lines[lineIndex];
+            let end = 0;
+            while (nextLine.charAt(0) === ':') {
+                end = lineIndex;
+                nextLine = lines[++lineIndex];
+            }
+            if (end > 0) {
+                let line = lines[i];
+                const lineAmount = end - start + 1;
+                const replaceLines = new Array<string>(lineAmount).fill('');
+                const splitLines = lines.splice(start, lineAmount, ...replaceLines).map(e => e.substring(1));
+                const padding = ' '.repeat(splitLines.length);
+                line = [line, ...splitLines, padding].join('');
+                lines[i] = line;
+                i = end;
+            }
+        }
+        return lines.join(windowsEol ? '\r\n' : '\n');
+    }
+
+}

--- a/bbj-vscode/src/language/bbj-module.ts
+++ b/bbj-vscode/src/language/bbj-module.ts
@@ -22,6 +22,7 @@ import { BBjIndexManager } from './bbj-index-manager';
 import { BBjDocumentSymbolProvider } from './bbj-document-symbol';
 import { BBjDocumentValidator } from './bbj-document-validator';
 import { BBjCompletionProvider } from './bbj-completion-provider';
+import { BbjLexer } from './bbj-lexer';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -67,7 +68,8 @@ export const BBjModule: Module<BBjServices, PartialLangiumServices & BBjAddedSer
     },
     parser: {
         ValueConverter: () => new BBjValueConverter(),
-        TokenBuilder: () => new BBjTokenBuilder()
+        TokenBuilder: () => new BBjTokenBuilder(),
+        Lexer: services => new BbjLexer(services)
     }
 };
 

--- a/bbj-vscode/src/language/bbj-token-builder.ts
+++ b/bbj-vscode/src/language/bbj-token-builder.ts
@@ -8,6 +8,7 @@ export class BBjTokenBuilder extends DefaultTokenBuilder {
         this.spliceToken(tokens, 'MLTHEN', 1);
         this.spliceToken(tokens, 'NEXT_TOKEN', 1);
         this.spliceToken(tokens, 'METHODRET_END', 1);
+        this.spliceToken(tokens, 'ENDLINE_PRINT_COMMA', 1);
         return tokens;
     }
 
@@ -41,6 +42,14 @@ export class BBjTokenBuilder extends DefaultTokenBuilder {
                 // Add more expceptional tokens here if an explicit line break token is needed
                 PATTERN: this.regexPatternFunction(/METHODRET[ \t]*(?=(;|\r?\n))/i),
                 LINE_BREAKS: false
+            };
+            return token;
+        } else if (terminal.name === 'ENDLINE_PRINT_COMMA') {
+            const token: TokenType = {
+                name: terminal.name,
+                // Add more expceptional tokens here if an explicit line break token is needed
+                PATTERN: this.regexPatternFunction(/,(?=(\r?\n))/i),
+                LINE_BREAKS: true
             };
             return token;
         } else {

--- a/bbj-vscode/src/language/bbj.langium
+++ b/bbj-vscode/src/language/bbj.langium
@@ -77,7 +77,7 @@ LetStatement:
 
 PrintValue:
     // TODO find out where mnemonics can be used and consider to add a mnemonic Expression
-    ('?' | 'PRINT' | 'WRITE') 'RECORD'? (value+=(Expression|MNEMONIC) (',' value+=(Expression|MNEMONIC))*)?
+    ('?' | 'PRINT' | 'WRITE') 'RECORD'? (value+=(Expression|MNEMONIC) (',' value+=(Expression|MNEMONIC))*)? ENDLINE_PRINT_COMMA?
 ;
 
 ClassDecl returns BbjClass:
@@ -367,6 +367,8 @@ LibVariable returns LibVariable:
 
 hidden terminal WS: /\s+/;
 terminal COMMENT: /([rR][eE][mM])([ \t][^\n\r]*)?[\n\r]+/; // (rEm)(space or tab)(all but linebreak)(linebreak)
+
+terminal ENDLINE_PRINT_COMMA: /_endline_print_comma/;
 
 terminal NEXT_TOKEN: /_next/;
 terminal METHODRET_END: /_methodret_end/;

--- a/bbj-vscode/test/lexer.test.ts
+++ b/bbj-vscode/test/lexer.test.ts
@@ -1,0 +1,31 @@
+import { EmptyFileSystem, expandToString } from "langium";
+import { createBBjTestServices } from "./bbj-test-module";
+import { describe, test, expect } from "vitest";
+
+const services = createBBjTestServices(EmptyFileSystem);
+const lexer = services.BBj.parser.Lexer;
+
+describe('Lexer tests', () => {
+
+    test('Joins split lines', () => {
+        const text = expandToString`
+        P
+        :R
+        :INT
+        : "Hel
+        :lo World
+        :"
+
+        PRINT "After"
+        `;
+        const result = lexer.tokenize(text);
+        // Text is lexed correctly without errors
+        expect(result.errors).toHaveLength(0);
+        // Expected to have exactly 4 tokens (2 PRINT, 2 strings)
+        expect(result.tokens).toHaveLength(4);
+        const afterIndex = text.indexOf('PRINT "After"');
+        // The second PRINT statement is starting at the correct offset
+        expect(result.tokens[2].startOffset).toBe(afterIndex);
+    });
+
+});


### PR DESCRIPTION
Closes #29 by adding a special `ENDLINE_PRINT_COMMA`.

Closes #30 by creating a modified lexer implementation. 