### PR TITLE
Adding the disk letter to the CP for Windows Users

### DIFF
--- a/bbj-vscode/java-interop/java-interop.bbj
+++ b/bbj-vscode/java-interop/java-interop.bbj
@@ -28,7 +28,7 @@ if argc=3 then
     pw$=argv(2)
 fi
 
-cpdir! = dir("")+"lib/*"
+cpdir! = dsk("")+dir("")+"lib/*"
 api! = BBjAdminFactory.getBBjAdmin(admin$,pw$)
 
 cpEntries! = new ArrayList()


### PR DESCRIPTION
Fixing the CP for Windows Users by adding the DSK("") command in the CP path 