### PR TITLE
fix: line and block comments shortcuts are not working in vscode

### DIFF
--- a/bbj-vscode/language-configuration.json
+++ b/bbj-vscode/language-configuration.json
@@ -1,28 +1,100 @@
 {
     "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "REM",
+        "lineComment": "REM"
     },
-    // symbols used as brackets
     "brackets": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"]
+        [
+            "{",
+            "}"
+        ],
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ]
     ],
-    // symbols that are auto closed when typing
     "autoClosingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
+        [
+            "{",
+            "}"
+        ],
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ],
+        [
+            "\"",
+            "\""
+        ],
+        [
+            "'",
+            "'"
+        ],
+        {
+            "open": "REM /**",
+            "close": "REM  */",
+            "notIn": [
+                "string"
+            ]
+        },
+        {
+            "open": "rem /**",
+            "close": "rem  */",
+            "notIn": [
+                "string"
+            ]
+        },
     ],
-    // symbols that can be used to surround a selection
     "surroundingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
-    ]
+        [
+            "{",
+            "}"
+        ],
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ],
+        [
+            "\"",
+            "\""
+        ],
+        [
+            "'",
+            "'"
+        ]
+    ],
+    "onEnterRules": [
+        {
+            "beforeText": "^\\s*[Rr][Ee][Mm]\\s*\\/\\*\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+            "action": {
+                "indent": "indentOutdent",
+                "appendText": "REM  * "
+            }
+        },
+        {
+            "beforeText": "^\\s*[Rr][Ee][Mm]\\s*\\*[^\\/].*$",
+            "action": {
+                "indent": "none",
+                "appendText": "REM  * "
+            }
+        },
+        {
+            "beforeText": "^\\s*[Rr][Ee][Mm][^\\*]$",
+            "action": {
+                "indent": "none",
+                "appendText": "REM "
+            }
+        }
+    ],
 }

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -40,6 +40,12 @@
                 "path": "./syntaxes/bbj.tmLanguage.json"
             }
         ],
+        "snippets": [
+            {
+                "language": "bbj",
+                "path": "./snippets/bbj.json"
+            }
+        ],      
         "commands": [
             {
                 "category": "BBj",

--- a/bbj-vscode/snippets/bbj.json
+++ b/bbj-vscode/snippets/bbj.json
@@ -1,0 +1,11 @@
+{
+    "Auto Comment Block": {
+        "prefix": "/**",
+        "body": [
+            "REM /**",
+            "REM  * $1",
+            "REM  */"
+        ],
+        "description": "Auto Comment Block"
+    }
+}


### PR DESCRIPTION
fix #73