### PR TITLE
Add VERBs table as markdown file

### DIFF
--- a/bbj-vscode/VERBs.md
+++ b/bbj-vscode/VERBs.md
@@ -138,7 +138,7 @@
 | OK |     | [VKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/vkeyed_verb.htm) |
 | OK | [WAIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/wait_verb.htm) | [WAIT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/wait_verb_bbj.htm) |
 | OK | [WHILE .. WEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/while_wend_verbs.htm) |     |
-| ok | [WRITE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/write_verb.htm) | [WRITE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/write_verb_bbj.htm) |
+| OK | [WRITE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/write_verb.htm) | [WRITE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/write_verb_bbj.htm) |
 | TODO | [XCALL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xcall_verb.htm) |     |
 | TODO |     | [XFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xfile_verb.htm) |
 | OK |     | [XKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xkeyed_verb.htm) |

--- a/bbj-vscode/VERBs.md
+++ b/bbj-vscode/VERBs.md
@@ -1,144 +1,144 @@
 # VERB table ([original](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/Alphabetical_Verbs.htm))
 
-| Status | Main Description | BBj-Specific Description |
-| --- | --- | --- |
-| OK | [ADDR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/addr_verb.htm) |     |
-| TODO | [AUTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/auto_verb.htm) |     |
-| TODO | [BACKGROUND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/background_verb.htm) |     |
-| OK | [BEGIN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/begin_verb.htm) | [BEGIN Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/BEGIN_Verb_-_BBj.htm) |
-| OK | [BREAK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/break_verb.htm) |     |
-| OK | [CALL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/call_verb.htm) | [CALL Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/call_verb_bbj.htm) |
-| TODO |     | [CALLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/callback_verb.htm) |
-| TODO | [CHANOPT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/chanopt_verb.htm) | [CHANOPT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/CHANOPT_Verb_-_BBj.htm) |
-| OK | [CHDIR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/chdir_verb.htm) |     |
-| TODO | [CISAM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cisam_verb.htm) |     |
-| TODO |     | [CLASS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/class_verb.htm) |
-| TODO |     | [CLASSEND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/classend_verb.htm) |
-| OK | [CLEAR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clear_verb.htm) | [CLEAR Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/CLEAR_Verb_-_BBj.htm) |
-| TODO |     | [CLEARP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clearp_verb.htm) |
-| TODO | [CLIPCLEAR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipclear_verb.htm) |     |
-| TODO | [CLIPFROMFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipfromfile_verb.htm) |     |
-| OK | [CLIPFROMSTR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipfromstr_verb.htm) |     |
-| TODO | [CLIPLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cliplock_verb.htm) |     |
-| TODO | [CLIPTOFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cliptofile_verb.htm) |     |
-| TODO | [CLIPUNLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipunlock_verb.htm) |     |
-| OK | [CLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/close_verb.htm) | [CLOSE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/close_verb_bbj.htm) |
-| OK | [CONTINUE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/continue_verb.htm) |     |
-| TODO | [DEF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/def_verb.htm) | [DEF Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/def_verb_bbj.htm) |
-| TODO | [DELETE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/delete_verb.htm) |     |
-| TODO |     | [DENUM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/denum_verb.htm) |
-| TODO | [DIM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/dim_verb.htm) | [DIM Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/dim_verb_bbj.htm) |
-| TODO | [DIRECT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/direct_verb.htm) |     |
-| TODO | [DISABLE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/disable_verb.htm) |     |
-| TODO | [DREAD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/dread_verb.htm) | [DREAD Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/dread_verb_bbj.htm) |
-| OK | [DROP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/drop_verb.htm) |     |
-| TODO | [DUMP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/dump_verb.htm) | [DUMP Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/dump_verb_bbj.htm) |
-| TODO | [EDIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/edit_verb.htm) |     |
-| TODO | [ENABLE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/enable_verb.htm) |     |
-| OK | [END Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/end_verb.htm) (BYE) |     |
-| TODO | [ENDTRACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/endtrace_verb.htm) |     |
-| OK | [ENTER Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/enter_verb.htm) | [ENTER Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/enter_verb_bbj.htm) |
-| TODO | [ERASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/erase_verb.htm) | [ERASE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/erase_verb_bbj.htm) |
-| OK | [ESCAPE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/escape_verb.htm) |     |
-| TODO | [ESCON/ESCOFF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/escon_escoff_verb.htm) |     |
-| OK | [EXECUTE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/execute_verb.htm) | [EXECUTE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/EXECUTE_Verb_-_BBj.htm) |
-| OK | [EXIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/exit_verb.htm) |     |
-| TODO | [EXITTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/exitto_verb.htm) |     |
-| OK | [EXTRACT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/extract_verb.htm) (+EXTRACTRECORD) |     |
-| TODO | [FIELD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/field_verb.htm) | [FIELD Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/field_verb_bbj.htm) |
-| TODO | [FILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/file_verb.htm) |     |
-| TODO | [FILEOPT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/fileopt_verb.htm) |     |
-| OK | [FIND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/find_verb.htm) (+FINDRECORD) |     |
-| TODO | [FLOATINGPOINT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/floatingpoint_verb.htm) | [FLOATINGPOINT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/floatingpoint_verb_bbj.htm) |
-| OK | FOR ... TO ... STEP | |
-| OK | [FOR .. NEXT Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/for_next_verbs.htm) | [FOR .. NEXT Verbs - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/for_next_verbs_bbj.htm) |
-| TODO |     | [FULLTEXT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/FULLTEXT_Verb-Create_FULLTEXT_File.htm) |
-| OK | [GOSUB Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/gosub_verb.htm) |     |
-| OK | [GOTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/goto_verb.htm) |     |
-| OK | [IF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/if_verb.htm) (IF/ELSE/ENDIF/FI) |     |
-| TODO | [INDEXED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/indexed_verb.htm) |     |
-| TODO | [INITFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/initfile_verb.htm) | [INITFILE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/INITFILE_Verb_BBj.htm) |
-| OK | [INPUT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/input_verb.htm) (+INPUTRECORD) |     |
-| TODO | [INPUTE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/inpute_verb.htm) |     |
-| TODO | [INPUTN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/inputn_verb.htm) |     |
-| TODO |     | [INTERFACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/interface_verb.htm) |
-| TODO |     | [INTERFACEEND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/interfaceend_verb.htm) |
-| TODO | [IOLIST Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/iolist_verb.htm) |     |
-| TODO |     | [JERASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jerase_verb.htm) |
-| TODO |     | [JKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jkeyed_verb_create_journaled_file.htm) |
-| TODO |     | [JOPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jopen_verb.htm) |
-| TODO | [LCHECKIN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/lcheckin_verb_check_in_license.htm) |     |
-| OK | [LET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/let_verb.htm) | [LET Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/let_verb_bbj.htm) |
-| TODO | [LIST Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/list_verb.htm) |     |
-| TODO | [LOAD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/load_verb.htm) |     |
-| TODO | [LOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/lock_verb.htm) | [LOCK Verb - Lock File BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/lock_verb_bbj.htm) |
-| TODO | [MERGE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/merge_verb.htm) | [MERGE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/merge_verb_bbj.htm) |
-| OK |     | [METHOD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/method_verb.htm) |
-| OK |     | [METHODEND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/methodend_verb.htm) |
-| OK | [MKDIR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/mkdir_verb.htm) | [MKDIR Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/mkdir_verb_bbj.htm) |
-| OK | [MKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/mkeyed_verb.htm) |     |
-| TODO | [ON GOTO/GOSUB Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/on_goto_gosub_verbs.htm) |     |
-| OK | [OPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/open_verb.htm) | [OPEN Verb - Open File BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/open_verb_open_file_bbj.htm) |
-| OK | [PRECISION Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/precision_verb.htm) | [PRECISION Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/precision_verb_bbj.htm) |
-| TODO | [PREFIX Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/prefix_verb.htm) | [PREFIX Verb - Set File System Search Paths - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/prefix_verb_set_file_system_search_paths_bbj.htm) |
-| OK | [PRINT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/print_verb.htm) |     |
-| OK |     | [PROCESS\_EVENTS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/process_events_verb.htm) |
-| TODO | [PROGRAM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/program_verb.htm) |     |
-| OK | [READ Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/read_verb.htm) (+READRECORD) | [READ Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/read_verb_bbj.htm) |
-| OK |     | [REDIM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/REDIM_Verb.htm) |
-| OK | [RELEASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/release_verb.htm) | [RELEASE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/release_verb_bbj.htm) |
-| OK | [REM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rem_verb.htm) |     |
-| TODO | [REMOVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/remove_verb.htm) | [REMOVE Verb - Delete Key from Keyed File - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/remove_verb_delete_key_from_keyed_file_bbj.htm) |
-| TODO |     | [REMOVE\_CALLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/remove_callback_verb.htm) |
-| OK | [RENAME Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rename_verb.htm) |     |
-| TODO | [RENUM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/renum_verb.htm) | [RENUM Verb - Renumber Program Lines (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/renum_verb_renumber_program_lines_bbj.htm) |
-| OK | [REPEAT .. UNTIL Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/repeat_until_verbs.htm) |     |
-| TODO | [RESCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/resclose_verb.htm) |     |
-| TODO | [RESERVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/reserve_verb.htm) |     |
-| TODO | [RESET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/reset_verb.htm) |     |
-| TODO | [RESTORE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/restore_verb.htm) |     |
-| TODO | [RETRY Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/retry_verb.htm) |     |
-| OK | [RETURN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/return_verb.htm) |     |
-| OK | [RMDIR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rmdir_verb.htm) | [RMDIR Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/rmdir_verb_bbj.htm) |
-| OK | [RUN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/run_verb.htm) |     |
-| TODO | [SAVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/save_verb.htm) | [SAVE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/save_verb_bbj.htm) |
-| TODO |     | [SAVEP Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/savep_verb_bbj.htm) |
-| TODO |     | [SCAN Command](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/scan_command_scan_for_text_in_program.htm) |
-| TODO | [SELECT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/select_verb.htm) |     |
-| TODO | [SERIAL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/serial_verb.htm) |     |
-| TODO | [SETDAY Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setday_verb.htm) |     |
-| TODO | [SETDRIVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setdrive_verb.htm) |     |
-| OK | [SETERR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/seterr_verb.htm) |     |
-| OK | [SETESC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setesc_verb.htm) |     |
-| OK | [SETOPTS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setopts_verb.htm) | [SETOPTS Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/setopts_verb_bbj.htm) |
-| TODO |     | [SETTERM Verb - Reset Terminal Alias (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/setterm_verb_reset_terminal_alias_bbj.htm) |
-| TODO | [SETTIME Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/settime_verb.htm) | [SETTIME Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/settime_verb_bbj.htm) |
-| TODO | [SETTRACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/settrace_verb.htm) | [SETTRACE Verb – BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/settrace_verb_bbj.htm) |
-| TODO | [SORT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sort_verb.htm) |     |
-| OK | [SQLCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlclose_verb.htm) |     |
-| TODO |     | [SQLCOMMIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlcommit_verb_commit_current_transaction.htm) |
-| TODO | [SQLEXEC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlexec_verb.htm) |     |
-| OK | [SQLOPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlopen_verb.htm) | [SQLOPEN Verb - Open SQL Channel BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/sqlopen_verb_open_sql_channel_bbj.htm) |
-| OK | [SQLPREP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlprep_verb.htm) | [SQLPREP Verb - Set Up SQL Command (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/sqlprep_verb_set_up_sql_command_bbj.htm) |
-| TODO |     | [SQLROLLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlrollback_verb_rollback_current_transaction.htm) |
-| TODO | [SQLSET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlset_verb.htm) |     |
-| TODO | [START Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/start_verb.htm) | [START Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/start_verb_bbj.htm) |
-| TODO | [STOP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/stop_verb.htm) |     |
-| TODO | [STRING Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/string_verb.htm) |     |
-| OK | [SWITCH .. CASE .. SWEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/switch_case_swend_verbs.htm) | [SWITCH .. CASE .. SWEND Verbs - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/SWITCH..CASE..SWEND_Verbs-BBj.htm) |
-| TODO |     |     |
-| TODO | [TABLE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/table_verb.htm) |     |
-| TODO |     | [TCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/tclose_verb.htm) |
-| TODO |     | [TCOMMIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/tcommit_verb.htm) |
-| OK |     | [THROW Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/throw_verb.htm) |
-| TODO |     | [TROLLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/trollback_verb.htm) |
-| TODO | [UNLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/unlock_verb.htm) |     |
-| TODO | [UPDATELIC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/updatelic_verb_update_license_for_basis_license_manager.htm) |     |
-| TODO |     | [USE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/use_verb.htm) |
-| OK |     | [VKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/vkeyed_verb.htm) |
-| OK | [WAIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/wait_verb.htm) | [WAIT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/wait_verb_bbj.htm) |
-| OK | [WHILE .. WEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/while_wend_verbs.htm) |     |
-| OK | [WRITE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/write_verb.htm) | [WRITE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/write_verb_bbj.htm) |
-| TODO | [XCALL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xcall_verb.htm) |     |
-| TODO |     | [XFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xfile_verb.htm) |
-| OK |     | [XKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xkeyed_verb.htm) |
+| Status | Test | Main Description | BBj-Specific Description |
+| --- | --- | --- | --- |
+| OK | `npx vitest run -t "TODO"` | `npx vitest run -t "TODO"` | [ADDR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/addr_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [AUTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/auto_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [BACKGROUND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/background_verb.htm) |     |
+| OK | `npx vitest run -t "Check Begin Clear Verb"` | [BEGIN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/begin_verb.htm) | [BEGIN Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/BEGIN_Verb_-_BBj.htm) |
+| OK | `npx vitest run -t "Check Exit Verbs"` | [BREAK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/break_verb.htm) |     |
+| OK | `npx vitest run -t "Check CALL and RUN"` | [CALL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/call_verb.htm) | [CALL Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/call_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [CALLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/callback_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` | [CHANOPT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/chanopt_verb.htm) | [CHANOPT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/CHANOPT_Verb_-_BBj.htm) |
+| OK | `npx vitest run -t "Dir statements"` | [CHDIR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/chdir_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [CISAM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cisam_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` |     | [CLASS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/class_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [CLASSEND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/classend_verb.htm) |
+| OK | `npx vitest run -t "Check Begin Clear Verb"` | [CLEAR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clear_verb.htm) | [CLEAR Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/CLEAR_Verb_-_BBj.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [CLEARP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clearp_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` | [CLIPCLEAR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipclear_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [CLIPFROMFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipfromfile_verb.htm) |     |
+| OK | `npx vitest run -t "TODO"` | [CLIPFROMSTR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipfromstr_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [CLIPLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cliplock_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [CLIPTOFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cliptofile_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [CLIPUNLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipunlock_verb.htm) |     |
+| OK | `npx vitest run -t "TODO"` | [CLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/close_verb.htm) | [CLOSE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/close_verb_bbj.htm) |
+| OK | `npx vitest run -t "Check Exit Verbs"` | [CONTINUE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/continue_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [DEF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/def_verb.htm) | [DEF Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/def_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [DELETE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/delete_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` |     | [DENUM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/denum_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` | [DIM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/dim_verb.htm) | [DIM Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/dim_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [DIRECT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/direct_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [DISABLE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/disable_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [DREAD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/dread_verb.htm) | [DREAD Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/dread_verb_bbj.htm) |
+| OK | `npx vitest run -t "Check Drop Verb"` | [DROP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/drop_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [DUMP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/dump_verb.htm) | [DUMP Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/dump_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [EDIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/edit_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [ENABLE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/enable_verb.htm) |     |
+| OK | `npx vitest run -t "Check Exit Verbs"` | [END Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/end_verb.htm) (BYE) |     |
+| TODO | `npx vitest run -t "TODO"` | [ENDTRACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/endtrace_verb.htm) |     |
+| OK | `npx vitest run -t "Check Enter Verb"` | [ENTER Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/enter_verb.htm) | [ENTER Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/enter_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [ERASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/erase_verb.htm) | [ERASE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/erase_verb_bbj.htm) |
+| OK | `npx vitest run -t "Check Exit Verbs"` | [ESCAPE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/escape_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [ESCON/ESCOFF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/escon_escoff_verb.htm) |     |
+| OK | `npx vitest run -t "Execute statement"` | [EXECUTE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/execute_verb.htm) | [EXECUTE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/EXECUTE_Verb_-_BBj.htm) |
+| OK | `npx vitest run -t "Check Exit Verbs"` | [EXIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/exit_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [EXITTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/exitto_verb.htm) |     |
+| OK | `npx vitest run -t "Check readrecord and similar"` <br/> `npx vitest run -t "READ: Input variable should be linked or created."` | [EXTRACT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/extract_verb.htm) (+EXTRACTRECORD) |     |
+| TODO | `npx vitest run -t "TODO"` | [FIELD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/field_verb.htm) | [FIELD Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/field_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [FILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/file_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [FILEOPT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/fileopt_verb.htm) |     |
+| OK | `npx vitest run -t "Check read and similar, with record"` | [FIND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/find_verb.htm) (+FINDRECORD) |     |
+| TODO | `npx vitest run -t "TODO"` | [FLOATINGPOINT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/floatingpoint_verb.htm) | [FLOATINGPOINT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/floatingpoint_verb_bbj.htm) |
+| OK | `npx vitest run -t "Program definition test"` | FOR ... TO ... STEP | |
+| TODO | `npx vitest run -t "TODO"` | [FOR .. NEXT Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/for_next_verbs.htm) | [FOR .. NEXT Verbs - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/for_next_verbs_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [FULLTEXT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/FULLTEXT_Verb-Create_FULLTEXT_File.htm) |
+| OK | `npx vitest run -t "TODO"` | [GOSUB Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/gosub_verb.htm) |     |
+| OK | `npx vitest run -t "Seterr and Setesc"`| [GOTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/goto_verb.htm) |     |
+| OK | `npx vitest run -t "Parse \"METHODRET\" in a multi line \"IF\""` | [IF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/if_verb.htm) (IF/ELSE/ENDIF/FI) |     |
+| TODO | `npx vitest run -t "TODO"` | [INDEXED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/indexed_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [INITFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/initfile_verb.htm) | [INITFILE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/INITFILE_Verb_BBj.htm) |
+| OK | `npx vitest run -t "TODO"` | [INPUT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/input_verb.htm) (+INPUTRECORD) |     |
+| TODO | `npx vitest run -t "TODO"` | [INPUTE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/inpute_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [INPUTN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/inputn_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` |     | [INTERFACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/interface_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [INTERFACEEND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/interfaceend_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` | [IOLIST Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/iolist_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` |     | [JERASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jerase_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [JKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jkeyed_verb_create_journaled_file.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [JOPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jopen_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` | [LCHECKIN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/lcheckin_verb_check_in_license.htm) |     |
+| OK | `npx vitest run -t "Mnemonic tests"`| [LET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/let_verb.htm) | [LET Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/let_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [LIST Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/list_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [LOAD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/load_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [LOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/lock_verb.htm) | [LOCK Verb - Lock File BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/lock_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [MERGE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/merge_verb.htm) | [MERGE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/merge_verb_bbj.htm) |
+| OK | `npx vitest run -t "Check throw statement syntax"`  |   | [METHOD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/method_verb.htm) |
+| OK |  `npx vitest run -t "Check throw statement syntax"` |   | [METHODEND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/methodend_verb.htm) |
+| OK | `npx vitest run -t "Dir statements"` | [MKDIR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/mkdir_verb.htm) | [MKDIR Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/mkdir_verb_bbj.htm) |
+| OK | `npx vitest run -t "Check KeyedFileStatement Verb"` | [MKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/mkeyed_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [ON GOTO/GOSUB Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/on_goto_gosub_verbs.htm) |     |
+| OK | `npx vitest run -t "Check Open Verb optional params keywords"` | [OPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/open_verb.htm) | [OPEN Verb - Open File BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/open_verb_open_file_bbj.htm) |
+| OK | `npx vitest run -t "Check Precision Verb"` | [PRECISION Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/precision_verb.htm) | [PRECISION Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/precision_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [PREFIX Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/prefix_verb.htm) | [PREFIX Verb - Set File System Search Paths - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/prefix_verb_set_file_system_search_paths_bbj.htm) |
+| OK | `npx vitest run -t "Parse \"REM\" as independent statement in compound statement"` |  [PRINT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/print_verb.htm) |     |
+| OK | `npx vitest run -t "Check PROCESS_EVENT Parameters"` |    | [PROCESS\_EVENTS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/process_events_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` | [PROGRAM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/program_verb.htm) |     |
+| OK | `npx vitest run -t "Check read and similar, with record"` | [READ Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/read_verb.htm) (+READRECORD) | [READ Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/read_verb_bbj.htm) |
+| OK | `npx vitest run -t "TODO"` |    | [REDIM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/REDIM_Verb.htm) |
+| OK | `npx vitest run -t "TODO"` | [RELEASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/release_verb.htm) | [RELEASE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/release_verb_bbj.htm) |
+| OK | `npx vitest run -t "Parse \"REM\" as independent statement on own line"`| [REM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rem_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [REMOVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/remove_verb.htm) | [REMOVE Verb - Delete Key from Keyed File - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/remove_verb_delete_key_from_keyed_file_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [REMOVE\_CALLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/remove_callback_verb.htm) |
+| OK | `npx vitest run -t "Rename statement"` | [RENAME Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rename_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [RENUM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/renum_verb.htm) | [RENUM Verb - Renumber Program Lines (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/renum_verb_renumber_program_lines_bbj.htm) |
+| OK | `npx vitest run -t "Check REPEAT..UNTIL Verb"` | [REPEAT .. UNTIL Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/repeat_until_verbs.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [RESCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/resclose_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [RESERVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/reserve_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [RESET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/reset_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [RESTORE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/restore_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [RETRY Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/retry_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [RETURN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/return_verb.htm) |     |
+| OK | `npx vitest run -t "Dir statements"` | [RMDIR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rmdir_verb.htm) | [RMDIR Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/rmdir_verb_bbj.htm) |
+| OK | `npx vitest run -t "Check CALL and RUN"` | [RUN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/run_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [SAVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/save_verb.htm) | [SAVE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/save_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [SAVEP Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/savep_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [SCAN Command](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/scan_command_scan_for_text_in_program.htm) |
+| TODO | `npx vitest run -t "TODO"` | [SELECT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/select_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [SERIAL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/serial_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [SETDAY Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setday_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [SETDRIVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setdrive_verb.htm) |     |
+| OK | `npx vitest run -t "Seterr and Setesc"` | [SETERR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/seterr_verb.htm) |     |
+| OK | `npx vitest run -t "Seterr and Setesc"` | [SETESC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setesc_verb.htm) |     |
+| OK | `npx vitest run -t "Check SETOPTS Verb"` | [SETOPTS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setopts_verb.htm) | [SETOPTS Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/setopts_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [SETTERM Verb - Reset Terminal Alias (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/setterm_verb_reset_terminal_alias_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [SETTIME Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/settime_verb.htm) | [SETTIME Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/settime_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [SETTRACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/settrace_verb.htm) | [SETTRACE Verb – BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/settrace_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [SORT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sort_verb.htm) |     |
+| OK | `npx vitest run -t "TODO"` | [SQLCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlclose_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` |     | [SQLCOMMIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlcommit_verb_commit_current_transaction.htm) |
+| TODO | `npx vitest run -t "TODO"` | [SQLEXEC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlexec_verb.htm) |     |
+| OK | `npx vitest run -t "Check SQLOpen Verb"` | [SQLOPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlopen_verb.htm) | [SQLOPEN Verb - Open SQL Channel BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/sqlopen_verb_open_sql_channel_bbj.htm) |
+| OK | `npx vitest run -t "TODO"` | [SQLPREP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlprep_verb.htm) | [SQLPREP Verb - Set Up SQL Command (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/sqlprep_verb_set_up_sql_command_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [SQLROLLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlrollback_verb_rollback_current_transaction.htm) |
+| TODO | `npx vitest run -t "TODO"` | [SQLSET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlset_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [START Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/start_verb.htm) | [START Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/start_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [STOP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/stop_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [STRING Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/string_verb.htm) |     |
+| OK | `npx vitest run -t "TODO"` | [SWITCH .. CASE .. SWEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/switch_case_swend_verbs.htm) | [SWITCH .. CASE .. SWEND Verbs - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/SWITCH..CASE..SWEND_Verbs-BBj.htm) |
+| TODO | `npx vitest run -t "TODO"` |     |     |
+| TODO | `npx vitest run -t "TODO"` | [TABLE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/table_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` |     | [TCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/tclose_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [TCOMMIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/tcommit_verb.htm) |
+| OK | `npx vitest run -t "Check throw statement syntax"` |    | [THROW Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/throw_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` |     | [TROLLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/trollback_verb.htm) |
+| TODO | `npx vitest run -t "TODO"` | [UNLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/unlock_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` | [UPDATELIC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/updatelic_verb_update_license_for_basis_license_manager.htm) |     |
+| TODO | `npx vitest run -t "TODO"` |     | [USE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/use_verb.htm) |
+| OK | `npx vitest run -t "Check KeyedFileStatement Verb"` |      | [VKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/vkeyed_verb.htm) |
+| OK | `npx vitest run -t "TODO"` | [WAIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/wait_verb.htm) | [WAIT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/wait_verb_bbj.htm) |
+| OK | `npx vitest run -t "TODO"` | [WHILE .. WEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/while_wend_verbs.htm) |     |
+| OK | `npx vitest run -t "Check read and similar, with record"` | [WRITE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/write_verb.htm) | [WRITE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/write_verb_bbj.htm) |
+| TODO | `npx vitest run -t "TODO"` | [XCALL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xcall_verb.htm) |     |
+| TODO | `npx vitest run -t "TODO"` |     | [XFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xfile_verb.htm) |
+| OK | `npx vitest run -t "Check KeyedFileStatement Verb"` |    | [XKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xkeyed_verb.htm) |

--- a/bbj-vscode/VERBs.md
+++ b/bbj-vscode/VERBs.md
@@ -1,0 +1,144 @@
+# VERB table ([original](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/Alphabetical_Verbs.htm))
+
+| Status | Main Description | BBj-Specific Description |
+| --- | --- | --- |
+| OK | [ADDR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/addr_verb.htm) |     |
+| TODO | [AUTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/auto_verb.htm) |     |
+| TODO | [BACKGROUND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/background_verb.htm) |     |
+| OK | [BEGIN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/begin_verb.htm) | [BEGIN Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/BEGIN_Verb_-_BBj.htm) |
+| OK | [BREAK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/break_verb.htm) |     |
+| OK | [CALL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/call_verb.htm) | [CALL Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/call_verb_bbj.htm) |
+| TODO |     | [CALLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/callback_verb.htm) |
+| TODO | [CHANOPT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/chanopt_verb.htm) | [CHANOPT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/CHANOPT_Verb_-_BBj.htm) |
+| OK | [CHDIR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/chdir_verb.htm) |     |
+| TODO | [CISAM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cisam_verb.htm) |     |
+| TODO |     | [CLASS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/class_verb.htm) |
+| TODO |     | [CLASSEND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/classend_verb.htm) |
+| OK | [CLEAR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clear_verb.htm) | [CLEAR Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/CLEAR_Verb_-_BBj.htm) |
+| TODO |     | [CLEARP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clearp_verb.htm) |
+| TODO | [CLIPCLEAR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipclear_verb.htm) |     |
+| TODO | [CLIPFROMFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipfromfile_verb.htm) |     |
+| OK | [CLIPFROMSTR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipfromstr_verb.htm) |     |
+| TODO | [CLIPLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cliplock_verb.htm) |     |
+| TODO | [CLIPTOFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cliptofile_verb.htm) |     |
+| TODO | [CLIPUNLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipunlock_verb.htm) |     |
+| OK | [CLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/close_verb.htm) | [CLOSE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/close_verb_bbj.htm) |
+| OK | [CONTINUE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/continue_verb.htm) |     |
+| TODO | [DEF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/def_verb.htm) | [DEF Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/def_verb_bbj.htm) |
+| TODO | [DELETE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/delete_verb.htm) |     |
+| TODO |     | [DENUM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/denum_verb.htm) |
+| TODO | [DIM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/dim_verb.htm) | [DIM Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/dim_verb_bbj.htm) |
+| TODO | [DIRECT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/direct_verb.htm) |     |
+| TODO | [DISABLE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/disable_verb.htm) |     |
+| TODO | [DREAD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/dread_verb.htm) | [DREAD Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/dread_verb_bbj.htm) |
+| OK | [DROP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/drop_verb.htm) |     |
+| TODO | [DUMP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/dump_verb.htm) | [DUMP Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/dump_verb_bbj.htm) |
+| TODO | [EDIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/edit_verb.htm) |     |
+| TODO | [ENABLE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/enable_verb.htm) |     |
+| OK | [END Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/end_verb.htm) (BYE) |     |
+| TODO | [ENDTRACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/endtrace_verb.htm) |     |
+| OK | [ENTER Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/enter_verb.htm) | [ENTER Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/enter_verb_bbj.htm) |
+| TODO | [ERASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/erase_verb.htm) | [ERASE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/erase_verb_bbj.htm) |
+| OK | [ESCAPE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/escape_verb.htm) |     |
+| TODO | [ESCON/ESCOFF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/escon_escoff_verb.htm) |     |
+| OK | [EXECUTE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/execute_verb.htm) | [EXECUTE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/EXECUTE_Verb_-_BBj.htm) |
+| OK | [EXIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/exit_verb.htm) |     |
+| TODO | [EXITTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/exitto_verb.htm) |     |
+| OK | [EXTRACT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/extract_verb.htm) (+EXTRACTRECORD) |     |
+| TODO | [FIELD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/field_verb.htm) | [FIELD Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/field_verb_bbj.htm) |
+| TODO | [FILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/file_verb.htm) |     |
+| TODO | [FILEOPT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/fileopt_verb.htm) |     |
+| OK | [FIND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/find_verb.htm) (+FINDRECORD) |     |
+| TODO | [FLOATINGPOINT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/floatingpoint_verb.htm) | [FLOATINGPOINT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/floatingpoint_verb_bbj.htm) |
+| OK | FOR ... TO ... STEP | |
+| OK | [FOR .. NEXT Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/for_next_verbs.htm) | [FOR .. NEXT Verbs - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/for_next_verbs_bbj.htm) |
+| TODO |     | [FULLTEXT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/FULLTEXT_Verb-Create_FULLTEXT_File.htm) |
+| OK | [GOSUB Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/gosub_verb.htm) |     |
+| OK | [GOTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/goto_verb.htm) |     |
+| OK | [IF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/if_verb.htm) (IF/ELSE/ENDIF/FI) |     |
+| TODO | [INDEXED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/indexed_verb.htm) |     |
+| TODO | [INITFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/initfile_verb.htm) | [INITFILE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/INITFILE_Verb_BBj.htm) |
+| OK | [INPUT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/input_verb.htm) (+INPUTRECORD) |     |
+| TODO | [INPUTE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/inpute_verb.htm) |     |
+| TODO | [INPUTN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/inputn_verb.htm) |     |
+| TODO |     | [INTERFACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/interface_verb.htm) |
+| TODO |     | [INTERFACEEND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/interfaceend_verb.htm) |
+| TODO | [IOLIST Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/iolist_verb.htm) |     |
+| TODO |     | [JERASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jerase_verb.htm) |
+| TODO |     | [JKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jkeyed_verb_create_journaled_file.htm) |
+| TODO |     | [JOPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jopen_verb.htm) |
+| TODO | [LCHECKIN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/lcheckin_verb_check_in_license.htm) |     |
+| OK | [LET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/let_verb.htm) | [LET Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/let_verb_bbj.htm) |
+| TODO | [LIST Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/list_verb.htm) |     |
+| TODO | [LOAD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/load_verb.htm) |     |
+| TODO | [LOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/lock_verb.htm) | [LOCK Verb - Lock File BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/lock_verb_bbj.htm) |
+| TODO | [MERGE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/merge_verb.htm) | [MERGE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/merge_verb_bbj.htm) |
+| OK |     | [METHOD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/method_verb.htm) |
+| OK |     | [METHODEND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/methodend_verb.htm) |
+| OK | [MKDIR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/mkdir_verb.htm) | [MKDIR Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/mkdir_verb_bbj.htm) |
+| OK | [MKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/mkeyed_verb.htm) |     |
+| TODO | [ON GOTO/GOSUB Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/on_goto_gosub_verbs.htm) |     |
+| OK | [OPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/open_verb.htm) | [OPEN Verb - Open File BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/open_verb_open_file_bbj.htm) |
+| OK | [PRECISION Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/precision_verb.htm) | [PRECISION Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/precision_verb_bbj.htm) |
+| TODO | [PREFIX Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/prefix_verb.htm) | [PREFIX Verb - Set File System Search Paths - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/prefix_verb_set_file_system_search_paths_bbj.htm) |
+| OK | [PRINT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/print_verb.htm) |     |
+| OK |     | [PROCESS\_EVENTS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/process_events_verb.htm) |
+| TODO | [PROGRAM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/program_verb.htm) |     |
+| OK | [READ Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/read_verb.htm) (+READRECORD) | [READ Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/read_verb_bbj.htm) |
+| OK |     | [REDIM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/REDIM_Verb.htm) |
+| OK | [RELEASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/release_verb.htm) | [RELEASE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/release_verb_bbj.htm) |
+| OK | [REM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rem_verb.htm) |     |
+| TODO | [REMOVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/remove_verb.htm) | [REMOVE Verb - Delete Key from Keyed File - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/remove_verb_delete_key_from_keyed_file_bbj.htm) |
+| TODO |     | [REMOVE\_CALLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/remove_callback_verb.htm) |
+| OK | [RENAME Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rename_verb.htm) |     |
+| TODO | [RENUM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/renum_verb.htm) | [RENUM Verb - Renumber Program Lines (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/renum_verb_renumber_program_lines_bbj.htm) |
+| OK | [REPEAT .. UNTIL Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/repeat_until_verbs.htm) |     |
+| TODO | [RESCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/resclose_verb.htm) |     |
+| TODO | [RESERVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/reserve_verb.htm) |     |
+| TODO | [RESET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/reset_verb.htm) |     |
+| TODO | [RESTORE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/restore_verb.htm) |     |
+| TODO | [RETRY Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/retry_verb.htm) |     |
+| OK | [RETURN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/return_verb.htm) |     |
+| OK | [RMDIR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rmdir_verb.htm) | [RMDIR Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/rmdir_verb_bbj.htm) |
+| OK | [RUN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/run_verb.htm) |     |
+| TODO | [SAVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/save_verb.htm) | [SAVE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/save_verb_bbj.htm) |
+| TODO |     | [SAVEP Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/savep_verb_bbj.htm) |
+| TODO |     | [SCAN Command](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/scan_command_scan_for_text_in_program.htm) |
+| TODO | [SELECT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/select_verb.htm) |     |
+| TODO | [SERIAL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/serial_verb.htm) |     |
+| TODO | [SETDAY Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setday_verb.htm) |     |
+| TODO | [SETDRIVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setdrive_verb.htm) |     |
+| OK | [SETERR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/seterr_verb.htm) |     |
+| OK | [SETESC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setesc_verb.htm) |     |
+| OK | [SETOPTS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setopts_verb.htm) | [SETOPTS Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/setopts_verb_bbj.htm) |
+| TODO |     | [SETTERM Verb - Reset Terminal Alias (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/setterm_verb_reset_terminal_alias_bbj.htm) |
+| TODO | [SETTIME Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/settime_verb.htm) | [SETTIME Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/settime_verb_bbj.htm) |
+| TODO | [SETTRACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/settrace_verb.htm) | [SETTRACE Verb – BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/settrace_verb_bbj.htm) |
+| TODO | [SORT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sort_verb.htm) |     |
+| OK | [SQLCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlclose_verb.htm) |     |
+| TODO |     | [SQLCOMMIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlcommit_verb_commit_current_transaction.htm) |
+| TODO | [SQLEXEC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlexec_verb.htm) |     |
+| OK | [SQLOPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlopen_verb.htm) | [SQLOPEN Verb - Open SQL Channel BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/sqlopen_verb_open_sql_channel_bbj.htm) |
+| OK | [SQLPREP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlprep_verb.htm) | [SQLPREP Verb - Set Up SQL Command (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/sqlprep_verb_set_up_sql_command_bbj.htm) |
+| TODO |     | [SQLROLLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlrollback_verb_rollback_current_transaction.htm) |
+| TODO | [SQLSET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlset_verb.htm) |     |
+| TODO | [START Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/start_verb.htm) | [START Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/start_verb_bbj.htm) |
+| TODO | [STOP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/stop_verb.htm) |     |
+| TODO | [STRING Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/string_verb.htm) |     |
+| OK | [SWITCH .. CASE .. SWEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/switch_case_swend_verbs.htm) | [SWITCH .. CASE .. SWEND Verbs - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/SWITCH..CASE..SWEND_Verbs-BBj.htm) |
+| TODO |     |     |
+| TODO | [TABLE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/table_verb.htm) |     |
+| TODO |     | [TCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/tclose_verb.htm) |
+| TODO |     | [TCOMMIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/tcommit_verb.htm) |
+| OK |     | [THROW Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/throw_verb.htm) |
+| TODO |     | [TROLLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/trollback_verb.htm) |
+| TODO | [UNLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/unlock_verb.htm) |     |
+| TODO | [UPDATELIC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/updatelic_verb_update_license_for_basis_license_manager.htm) |     |
+| TODO |     | [USE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/use_verb.htm) |
+| OK |     | [VKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/vkeyed_verb.htm) |
+| OK | [WAIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/wait_verb.htm) | [WAIT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/wait_verb_bbj.htm) |
+| OK | [WHILE .. WEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/while_wend_verbs.htm) |     |
+| ok | [WRITE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/write_verb.htm) | [WRITE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/write_verb_bbj.htm) |
+| TODO | [XCALL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xcall_verb.htm) |     |
+| TODO |     | [XFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xfile_verb.htm) |
+| OK |     | [XKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xkeyed_verb.htm) |

--- a/bbj-vscode/VERBs.md
+++ b/bbj-vscode/VERBs.md
@@ -85,8 +85,8 @@
 | OK | `npx vitest run -t "Check PROCESS_EVENT Parameters"` |    | [PROCESS\_EVENTS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/process_events_verb.htm) |
 | TODO | `npx vitest run -t "TODO"` | [PROGRAM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/program_verb.htm) |     |
 | OK | `npx vitest run -t "Check read and similar, with record"` | [READ Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/read_verb.htm) (+READRECORD) | [READ Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/read_verb_bbj.htm) |
-| OK | `npx vitest run -t "TODO"` |    | [REDIM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/REDIM_Verb.htm) |
-| OK | `npx vitest run -t "TODO"` | [RELEASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/release_verb.htm) | [RELEASE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/release_verb_bbj.htm) |
+| OK | `npx vitest run -t "Check REDIM verb"` |    | [REDIM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/REDIM_Verb.htm) |
+| OK | `npx vitest run -t "Check RELEASE verb"` | [RELEASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/release_verb.htm) | [RELEASE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/release_verb_bbj.htm) |
 | OK | `npx vitest run -t "Parse \"REM\" as independent statement on own line"`| [REM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rem_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [REMOVE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/remove_verb.htm) | [REMOVE Verb - Delete Key from Keyed File - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/remove_verb_delete_key_from_keyed_file_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` |     | [REMOVE\_CALLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/remove_callback_verb.htm) |
@@ -115,17 +115,17 @@
 | TODO | `npx vitest run -t "TODO"` | [SETTIME Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/settime_verb.htm) | [SETTIME Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/settime_verb_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` | [SETTRACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/settrace_verb.htm) | [SETTRACE Verb – BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/settrace_verb_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` | [SORT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sort_verb.htm) |     |
-| OK | `npx vitest run -t "TODO"` | [SQLCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlclose_verb.htm) |     |
+| OK | `npx vitest run -t "Check SQLCLOSE verb"` | [SQLCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlclose_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` |     | [SQLCOMMIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlcommit_verb_commit_current_transaction.htm) |
 | TODO | `npx vitest run -t "TODO"` | [SQLEXEC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlexec_verb.htm) |     |
-| OK | `npx vitest run -t "Check SQLOpen Verb"` | [SQLOPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlopen_verb.htm) | [SQLOPEN Verb - Open SQL Channel BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/sqlopen_verb_open_sql_channel_bbj.htm) |
-| OK | `npx vitest run -t "TODO"` | [SQLPREP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlprep_verb.htm) | [SQLPREP Verb - Set Up SQL Command (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/sqlprep_verb_set_up_sql_command_bbj.htm) |
+| TODO incomplete parameters | `npx vitest run -t "Check SQLOpen Verb"` | [SQLOPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlopen_verb.htm) | [SQLOPEN Verb - Open SQL Channel BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/sqlopen_verb_open_sql_channel_bbj.htm) |
+| OK | `npx vitest run -t "Check SQLPREP verb"` | [SQLPREP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlprep_verb.htm) | [SQLPREP Verb - Set Up SQL Command (BBj)](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/sqlprep_verb_set_up_sql_command_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` |     | [SQLROLLBACK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlrollback_verb_rollback_current_transaction.htm) |
 | TODO | `npx vitest run -t "TODO"` | [SQLSET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/sqlset_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [START Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/start_verb.htm) | [START Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/start_verb_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` | [STOP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/stop_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [STRING Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/string_verb.htm) |     |
-| OK | `npx vitest run -t "TODO"` | [SWITCH .. CASE .. SWEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/switch_case_swend_verbs.htm) | [SWITCH .. CASE .. SWEND Verbs - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/SWITCH..CASE..SWEND_Verbs-BBj.htm) |
+| OK | `npx vitest run -t "Check SWITCH...CASE...SWEND verb"` | [SWITCH .. CASE .. SWEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/switch_case_swend_verbs.htm) | [SWITCH .. CASE .. SWEND Verbs - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/SWITCH..CASE..SWEND_Verbs-BBj.htm) |
 | TODO | `npx vitest run -t "TODO"` |     |     |
 | TODO | `npx vitest run -t "TODO"` | [TABLE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/table_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` |     | [TCLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/tclose_verb.htm) |
@@ -136,8 +136,8 @@
 | TODO | `npx vitest run -t "TODO"` | [UPDATELIC Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/updatelic_verb_update_license_for_basis_license_manager.htm) |     |
 | TODO | `npx vitest run -t "TODO"` |     | [USE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/use_verb.htm) |
 | OK | `npx vitest run -t "Check KeyedFileStatement Verb"` |      | [VKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/vkeyed_verb.htm) |
-| OK | `npx vitest run -t "TODO"` | [WAIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/wait_verb.htm) | [WAIT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/wait_verb_bbj.htm) |
-| OK | `npx vitest run -t "TODO"` | [WHILE .. WEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/while_wend_verbs.htm) |     |
+| OK | `npx vitest run -t "Check WAIT verb"` | [WAIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/wait_verb.htm) | [WAIT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/wait_verb_bbj.htm) |
+| OK | `npx vitest run -t "Check WHILE verb"` | [WHILE .. WEND Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/while_wend_verbs.htm) |     |
 | OK | `npx vitest run -t "Check read and similar, with record"` | [WRITE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/write_verb.htm) | [WRITE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/write_verb_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` | [XCALL Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xcall_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` |     | [XFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/xfile_verb.htm) |

--- a/bbj-vscode/VERBs.md
+++ b/bbj-vscode/VERBs.md
@@ -2,7 +2,7 @@
 
 | Status | Test | Main Description | BBj-Specific Description |
 | --- | --- | --- | --- |
-| OK | `npx vitest run -t "TODO"` | `npx vitest run -t "TODO"` | [ADDR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/addr_verb.htm) |     |
+| OK | `npx vitest run -t "TODO"` | [ADDR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/addr_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [AUTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/auto_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [BACKGROUND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/background_verb.htm) |     |
 | OK | `npx vitest run -t "Check Begin Clear Verb"` | [BEGIN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/begin_verb.htm) | [BEGIN Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/BEGIN_Verb_-_BBj.htm) |

--- a/bbj-vscode/VERBs.md
+++ b/bbj-vscode/VERBs.md
@@ -2,7 +2,7 @@
 
 | Status | Test | Main Description | BBj-Specific Description |
 | --- | --- | --- | --- |
-| OK | `npx vitest run -t "TODO"` | [ADDR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/addr_verb.htm) |     |
+| OK | `npx vitest run -t "Check ADDR verb"` | [ADDR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/addr_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [AUTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/auto_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [BACKGROUND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/background_verb.htm) |     |
 | OK | `npx vitest run -t "Check Begin Clear Verb"` | [BEGIN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/begin_verb.htm) | [BEGIN Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/BEGIN_Verb_-_BBj.htm) |
@@ -18,11 +18,11 @@
 | TODO | `npx vitest run -t "TODO"` |     | [CLEARP Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clearp_verb.htm) |
 | TODO | `npx vitest run -t "TODO"` | [CLIPCLEAR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipclear_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [CLIPFROMFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipfromfile_verb.htm) |     |
-| OK | `npx vitest run -t "TODO"` | [CLIPFROMSTR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipfromstr_verb.htm) |     |
+| OK | `npx vitest run -t "Check CLIPFROMSTR verb"` | [CLIPFROMSTR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipfromstr_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [CLIPLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cliplock_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [CLIPTOFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/cliptofile_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [CLIPUNLOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/clipunlock_verb.htm) |     |
-| OK | `npx vitest run -t "TODO"` | [CLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/close_verb.htm) | [CLOSE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/close_verb_bbj.htm) |
+| OK | `npx vitest run -t "Check CLOSE verb"` | [CLOSE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/close_verb.htm) | [CLOSE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/close_verb_bbj.htm) |
 | OK | `npx vitest run -t "Check Exit Verbs"` | [CONTINUE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/continue_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [DEF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/def_verb.htm) | [DEF Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/def_verb_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` | [DELETE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/delete_verb.htm) |     |
@@ -44,21 +44,21 @@
 | OK | `npx vitest run -t "Execute statement"` | [EXECUTE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/execute_verb.htm) | [EXECUTE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/EXECUTE_Verb_-_BBj.htm) |
 | OK | `npx vitest run -t "Check Exit Verbs"` | [EXIT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/exit_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [EXITTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/exitto_verb.htm) |     |
-| OK | `npx vitest run -t "Check readrecord and similar"` <br/> `npx vitest run -t "READ: Input variable should be linked or created."` | [EXTRACT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/extract_verb.htm) (+EXTRACTRECORD) |     |
+| TODO parameter combinations | `npx vitest run -t "Check readrecord and similar"` <br/> `npx vitest run -t "READ: Input variable should be linked or created."` | [EXTRACT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/extract_verb.htm) (+EXTRACTRECORD) |     |
 | TODO | `npx vitest run -t "TODO"` | [FIELD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/field_verb.htm) | [FIELD Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/field_verb_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` | [FILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/file_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [FILEOPT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/fileopt_verb.htm) |     |
-| OK | `npx vitest run -t "Check read and similar, with record"` | [FIND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/find_verb.htm) (+FINDRECORD) |     |
+| TODO parameter combinations | `npx vitest run -t "Check read and similar, with record"` | [FIND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/find_verb.htm) (+FINDRECORD) |     |
 | TODO | `npx vitest run -t "TODO"` | [FLOATINGPOINT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/floatingpoint_verb.htm) | [FLOATINGPOINT Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/floatingpoint_verb_bbj.htm) |
 | OK | `npx vitest run -t "Program definition test"` | FOR ... TO ... STEP | |
 | TODO | `npx vitest run -t "TODO"` | [FOR .. NEXT Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/for_next_verbs.htm) | [FOR .. NEXT Verbs - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/for_next_verbs_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` |     | [FULLTEXT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/FULLTEXT_Verb-Create_FULLTEXT_File.htm) |
-| OK | `npx vitest run -t "TODO"` | [GOSUB Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/gosub_verb.htm) |     |
-| OK | `npx vitest run -t "Seterr and Setesc"`| [GOTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/goto_verb.htm) |     |
+| OK | `npx vitest run -t "Check GOSUB verb"` | [GOSUB Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/gosub_verb.htm) |     |
+| OK | `npx vitest run -t "Check GOTO verb"`| [GOTO Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/goto_verb.htm) |     |
 | OK | `npx vitest run -t "Parse \"METHODRET\" in a multi line \"IF\""` | [IF Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/if_verb.htm) (IF/ELSE/ENDIF/FI) |     |
 | TODO | `npx vitest run -t "TODO"` | [INDEXED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/indexed_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [INITFILE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/initfile_verb.htm) | [INITFILE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/INITFILE_Verb_BBj.htm) |
-| OK | `npx vitest run -t "TODO"` | [INPUT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/input_verb.htm) (+INPUTRECORD) |     |
+| TODO parameter combinations | `npx vitest run -t "TODO"` | [INPUT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/input_verb.htm) (+INPUTRECORD) |     |
 | TODO | `npx vitest run -t "TODO"` | [INPUTE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/inpute_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [INPUTN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/inputn_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` |     | [INTERFACE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/interface_verb.htm) |
@@ -68,23 +68,23 @@
 | TODO | `npx vitest run -t "TODO"` |     | [JKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jkeyed_verb_create_journaled_file.htm) |
 | TODO | `npx vitest run -t "TODO"` |     | [JOPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/jopen_verb.htm) |
 | TODO | `npx vitest run -t "TODO"` | [LCHECKIN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/lcheckin_verb_check_in_license.htm) |     |
-| OK | `npx vitest run -t "Mnemonic tests"`| [LET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/let_verb.htm) | [LET Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/let_verb_bbj.htm) |
+| TODO matrix operations | `npx vitest run -t "Check LET verb"`| [LET Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/let_verb.htm) | [LET Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/let_verb_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` | [LIST Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/list_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [LOAD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/load_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [LOCK Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/lock_verb.htm) | [LOCK Verb - Lock File BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/lock_verb_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` | [MERGE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/merge_verb.htm) | [MERGE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/merge_verb_bbj.htm) |
-| OK | `npx vitest run -t "Check throw statement syntax"`  |   | [METHOD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/method_verb.htm) |
+| TODO check "static" and other parameters | `npx vitest run -t "Check throw statement syntax"` |   | [METHOD Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/method_verb.htm) |
 | OK |  `npx vitest run -t "Check throw statement syntax"` |   | [METHODEND Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/methodend_verb.htm) |
 | OK | `npx vitest run -t "Dir statements"` | [MKDIR Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/mkdir_verb.htm) | [MKDIR Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/mkdir_verb_bbj.htm) |
 | OK | `npx vitest run -t "Check KeyedFileStatement Verb"` | [MKEYED Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/mkeyed_verb.htm) |     |
 | TODO | `npx vitest run -t "TODO"` | [ON GOTO/GOSUB Verbs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/on_goto_gosub_verbs.htm) |     |
-| OK | `npx vitest run -t "Check Open Verb optional params keywords"` | [OPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/open_verb.htm) | [OPEN Verb - Open File BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/open_verb_open_file_bbj.htm) |
+| TODO check more parameter combinations | `npx vitest run -t "Check Open Verb optional params keywords"` | [OPEN Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/open_verb.htm) | [OPEN Verb - Open File BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/open_verb_open_file_bbj.htm) |
 | OK | `npx vitest run -t "Check Precision Verb"` | [PRECISION Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/precision_verb.htm) | [PRECISION Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/precision_verb_bbj.htm) |
 | TODO | `npx vitest run -t "TODO"` | [PREFIX Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/prefix_verb.htm) | [PREFIX Verb - Set File System Search Paths - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/prefix_verb_set_file_system_search_paths_bbj.htm) |
-| OK | `npx vitest run -t "Parse \"REM\" as independent statement in compound statement"` |  [PRINT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/print_verb.htm) |     |
+| TODO check more parameter combinations | `npx vitest run -t "Parse \"REM\" as independent statement in compound statement"` |  [PRINT Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/print_verb.htm) |     |
 | OK | `npx vitest run -t "Check PROCESS_EVENT Parameters"` |    | [PROCESS\_EVENTS Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/process_events_verb.htm) |
 | TODO | `npx vitest run -t "TODO"` | [PROGRAM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/program_verb.htm) |     |
-| OK | `npx vitest run -t "Check read and similar, with record"` | [READ Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/read_verb.htm) (+READRECORD) | [READ Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/read_verb_bbj.htm) |
+| TODO check more parameter combinations | `npx vitest run -t "Check read and similar, with record"` | [READ Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/read_verb.htm) (+READRECORD) | [READ Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/read_verb_bbj.htm) |
 | OK | `npx vitest run -t "Check REDIM verb"` |    | [REDIM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/REDIM_Verb.htm) |
 | OK | `npx vitest run -t "Check RELEASE verb"` | [RELEASE Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/release_verb.htm) | [RELEASE Verb - BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/release_verb_bbj.htm) |
 | OK | `npx vitest run -t "Parse \"REM\" as independent statement on own line"`| [REM Verb](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/rem_verb.htm) |     |

--- a/bbj-vscode/test/parser.test.ts
+++ b/bbj-vscode/test/parser.test.ts
@@ -3,7 +3,7 @@ import { parseHelper } from 'langium/test';
 import { streamAst } from 'langium';
 import { describe, expect, test } from 'vitest';
 import { createBBjServices } from '../src/language/bbj-module';
-import { CompoundStatement, LetStatement, Library, Model, PrintStatement, Program, ReadStatement, StringLiteral, SymbolRef, isCallStatement, isCommentStatement, isCompoundStatement, isExitWithNumberStatement, isLibrary, isPrintStatement, isProgram, isRedimStatement, isRunStatement, isSqlCloseStatement, isSqlPrepStatement, isSwitchCase, isSwitchStatement, isWaitStatement } from '../src/language/generated/ast';
+import { CompoundStatement, LetStatement, Library, Model, PrintStatement, Program, ReadStatement, StringLiteral, SymbolRef, isAddrStatement, isCallStatement, isClipFromStrStatement, isCloseStatement, isCommentStatement, isCompoundStatement, isExitWithNumberStatement, isGotoStatement, isLetStatement, isLibrary, isPrintStatement, isProgram, isRedimStatement, isRunStatement, isSqlCloseStatement, isSqlPrepStatement, isSwitchCase, isSwitchStatement, isWaitStatement } from '../src/language/generated/ast';
 
 const services = createBBjServices(EmptyFileSystem);
 
@@ -902,5 +902,72 @@ describe('Parser Tests', () => {
         `);
         expectNoParserLexerErrors(result);
         expectToContainAstNodeType(result, isRedimStatement);
+    });
+
+    test('Check ADDR verb', async () => {
+        const result = await parse(`
+            ADDR "MYPROG"
+            ADDR "MYPROG", ERR=ErrorLabel
+            ErrorLabel: STOP
+        `);
+        expectNoParserLexerErrors(result);
+        expectToContainAstNodeType(result, isAddrStatement);
+    });
+
+
+    test('Check CLIPFROMSTR verb', async () => {
+        //documentation: https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/clipboard_verbs_and_functions_bbj.htm
+        //1=TEXT
+        const result = await parse(`
+            Start:  str$ = "Test!"
+                    CLIPFROMSTR 1,str$
+                    CLIPFROMSTR 1,str$,ERR=ErrorLabel
+            ErrorLabel: STOP
+        `);
+        expectNoParserLexerErrors(result);
+        expectToContainAstNodeType(result, isClipFromStrStatement);
+    });
+
+    test('Check CLOSE verb', async () => {
+        const result = await parse(`
+            Start:  CLOSE (1)
+                    CLOSE (1,ERR=ErrorLabel)
+            ErrorLabel: STOP
+        `);
+        expectNoParserLexerErrors(result);
+        expectToContainAstNodeType(result, isCloseStatement);
+    });
+
+    test('Check GOSUB verb', async () => {
+        const result = await parse(`
+            Start:  GOSUB func
+                    STOP
+            func:   REM SUBROUTINE
+                    LET A=50; LET B=A * C / 2; PRINT B
+                    RETURN
+        `);
+        expectNoParserLexerErrors(result);
+        expectToContainAstNodeType(result, isGotoStatement);
+    });
+
+    test('Check GOTO verb', async () => {
+        const result = await parse(`
+            start:  GOTO region
+                    STOP
+            region: REM and so on
+        `);
+        expectNoParserLexerErrors(result);
+        expectToContainAstNodeType(result, isGotoStatement);
+    });
+
+    test('Check LET verb', async () => {
+        //TODO what about matrix operations?
+        //https://documentation.basis.cloud/BASISHelp/WebHelp/commands/let_verb.htm
+        const result = await parse(`
+            C = 5
+            LET C=100
+        `);
+        expectNoParserLexerErrors(result);
+        expectToContainAstNodeType(result, isLetStatement);
     });
 });


### PR DESCRIPTION
I looked at the official documentation and made a comparison between what is already there in the grammar and covered by test and what is still to be done.

Some verbs were implemented but had no test: for most of them I added a test that covers all parameter combinations. For some I marked them as TODO, since the combination of parameters seem to be too complex to be done in this small PR.

Each verb has also a test command now, addressing the test via its title.
The most of the tests addresses "TODO", which means there is no test yet.

I hope this helps to get an overview what is still missing and what to do first (prioritizing).