### PR TITLE
Add verb RETURN with optional return value

### DIFF
--- a/bbj-vscode/src/language/bbj-token-builder.ts
+++ b/bbj-vscode/src/language/bbj-token-builder.ts
@@ -7,6 +7,7 @@ export class BBjTokenBuilder extends DefaultTokenBuilder {
         const tokens = super.buildTokens(grammar, options) as TokenType[];
         this.spliceToken(tokens, 'NEXT_TOKEN', 1);
         this.spliceToken(tokens, 'METHODRET_END', 1);
+        this.spliceToken(tokens, 'ENDLINE_RETURN', 1);
         this.spliceToken(tokens, 'ENDLINE_PRINT_COMMA', 1);
         return tokens;
     }
@@ -30,6 +31,13 @@ export class BBjTokenBuilder extends DefaultTokenBuilder {
                 name: terminal.name,
                 // Add more expceptional tokens here if an explicit line break token is needed
                 PATTERN: this.regexPatternFunction(/METHODRET[ \t]*(?=(;|\r?\n))/i),
+                LINE_BREAKS: false
+            };
+            return token;
+        } else if (terminal.name === 'ENDLINE_RETURN') {
+            const token: TokenType = {
+                name: terminal.name,
+                PATTERN: this.regexPatternFunction(/RETURN[ \t]*(?=(\r?\n))/),
                 LINE_BREAKS: false
             };
             return token;

--- a/bbj-vscode/src/language/bbj.langium
+++ b/bbj-vscode/src/language/bbj.langium
@@ -40,6 +40,7 @@ SingleStatement:
     WhileEndStatement |
     GotoStatement |
     KeywordStatement |
+    ReturnStatement |
     ExitWithNumberStatement |
     ExitToStatement |
     NextStatement |
@@ -195,6 +196,9 @@ ElseStatement:
 IfEndStatement:
     ('ENDIF' | 'FI') {infer IfEndStatement};
 
+ReturnStatement:
+    ENDLINE_RETURN | 'RETURN' returnValue=Expression?;
+
 WhileStatement:
     'WHILE' condition=Expression
 ;
@@ -225,7 +229,7 @@ SymbolicLabelRef infers LabelRef:
 ;
 
 KeywordStatement:
-    kind=('RETURN' | 'END' | 'BYE' | 'BREAK' | 'CONTINUE' | 'ESCAPE' | 'REPEAT')
+    kind=('END' | 'BYE' | 'BREAK' | 'CONTINUE' | 'ESCAPE' | 'REPEAT')
 ;
 
 ExitWithNumberStatement:
@@ -588,6 +592,7 @@ hidden terminal WS: /\s+/;
 terminal COMMENT: /([rR][eE][mM])([ \t][^\n\r]*)?[\n\r]+/; // (rEm)(space or tab)(all but linebreak)(linebreak)
 
 terminal ENDLINE_PRINT_COMMA: /_endline_print_comma/;
+terminal ENDLINE_RETURN: /_endline_return/;
 
 terminal NEXT_TOKEN: /_next/;
 terminal METHODRET_END: /_methodret_end/;

--- a/bbj-vscode/test/parser.test.ts
+++ b/bbj-vscode/test/parser.test.ts
@@ -808,4 +808,25 @@ describe('Parser Tests', () => {
         expectNoParserLexerErrors(result);
     });
 
+    test('Return statement without result', async () => {
+        const result = await parse(`
+        GOSUB funcNoReturn
+
+        funcNoReturn:
+            PRINT "we do something and RETURN"
+            RETURN
+        `);
+        expectNoParserLexerErrors(result);
+    });
+
+    test('Return statement with result', async () => {
+        const result = await parse(`
+        GOSUB funcWithReturn
+
+        funcWithReturn:
+            RETURN 42
+        `);
+        expectNoParserLexerErrors(result);
+    });
+
 });

--- a/examples/return.bbj
+++ b/examples/return.bbj
@@ -1,0 +1,9 @@
+GOSUB funcNoReturn
+GOSUB funcWithReturn
+
+funcNoReturn:
+    PRINT "we do something and RETURN"
+    RETURN
+
+funcWithReturn:
+    RETURN 123


### PR DESCRIPTION
Closes #44 

This was my first attempt to add a new verb variation (RETURN with return value).
Currently we just support RETURN without return value.

The priority was not high. I wanted to start with something simple.

#137 was developed afterwards in a separate branch. It would be a good idea to rebase and change the RETURN row from TODO to OK in the corresponding VERBs table.