### PR TITLE
Migrate Langium to version 3.2.0

### DIFF
--- a/bbj-vscode/package-lock.json
+++ b/bbj-vscode/package-lock.json
@@ -10,28 +10,28 @@
             "license": "MIT",
             "dependencies": {
                 "chevrotain": "^10.4.2",
-                "langium": "~1.3.1",
+                "langium": "^3.2.0",
                 "properties-file": "~3.2.5",
                 "properties-reader": "^2.2.0",
-                "vscode-jsonrpc": "~8.0.2",
-                "vscode-languageclient": "~8.0.2",
+                "vscode-jsonrpc": "^8.2.1",
+                "vscode-languageclient": "^9.0.1",
                 "vscode-uri": "^3.0.2"
             },
             "devDependencies": {
                 "@types/node": "^14.17.3",
-                "@types/vscode": "^1.56.0",
+                "@types/vscode": "^1.67.0",
                 "@typescript-eslint/eslint-plugin": "^5.28.0",
                 "@typescript-eslint/parser": "^5.28.0",
                 "concurrently": "^8.2.0",
                 "esbuild": "^0.18.12",
                 "eslint": "^8.17.0",
-                "langium-cli": "~1.3.1",
+                "langium-cli": "^3.2.0",
                 "shx": "^0.3.4",
                 "typescript": "^4.9.4",
                 "vitest": "~0.28.4"
             },
             "engines": {
-                "vscode": "^1.56.0"
+                "vscode": "^1.67.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -73,6 +73,11 @@
                 "@chevrotain/types": "10.4.2",
                 "lodash": "4.17.21"
             }
+        },
+        "node_modules/@chevrotain/regexp-to-ast": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
+            "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="
         },
         "node_modules/@chevrotain/types": {
             "version": "10.4.2",
@@ -937,6 +942,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1034,15 +1040,6 @@
                 "regexp-to-ast": "0.5.0"
             }
         },
-        "node_modules/chevrotain-allstar": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.1.4.tgz",
-            "integrity": "sha512-gr5PNT8keiOTt19r+XkRY19unZw7rUE/erXgfFMEJnk1ZTuiVGWREfzVPSlz9u6DxbR0zJ9NQzdQS0a/3SVKFw==",
-            "dependencies": {
-                "chevrotain": "^10.4.1",
-                "lodash": "^4.17.21"
-            }
-        },
         "node_modules/cli-truncate": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
@@ -1121,18 +1118,19 @@
             "dev": true
         },
         "node_modules/commander": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
-            "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
+            "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
             "dev": true,
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
         },
         "node_modules/concurrently": {
             "version": "8.2.0",
@@ -1664,9 +1662,9 @@
             "dev": true
         },
         "node_modules/fs-extra": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-            "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -1789,9 +1787,9 @@
             }
         },
         "node_modules/graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "node_modules/grapheme-splitter": {
@@ -2011,49 +2009,114 @@
             }
         },
         "node_modules/langium": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-1.3.1.tgz",
-            "integrity": "sha512-xC+DnAunl6cZIgYjRpgm3s1kYAB5/Wycsj24iYaXG9uai7SgvMaFZSrRvdA5rUK/lSta/CRvgF+ZFoEKEOFJ5w==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/langium/-/langium-3.2.0.tgz",
+            "integrity": "sha512-HxAPgCVC7X+dCN99QKlZMEoaLW4s/mt0IImYrP6ooEBOMh8lJYdFNNSpJ5NIOE+WFwQd3xa2phTJDmJhOWVR7A==",
             "dependencies": {
-                "chevrotain": "~10.4.2",
-                "chevrotain-allstar": "~0.1.4",
-                "vscode-languageserver": "~8.0.2",
-                "vscode-languageserver-textdocument": "~1.0.8",
-                "vscode-uri": "~3.0.7"
+                "chevrotain": "~11.0.3",
+                "chevrotain-allstar": "~0.3.0",
+                "vscode-languageserver": "~9.0.1",
+                "vscode-languageserver-textdocument": "~1.0.11",
+                "vscode-uri": "~3.0.8"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/langium-cli": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-1.3.1.tgz",
-            "integrity": "sha512-9faKpioKCjBD0Z4y165+wQlDFiDHOXYBlhPVgbV+neSnSB70belZLNfykAVa564360h7Br/5PogR5jW2n/tOKw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-3.2.0.tgz",
+            "integrity": "sha512-4JWeCMuTHyFO+GCnOVT8+jygdob4KnU0uh/26cMxgZ1FlenAk8zrOnrXbuUzIm0FAIetCqrR6GUXqeko+Vg5og==",
             "dev": true,
             "dependencies": {
-                "chalk": "~4.1.2",
-                "commander": "~10.0.0",
-                "fs-extra": "~11.1.0",
+                "chalk": "~5.3.0",
+                "commander": "~11.0.0",
+                "fs-extra": "~11.1.1",
                 "jsonschema": "~1.4.1",
-                "langium": "~1.3.0",
-                "langium-railroad": "~1.3.0",
+                "langium": "~3.2.0",
+                "langium-railroad": "~3.2.0",
                 "lodash": "~4.17.21"
             },
             "bin": {
                 "langium": "bin/langium.js"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/langium-cli/node_modules/chalk": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+            "dev": true,
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/langium-railroad": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-1.3.0.tgz",
-            "integrity": "sha512-I3gx79iF+Qpn2UjzfHLf2GENAD9mPdSZHL3juAZLBsxznw4se7MBrJX32oPr/35DTjU9q99wFCQoCXu7mcf+Bg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-3.2.0.tgz",
+            "integrity": "sha512-8wJqRid1udSH9PKo8AkRrJCUNHQ6Xu9tGi+//bLdHGDdlK9gpps1AwO71ufE864/so77K4ZmqBuLnBnxPcGs/Q==",
             "dev": true,
             "dependencies": {
-                "langium": "~1.3.0",
-                "railroad-diagrams": "^1.0.0"
+                "langium": "~3.2.0",
+                "railroad-diagrams": "~1.0.0"
+            }
+        },
+        "node_modules/langium/node_modules/@chevrotain/cst-dts-gen": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+            "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+            "dependencies": {
+                "@chevrotain/gast": "11.0.3",
+                "@chevrotain/types": "11.0.3",
+                "lodash-es": "4.17.21"
+            }
+        },
+        "node_modules/langium/node_modules/@chevrotain/gast": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+            "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+            "dependencies": {
+                "@chevrotain/types": "11.0.3",
+                "lodash-es": "4.17.21"
+            }
+        },
+        "node_modules/langium/node_modules/@chevrotain/types": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+            "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="
+        },
+        "node_modules/langium/node_modules/@chevrotain/utils": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+            "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
+        },
+        "node_modules/langium/node_modules/chevrotain": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+            "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+            "dependencies": {
+                "@chevrotain/cst-dts-gen": "11.0.3",
+                "@chevrotain/gast": "11.0.3",
+                "@chevrotain/regexp-to-ast": "11.0.3",
+                "@chevrotain/types": "11.0.3",
+                "@chevrotain/utils": "11.0.3",
+                "lodash-es": "4.17.21"
+            }
+        },
+        "node_modules/langium/node_modules/chevrotain-allstar": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+            "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+            "dependencies": {
+                "lodash-es": "^4.17.21"
+            },
+            "peerDependencies": {
+                "chevrotain": "^11.0.0"
             }
         },
         "node_modules/levn": {
@@ -2100,6 +2163,11 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "node_modules/lodash-es": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -2153,6 +2221,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -3049,9 +3118,9 @@
             "dev": true
         },
         "node_modules/universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
             "engines": {
                 "node": ">= 10.0.0"
@@ -3594,60 +3663,87 @@
             }
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-            "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+            "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageclient": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
-            "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+            "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
             "dependencies": {
-                "minimatch": "^3.0.4",
-                "semver": "^7.3.5",
-                "vscode-languageserver-protocol": "3.17.2"
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.5"
             },
             "engines": {
-                "vscode": "^1.67.0"
+                "vscode": "^1.82.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/vscode-languageserver": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz",
-            "integrity": "sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+            "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
             "dependencies": {
-                "vscode-languageserver-protocol": "3.17.2"
+                "vscode-languageserver-protocol": "3.17.5"
             },
             "bin": {
                 "installServerIntoExtension": "bin/installServerIntoExtension"
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
-            "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
             "dependencies": {
-                "vscode-jsonrpc": "8.0.2",
-                "vscode-languageserver-types": "3.17.2"
+                "vscode-jsonrpc": "8.2.0",
+                "vscode-languageserver-types": "3.17.5"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol/node_modules/vscode-jsonrpc": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-            "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.17.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
         },
         "node_modules/vscode-uri": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-            "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+            "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -3849,6 +3945,11 @@
                 "@chevrotain/types": "10.4.2",
                 "lodash": "4.17.21"
             }
+        },
+        "@chevrotain/regexp-to-ast": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
+            "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="
         },
         "@chevrotain/types": {
             "version": "10.4.2",
@@ -4358,6 +4459,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4434,15 +4536,6 @@
                 "regexp-to-ast": "0.5.0"
             }
         },
-        "chevrotain-allstar": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.1.4.tgz",
-            "integrity": "sha512-gr5PNT8keiOTt19r+XkRY19unZw7rUE/erXgfFMEJnk1ZTuiVGWREfzVPSlz9u6DxbR0zJ9NQzdQS0a/3SVKFw==",
-            "requires": {
-                "chevrotain": "^10.4.1",
-                "lodash": "^4.17.21"
-            }
-        },
         "cli-truncate": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
@@ -4505,15 +4598,16 @@
             "dev": true
         },
         "commander": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
-            "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
+            "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
             "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
         },
         "concurrently": {
             "version": "8.2.0",
@@ -4917,9 +5011,9 @@
             "dev": true
         },
         "fs-extra": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-            "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.0",
@@ -5005,9 +5099,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "grapheme-splitter": {
@@ -5173,40 +5267,100 @@
             "dev": true
         },
         "langium": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-1.3.1.tgz",
-            "integrity": "sha512-xC+DnAunl6cZIgYjRpgm3s1kYAB5/Wycsj24iYaXG9uai7SgvMaFZSrRvdA5rUK/lSta/CRvgF+ZFoEKEOFJ5w==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/langium/-/langium-3.2.0.tgz",
+            "integrity": "sha512-HxAPgCVC7X+dCN99QKlZMEoaLW4s/mt0IImYrP6ooEBOMh8lJYdFNNSpJ5NIOE+WFwQd3xa2phTJDmJhOWVR7A==",
             "requires": {
-                "chevrotain": "~10.4.2",
-                "chevrotain-allstar": "~0.1.4",
-                "vscode-languageserver": "~8.0.2",
-                "vscode-languageserver-textdocument": "~1.0.8",
-                "vscode-uri": "~3.0.7"
+                "chevrotain": "~11.0.3",
+                "chevrotain-allstar": "~0.3.0",
+                "vscode-languageserver": "~9.0.1",
+                "vscode-languageserver-textdocument": "~1.0.11",
+                "vscode-uri": "~3.0.8"
+            },
+            "dependencies": {
+                "@chevrotain/cst-dts-gen": {
+                    "version": "11.0.3",
+                    "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+                    "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+                    "requires": {
+                        "@chevrotain/gast": "11.0.3",
+                        "@chevrotain/types": "11.0.3",
+                        "lodash-es": "4.17.21"
+                    }
+                },
+                "@chevrotain/gast": {
+                    "version": "11.0.3",
+                    "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+                    "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+                    "requires": {
+                        "@chevrotain/types": "11.0.3",
+                        "lodash-es": "4.17.21"
+                    }
+                },
+                "@chevrotain/types": {
+                    "version": "11.0.3",
+                    "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+                    "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="
+                },
+                "@chevrotain/utils": {
+                    "version": "11.0.3",
+                    "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+                    "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
+                },
+                "chevrotain": {
+                    "version": "11.0.3",
+                    "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+                    "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+                    "requires": {
+                        "@chevrotain/cst-dts-gen": "11.0.3",
+                        "@chevrotain/gast": "11.0.3",
+                        "@chevrotain/regexp-to-ast": "11.0.3",
+                        "@chevrotain/types": "11.0.3",
+                        "@chevrotain/utils": "11.0.3",
+                        "lodash-es": "4.17.21"
+                    }
+                },
+                "chevrotain-allstar": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+                    "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+                    "requires": {
+                        "lodash-es": "^4.17.21"
+                    }
+                }
             }
         },
         "langium-cli": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-1.3.1.tgz",
-            "integrity": "sha512-9faKpioKCjBD0Z4y165+wQlDFiDHOXYBlhPVgbV+neSnSB70belZLNfykAVa564360h7Br/5PogR5jW2n/tOKw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-3.2.0.tgz",
+            "integrity": "sha512-4JWeCMuTHyFO+GCnOVT8+jygdob4KnU0uh/26cMxgZ1FlenAk8zrOnrXbuUzIm0FAIetCqrR6GUXqeko+Vg5og==",
             "dev": true,
             "requires": {
-                "chalk": "~4.1.2",
-                "commander": "~10.0.0",
-                "fs-extra": "~11.1.0",
+                "chalk": "~5.3.0",
+                "commander": "~11.0.0",
+                "fs-extra": "~11.1.1",
                 "jsonschema": "~1.4.1",
-                "langium": "~1.3.0",
-                "langium-railroad": "~1.3.0",
+                "langium": "~3.2.0",
+                "langium-railroad": "~3.2.0",
                 "lodash": "~4.17.21"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+                    "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+                    "dev": true
+                }
             }
         },
         "langium-railroad": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-1.3.0.tgz",
-            "integrity": "sha512-I3gx79iF+Qpn2UjzfHLf2GENAD9mPdSZHL3juAZLBsxznw4se7MBrJX32oPr/35DTjU9q99wFCQoCXu7mcf+Bg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-3.2.0.tgz",
+            "integrity": "sha512-8wJqRid1udSH9PKo8AkRrJCUNHQ6Xu9tGi+//bLdHGDdlK9gpps1AwO71ufE864/so77K4ZmqBuLnBnxPcGs/Q==",
             "dev": true,
             "requires": {
-                "langium": "~1.3.0",
-                "railroad-diagrams": "^1.0.0"
+                "langium": "~3.2.0",
+                "railroad-diagrams": "~1.0.0"
             }
         },
         "levn": {
@@ -5238,6 +5392,11 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "lodash-es": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "lodash.merge": {
             "version": "4.6.2",
@@ -5282,6 +5441,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -5895,9 +6055,9 @@
             "dev": true
         },
         "universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true
         },
         "uri-js": {
@@ -6156,51 +6316,76 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-            "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+            "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ=="
         },
         "vscode-languageclient": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
-            "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+            "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
             "requires": {
-                "minimatch": "^3.0.4",
-                "semver": "^7.3.5",
-                "vscode-languageserver-protocol": "3.17.2"
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.5"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.6",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+                    "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
             }
         },
         "vscode-languageserver": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz",
-            "integrity": "sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+            "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
             "requires": {
-                "vscode-languageserver-protocol": "3.17.2"
+                "vscode-languageserver-protocol": "3.17.5"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.17.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
-            "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
             "requires": {
-                "vscode-jsonrpc": "8.0.2",
-                "vscode-languageserver-types": "3.17.2"
+                "vscode-jsonrpc": "8.2.0",
+                "vscode-languageserver-types": "3.17.5"
+            },
+            "dependencies": {
+                "vscode-jsonrpc": {
+                    "version": "8.2.0",
+                    "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+                    "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="
+                }
             }
         },
         "vscode-languageserver-textdocument": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-            "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
         },
         "vscode-languageserver-types": {
-            "version": "3.17.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
         },
         "vscode-uri": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-            "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+            "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
         },
         "which": {
             "version": "2.0.2",

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -6,8 +6,9 @@
     "description": "BBj Language Support for Visual Studio Code",
     "license": "MIT",
     "icon": "images/icon.png",
+    "type": "module",
     "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.67.0"
     },
     "categories": [
         "Programming Languages"
@@ -287,22 +288,22 @@
     },
     "dependencies": {
         "chevrotain": "^10.4.2",
-        "langium": "~1.3.1",
+        "langium": "^3.2.0",
         "properties-file": "~3.2.5",
         "properties-reader": "^2.2.0",
-        "vscode-jsonrpc": "~8.0.2",
-        "vscode-languageclient": "~8.0.2",
+        "vscode-jsonrpc": "^8.2.1",
+        "vscode-languageclient": "^9.0.1",
         "vscode-uri": "^3.0.2"
     },
     "devDependencies": {
         "@types/node": "^14.17.3",
-        "@types/vscode": "^1.56.0",
+        "@types/vscode": "^1.67.0",
         "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.28.0",
         "concurrently": "^8.2.0",
         "esbuild": "^0.18.12",
         "eslint": "^8.17.0",
-        "langium-cli": "~1.3.1",
+        "langium-cli": "^3.2.0",
         "shx": "^0.3.4",
         "typescript": "^4.9.4",
         "vitest": "~0.28.4"

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -8,9 +8,9 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import {
     LanguageClient, LanguageClientOptions, ServerOptions, TransportKind
-} from 'vscode-languageclient/node';
-import { BBjLibraryFileSystemProvider } from './language/lib/fs-provider';
-import { DocumentFormatter } from './document-formatter';
+} from 'vscode-languageclient/node.js';
+import { BBjLibraryFileSystemProvider } from './language/lib/fs-provider.js';
+import { DocumentFormatter } from './document-formatter.js';
 
 const Commands = require("./Commands/Commands.js");
 

--- a/bbj-vscode/src/language/bbj-comment-provider.ts
+++ b/bbj-vscode/src/language/bbj-comment-provider.ts
@@ -1,6 +1,6 @@
 import { AstNode, GenericAstNode } from "langium";
-import { CommentProvider } from "langium/lib/documentation/comment-provider";
-import { BbjClass, CommentStatement, isBBjClassMember, isBbjClass, isCommentStatement } from "./generated/ast";
+import { CommentProvider } from "langium";
+import { BbjClass, CommentStatement, isBBjClassMember, isBbjClass, isCommentStatement } from "./generated/ast.js";
 
 export class BBjCommentProvider implements CommentProvider {
 

--- a/bbj-vscode/src/language/bbj-completion-provider.ts
+++ b/bbj-vscode/src/language/bbj-completion-provider.ts
@@ -1,10 +1,9 @@
-import { AstNodeDescription, CompletionAcceptor, CompletionContext, CompletionValueItem, DefaultCompletionProvider, LangiumServices, MaybePromise, NextFeature, Reference, ReferenceInfo, getContainerOfType } from "langium";
-
-import { CrossReference, Keyword, isAssignment } from "langium/lib/grammar/generated/ast";
+import { CompletionAcceptor, CompletionContext, CompletionValueItem, DefaultCompletionProvider, LangiumServices, NextFeature } from "langium/lsp";
+import { AstUtils, AstNodeDescription, MaybePromise, Reference, ReferenceInfo, GrammarAST } from "langium";
 import { CompletionItemKind } from "vscode-languageserver";
-import { documentationHeader, methodSignature } from "./bbj-hover";
-import { isFunctionNodeDescription, type FunctionNodeDescription } from "./bbj-nodedescription-provider";
-import { LibEventType, LibSymbolicLabelDecl } from "./generated/ast";
+import { documentationHeader, methodSignature } from "./bbj-hover.js";
+import { isFunctionNodeDescription, type FunctionNodeDescription } from "./bbj-nodedescription-provider.js";
+import { LibEventType, LibSymbolicLabelDecl } from "./generated/ast.js";
 
 export class BBjCompletionProvider extends DefaultCompletionProvider {
 
@@ -51,11 +50,11 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
     /**
      * Need to override to control deduplicate filtering
      */
-    protected override completionForCrossReference(context: CompletionContext, crossRef: NextFeature<CrossReference>, acceptor: CompletionAcceptor): MaybePromise<void> {
-        const assignment = getContainerOfType(crossRef.feature, isAssignment);
+    protected override completionForCrossReference(context: CompletionContext, crossRef: NextFeature<GrammarAST.CrossReference>, acceptor: CompletionAcceptor): MaybePromise<void> {
+        const assignment = AstUtils.getContainerOfType(crossRef.feature, GrammarAST.isAssignment);
         let node = context.node;
         if (assignment && node) {
-            if (crossRef.type && (crossRef.new || node.$type !== crossRef.type)) {
+            if (crossRef.type) {
                 node = {
                     $type: crossRef.type,
                     $container: node,
@@ -71,18 +70,15 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
                 property: assignment.feature
             };
             try {
-                const scope = this.scopeProvider.getScope(refInfo);
-                scope.getAllElements().forEach(e => {
-                    if (this.filterCrossReference(e)) {
-                        acceptor(context, this.createReferenceCompletionItem(e));
-                    }
-                });
+                this.getReferenceCandidates(refInfo, context).forEach(
+                    c => acceptor(context, this.createReferenceCompletionItem(c))
+                );
             } catch (err) {
                 console.error(err);
             }
         }
     }
-    protected override completionForKeyword(context: CompletionContext, keyword: Keyword, acceptor: CompletionAcceptor): MaybePromise<void> {
+    protected override completionForKeyword(context: CompletionContext, keyword: GrammarAST.Keyword, acceptor: CompletionAcceptor): MaybePromise<void> {
         // Filter out keywords that do not contain any word character
         if (!keyword.value.match(/[\w]/)) {
             return;

--- a/bbj-vscode/src/language/bbj-document-builder.ts
+++ b/bbj-vscode/src/language/bbj-document-builder.ts
@@ -1,30 +1,29 @@
-import { AstNode, BuildOptions, DefaultDocumentBuilder, DocumentState, FileSystemProvider, LangiumDocument, LangiumSharedServices, WorkspaceManager, interruptAndCheck, streamAllContents } from "langium";
+import { AstNode, BuildOptions, DefaultDocumentBuilder, DocumentState, FileSystemProvider, LangiumDocument, LangiumSharedCoreServices, WorkspaceManager, interruptAndCheck, AstUtils } from "langium";
 import { CancellationToken } from "vscode-jsonrpc";
 import { URI } from 'vscode-uri';
-import { BBjWorkspaceManager } from "./bbj-ws-manager";
-import { Use, isUse } from "./generated/ast";
-import { JavaSyntheticDocUri } from "./java-interop";
-
+import { BBjWorkspaceManager } from "./bbj-ws-manager.js";
+import { Use, isUse } from "./generated/ast.js";
+import { JavaSyntheticDocUri } from "./java-interop.js";
 
 export class BBjDocumentBuilder extends DefaultDocumentBuilder {
 
     wsManager: () => WorkspaceManager;
     fileSystemProvider: FileSystemProvider;
 
-    constructor(services: LangiumSharedServices) {
+    constructor(services: LangiumSharedCoreServices) {
         super(services);
         this.wsManager = () => services.workspace.WorkspaceManager;
         this.fileSystemProvider = services.workspace.FileSystemProvider
     }
 
-    protected override shouldValidate(_document: LangiumDocument<AstNode>, options: BuildOptions): boolean {
+    protected override shouldValidate(_document: LangiumDocument<AstNode>): boolean {
         if (_document.uri.toString() === JavaSyntheticDocUri) {
             // never validate programmatically created classpath document
             _document.state = DocumentState.Validated;
             return false;
         }
         if (this.wsManager() instanceof BBjWorkspaceManager) {
-            const validate = super.shouldValidate(_document, options)
+            const validate = super.shouldValidate(_document)
                 && !(this.wsManager() as BBjWorkspaceManager).isExternalDocument(_document.uri)
             if (!validate) {
                 // mark as validated to avoid rebuilding
@@ -32,7 +31,7 @@ export class BBjDocumentBuilder extends DefaultDocumentBuilder {
             }
             return validate;
         }
-        return super.shouldValidate(_document, options);
+        return super.shouldValidate(_document);
     }
 
     protected override async buildDocuments(documents: LangiumDocument<AstNode>[], options: BuildOptions, cancelToken: CancellationToken): Promise<void> {
@@ -51,7 +50,7 @@ export class BBjDocumentBuilder extends DefaultDocumentBuilder {
         const bbjImports = new Set<string>();
         for (const document of documents) {
             await interruptAndCheck(cancelToken);
-            streamAllContents(document.parseResult.value).filter(isUse).forEach((use: Use) => {
+            AstUtils.streamAllContents(document.parseResult.value).filter(isUse).forEach((use: Use) => {
                 if (use.bbjFilePath) {
                     bbjImports.add(use.bbjFilePath);
                 }
@@ -64,25 +63,28 @@ export class BBjDocumentBuilder extends DefaultDocumentBuilder {
 
         const addedDocuments: URI[] = []
         for (const importPath of bbjImports) {
-            const docFileData = prefixes.map(prefixPath => {
+            const docFileDataPromise = prefixes.map(async prefixPath => {
                 const prefixedPath = URI.file(prefixPath + (prefixPath.endsWith('/') ? '' : '/') + importPath)
                 try {
-                    const fileContent = fsProvider.readFileSync(prefixedPath);
+                    const fileContent = await fsProvider.readFile(prefixedPath);
                     return { uri: prefixedPath, text: fileContent }
                 } catch (e) {
                     return undefined;
                 }
             }).find(doc => doc !== undefined)
 
-            if (docFileData) {
-                const document = documentFactory.fromString(docFileData.text, docFileData.uri);
-                if (!langiumDocuments.hasDocument(document.uri)) {
-                    langiumDocuments.addDocument(document);
-                    addedDocuments.push(document.uri);
+            if(docFileDataPromise) {
+                const docFileData = await docFileDataPromise;
+                if (docFileData) {
+                    const document = documentFactory.fromString(docFileData.text, docFileData.uri);
+                    if (!langiumDocuments.hasDocument(document.uri)) {
+                        langiumDocuments.addDocument(document);
+                        addedDocuments.push(document.uri);
+                    }
+                } else {
+                    // log error?
+                    // console.debug(`Imported path ${importPath} can not be resolved. Skipped.`)
                 }
-            } else {
-                // log error?
-                // console.debug(`Imported path ${importPath} can not be resolved. Skipped.`)
             }
         }
         if (addedDocuments.length > 0) {

--- a/bbj-vscode/src/language/bbj-document-validator.ts
+++ b/bbj-vscode/src/language/bbj-document-validator.ts
@@ -11,7 +11,7 @@ export class BBjDocumentValidator extends DefaultDocumentValidator {
         return {
             message,
             range: getDiagnosticRange(info),
-            severity: info.code === DocumentValidator.LinkingError ? DiagnosticSeverity.Warning : toDiagnosticSeverity(severity),
+            severity: (info.data as any)?.code === DocumentValidator.LinkingError ? DiagnosticSeverity.Warning : toDiagnosticSeverity(severity),
             code: info.code,
             codeDescription: info.codeDescription,
             tags: info.tags,

--- a/bbj-vscode/src/language/bbj-hover.ts
+++ b/bbj-vscode/src/language/bbj-hover.ts
@@ -1,12 +1,12 @@
-import { AstNode, AstNodeHoverProvider, DocumentationProvider, LangiumServices, isJSDoc, parseJSDoc } from "langium";
+import { AstNode, DocumentationProvider, isJSDoc, parseJSDoc } from "langium";
+import { AstNodeHoverProvider, LangiumServices } from "langium/lsp";
 import { Hover } from "vscode-languageclient";
-import { MethodData, toMethodData } from "./bbj-nodedescription-provider";
-import { ClassMember, JavaMethod, isBBjClassMember, isBbjClass, isClass, isDocumented, isFieldDecl, isJavaClass, isJavaField, isJavaMethod, isLibEventType, isLibMember, isMethodDecl, isNamedElement } from "./generated/ast";
-import { JavadocProvider, MethodDoc, isMethodDoc } from "./java-javadoc";
-import { CommentProvider } from "langium/lib/documentation/comment-provider";
+import { MethodData, toMethodData } from "./bbj-nodedescription-provider.js";
+import { ClassMember, JavaMethod, isBBjClassMember, isBbjClass, isClass, isDocumented, isFieldDecl, isJavaClass, isJavaField, isJavaMethod, isLibEventType, isLibMember, isMethodDecl, isNamedElement } from "./generated/ast.js";
+import { JavadocProvider, MethodDoc, isMethodDoc } from "./java-javadoc.js";
+import { CommentProvider } from "langium";
 
 export class BBjHoverProvider extends AstNodeHoverProvider {
-
     protected readonly documentationProvider: DocumentationProvider;
     protected javadocProvider = JavadocProvider.getInstance();
     protected readonly commentProvider: CommentProvider;

--- a/bbj-vscode/src/language/bbj-index-manager.ts
+++ b/bbj-vscode/src/language/bbj-index-manager.ts
@@ -1,18 +1,17 @@
-import { AstNode, DefaultIndexManager, LangiumDocument, LangiumSharedServices, WorkspaceManager } from "langium";
-import { URI } from "vscode-uri";
-import { BBjWorkspaceManager } from "./bbj-ws-manager";
-import { JavaSyntheticDocUri } from "./java-interop";
+import { AstNode, DefaultIndexManager, LangiumDocument, LangiumSharedCoreServices, URI, WorkspaceManager } from "langium";
+import { BBjWorkspaceManager } from "./bbj-ws-manager.js";
+import { JavaSyntheticDocUri } from "./java-interop.js";
 
 export class BBjIndexManager extends DefaultIndexManager {
 
     wsManager: () => WorkspaceManager;
 
-    constructor(services: LangiumSharedServices) {
+    constructor(services: LangiumSharedCoreServices) {
         super(services);
         this.wsManager = () => services.workspace.WorkspaceManager;
     }
 
-    protected override isAffected(document: LangiumDocument<AstNode>, changed: URI): boolean {
+    public override isAffected(document: LangiumDocument<AstNode>, changedUris: Set<string>): boolean {
         if(document.uri.toString() === JavaSyntheticDocUri || document.uri.scheme === 'bbjlib') {
             // only affected by ClassPath changes
             return false;
@@ -24,12 +23,12 @@ export class BBjIndexManager extends DefaultIndexManager {
                 // don't rebuild external documents that has errors
                 return !isExternal
             }
-            if(!bbjWsManager.isExternalDocument(changed) && isExternal) {
+            if(![...changedUris].every(changed => bbjWsManager.isExternalDocument(URI.parse(changed))) && isExternal) {
                 // don't rebuild external documents if ws document changed
                 return false;
             }
         }
-        return super.isAffected(document, changed);
+        return super.isAffected(document, changedUris);
     }
 
 }

--- a/bbj-vscode/src/language/bbj-module.ts
+++ b/bbj-vscode/src/language/bbj-module.ts
@@ -5,31 +5,31 @@
  ******************************************************************************/
 
 import {
-    DeepPartial, DefaultSharedModuleContext,
+    DeepPartial,
     LangiumParser,
-    LangiumServices, LangiumSharedServices, Module, PartialLangiumServices,
-    createDefaultModule, createDefaultSharedModule,
+    Module,
     inject,
     prepareLangiumParser
 } from 'langium';
-import { BBjCommentProvider } from './bbj-comment-provider';
-import { BBjCompletionProvider } from './bbj-completion-provider';
-import { BBjDocumentBuilder } from './bbj-document-builder';
-import { BBjDocumentValidator } from './bbj-document-validator';
-import { BBjHoverProvider } from './bbj-hover';
-import { BBjIndexManager } from './bbj-index-manager';
-import { BbjLexer } from './bbj-lexer';
-import { BbjLinker } from './bbj-linker';
-import { BBjNodeKindProvider } from './bbj-node-kind';
-import { BBjAstNodeDescriptionProvider } from './bbj-nodedescription-provider';
-import { BbjNameProvider, BbjScopeProvider } from './bbj-scope';
-import { BbjScopeComputation } from './bbj-scope-local';
-import { BBjTokenBuilder } from './bbj-token-builder';
-import { BBjValidator, registerValidationChecks } from './bbj-validator';
-import { BBjValueConverter } from './bbj-value-converter';
-import { BBjWorkspaceManager } from './bbj-ws-manager';
-import { BBjGeneratedModule, BBjGeneratedSharedModule } from './generated/module';
-import { JavaInteropService } from './java-interop';
+import { LangiumSharedServices, LangiumServices, PartialLangiumServices, createDefaultSharedModule, createDefaultModule, DefaultSharedModuleContext } from 'langium/lsp';
+import { BBjCommentProvider } from './bbj-comment-provider.js';
+import { BBjCompletionProvider } from './bbj-completion-provider.js';
+import { BBjDocumentBuilder } from './bbj-document-builder.js';
+import { BBjDocumentValidator } from './bbj-document-validator.js';
+import { BBjHoverProvider } from './bbj-hover.js';
+import { BBjIndexManager } from './bbj-index-manager.js';
+import { BbjLexer } from './bbj-lexer.js';
+import { BbjLinker } from './bbj-linker.js';
+import { BBjNodeKindProvider } from './bbj-node-kind.js';
+import { BBjAstNodeDescriptionProvider } from './bbj-nodedescription-provider.js';
+import { BbjNameProvider, BbjScopeProvider } from './bbj-scope.js';
+import { BbjScopeComputation } from './bbj-scope-local.js';
+import { BBjTokenBuilder } from './bbj-token-builder.js';
+import { BBjValidator, registerValidationChecks } from './bbj-validator.js';
+import { BBjValueConverter } from './bbj-value-converter.js';
+import { BBjWorkspaceManager } from './bbj-ws-manager.js';
+import { BBjGeneratedModule, BBjGeneratedSharedModule } from './generated/module.js';
+import { JavaInteropService } from './java-interop.js';
 
 
 /**

--- a/bbj-vscode/src/language/bbj-node-kind.ts
+++ b/bbj-vscode/src/language/bbj-node-kind.ts
@@ -1,6 +1,7 @@
-import { AstNode, AstNodeDescription, NodeKindProvider, isAstNode } from "langium";
+import { AstNode, AstNodeDescription, isAstNode } from "langium";
+import { NodeKindProvider } from "langium/lsp";
 import { CompletionItemKind, SymbolKind } from "vscode-languageserver";
-import { ArrayDecl, BbjClass, JavaClass, JavaMethod, LibEventType, LibFunction, MethodDecl } from "./generated/ast";
+import { ArrayDecl, BbjClass, JavaClass, JavaMethod, LibEventType, LibFunction, MethodDecl } from "./generated/ast.js";
 
 
 export class BBjNodeKindProvider implements NodeKindProvider {

--- a/bbj-vscode/src/language/bbj-nodedescription-provider.ts
+++ b/bbj-vscode/src/language/bbj-nodedescription-provider.ts
@@ -1,12 +1,12 @@
-import { AstNode, AstNodeDescription, DefaultAstNodeDescriptionProvider, LangiumDocument, getDocument, isAstNodeDescription } from "langium";
-import { JavaMethod, LibEventType, LibFunction, MethodDecl } from "./generated/ast";
-import { documentationHeader } from "./bbj-hover";
+import { AstNode, AstNodeDescription, AstUtils, DefaultAstNodeDescriptionProvider, LangiumDocument, isAstNodeDescription } from "langium";
+import { JavaMethod, LibEventType, LibFunction, MethodDecl } from "./generated/ast.js";
+import { documentationHeader } from "./bbj-hover.js";
 
 
 
 export class BBjAstNodeDescriptionProvider extends DefaultAstNodeDescriptionProvider {
 
-    override createDescription(node: AstNode, name: string | undefined, document: LangiumDocument = getDocument(node)): AstNodeDescription {
+    override createDescription(node: AstNode, name: string | undefined, document: LangiumDocument = AstUtils.getDocument(node)): AstNodeDescription {
         const descr = super.createDescription(node, name, document);
         switch (node.$type) {
             case MethodDecl: return enhanceFunctionDescription(descr, toMethodData(node as MethodDecl))

--- a/bbj-vscode/src/language/bbj-scope.ts
+++ b/bbj-vscode/src/language/bbj-scope.ts
@@ -7,12 +7,13 @@
 import {
     AstNode, AstNodeDescription, AstNodeLocator, CstNode, DefaultNameProvider,
     DefaultScopeProvider,
-    EMPTY_SCOPE, EMPTY_STREAM, findNodeForProperty, getContainerOfType, getDocument, IndexManager, isAstNode,
+    EMPTY_SCOPE, EMPTY_STREAM, AstUtils, IndexManager, isAstNode,
     ReferenceInfo, Scope, Stream, stream,
-    StreamScope
+    StreamScope,
+    GrammarUtils
 } from 'langium';
-import { BBjServices } from './bbj-module';
-import { isJavaDocument } from './bbj-scope-local';
+import { BBjServices } from './bbj-module.js';
+import { isJavaDocument } from './bbj-scope-local.js';
 import {
     Assignment, BbjClass, Class,
     Expression,
@@ -31,8 +32,8 @@ import {
     LibEventType,
     LibMember, MethodDecl, NamedElement, Program,
     Statement, Use
-} from './generated/ast';
-import { JavaInteropService } from './java-interop';
+} from './generated/ast.js';
+import { JavaInteropService } from './java-interop.js';
 
 
 export class BbjScopeProvider extends DefaultScopeProvider {
@@ -52,7 +53,7 @@ export class BbjScopeProvider extends DefaultScopeProvider {
             || (context.property === 'resolvedReturnType' && isJavaMethod(context.container))
         ) {
             // Scope for JavaClass only
-            const doc = getDocument(context.container)
+            const doc = AstUtils.getDocument(context.container)
             const precomputed = doc.precomputedScopes
             if (precomputed) {
                 if (isJavaDocument(doc)) {
@@ -63,7 +64,7 @@ export class BbjScopeProvider extends DefaultScopeProvider {
                     console.warn(`JavaDocument without classesMapScope.`)
                 }
                 console.warn(`Resolving JavaMember from outside of JavaDocument.`)
-                const classPath = getContainerOfType(context.container, isClasspath);
+                const classPath = AstUtils.getContainerOfType(context.container, isClasspath);
                 if (classPath) {
                     const allDescriptions = precomputed.get(classPath);
                     return new StreamScope(stream(allDescriptions)) // don't filter as we only have classes as children
@@ -96,7 +97,7 @@ export class BbjScopeProvider extends DefaultScopeProvider {
             }
             return EMPTY_SCOPE
         } else if (isSymbolRef(context.container)) {
-            const bbjType = getContainerOfType(context.container, isBbjClass)
+            const bbjType = AstUtils.getContainerOfType(context.container, isBbjClass)
             var memberScope = EMPTY_STREAM;
             if (bbjType) {
                 if (context.container.instanceAccess) {
@@ -105,7 +106,7 @@ export class BbjScopeProvider extends DefaultScopeProvider {
             }
 
             const memberAndImports = new StreamScopeWithPredicate(
-                memberScope.concat(this.importedBBjClasses(getContainerOfType(context.container, isProgram))),
+                memberScope.concat(this.importedBBjClasses(AstUtils.getContainerOfType(context.container, isProgram))),
                 this.superGetScope(context)
             )
 
@@ -154,7 +155,7 @@ export class BbjScopeProvider extends DefaultScopeProvider {
         }
         switch (referenceType) {
             case Class: {
-                const program = getContainerOfType(_context.container, isProgram)
+                const program = AstUtils.getContainerOfType(_context.container, isProgram)
                 // when looking for classes return only JavaClasses. References are case sensitive
                 // Temporally add imported BBjClasses
                 return new StreamScopeWithPredicate(stream(this.importedBBjClasses(program)), new StreamScopeWithPredicate(this.indexManager.allElements(JavaClass)));
@@ -183,7 +184,7 @@ export class BbjScopeProvider extends DefaultScopeProvider {
     }
 
     createBBjClassMemberScope(bbjType: BbjClass, methodsOnly: boolean = false): StreamScope {
-        const document = getDocument(bbjType)
+        const document = AstUtils.getDocument(bbjType)
         const typeScope = document?.precomputedScopes?.get(bbjType)
         let descriptions: AstNodeDescription[] = []
         if (typeScope) {
@@ -200,7 +201,7 @@ export class BbjScopeProvider extends DefaultScopeProvider {
             // handle implicit extends java.lang.Object
             const javaObject = this.javaInterop.getResolvedClass('java.lang.Object');
             if (javaObject) {
-                return this.createCaseSensitiveScope(descriptions, this.createScopeForNodes(stream(javaObject.fields).concat(javaObject.methods)))
+                return this.createCaseSensitiveScope(descriptions, this.createScopeForNodes(stream(javaObject.fields as any[]).concat(javaObject.methods as any[])))
             }
         }
         return this.createCaseSensitiveScope(descriptions)
@@ -288,11 +289,11 @@ export class BbjNameProvider extends DefaultNameProvider {
     static called = new Map<string | undefined, number>
 
     override getNameNode(node: AstNode): CstNode | undefined {
-        if (!getDocument(node)) {
+        if (!AstUtils.getDocument(node)) {
             // synthetic nodes
             return undefined
         }
-        return findNodeForProperty(node.$cstNode, 'name');
+        return GrammarUtils.findNodeForProperty(node.$cstNode, 'name');
     }
 }
 

--- a/bbj-vscode/src/language/bbj-validator.ts
+++ b/bbj-vscode/src/language/bbj-validator.ts
@@ -4,12 +4,12 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstNode, CompositeCstNode, CstNode, LeafCstNode, Properties, RootCstNode, ValidationAcceptor, ValidationChecks, findNodesForKeyword, getContainerOfType, getDocument, isCompositeCstNode, isLeafCstNode } from 'langium';
+import { AstNode, AstUtils, CompositeCstNode, CstNode, GrammarUtils, LeafCstNode, Properties, RootCstNode, ValidationAcceptor, ValidationChecks, isCompositeCstNode, isLeafCstNode } from 'langium';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Range } from 'vscode-languageserver-types';
-import type { BBjServices } from './bbj-module';
-import { BBjAstType, CommentStatement, DefFunction, EraseStatement, InitFileStatement, KeyedFileStatement, OpenStatement, Option, Use, isArrayDeclarationStatement, isBbjClass, isCommentStatement, isCompoundStatement, isElseStatement, isFieldDecl, isForStatement, isIfEndStatement, isIfStatement, isKeywordStatement, isLabelDecl, isLetStatement, isLibMember, isMethodDecl, isOption, isParameterDecl, isStatement } from './generated/ast';
-import { JavaInteropService } from './java-interop';
+import type { BBjServices } from './bbj-module.js';
+import { BBjAstType, CommentStatement, DefFunction, EraseStatement, InitFileStatement, KeyedFileStatement, OpenStatement, Option, Use, isArrayDeclarationStatement, isBbjClass, isCommentStatement, isCompoundStatement, isElseStatement, isFieldDecl, isForStatement, isIfEndStatement, isIfStatement, isKeywordStatement, isLabelDecl, isLetStatement, isLibMember, isMethodDecl, isOption, isParameterDecl, isStatement } from './generated/ast.js';
+import { JavaInteropService } from './java-interop.js';
 
 /**
  * Register custom validation checks.
@@ -87,7 +87,7 @@ export class BBjValidator {
                 || isLetStatement(node.$container)
                 || isForStatement(node.$container)
                 || isArrayDeclarationStatement(node.$container)
-                || getContainerOfType(previous, isIfStatement)) {
+                || AstUtils.getContainerOfType(previous, isIfStatement)) {
                 return false;
             }
             return true;
@@ -105,7 +105,7 @@ export class BBjValidator {
     }
 
     checkCommentNewLines(node: CommentStatement, accept: ValidationAcceptor): void {
-        const document = getDocument(node);
+        const document = AstUtils.getDocument(node);
         if (document.parseResult.parserErrors.length > 0 || isLabelDecl(this.getPreviousNode(node))) {
             return;
         }
@@ -127,7 +127,7 @@ export class BBjValidator {
     }
 
     checkLinebreaks(node: AstNode, accept: ValidationAcceptor): void {
-        const document = getDocument(node);
+        const document = AstUtils.getDocument(node);
         if (document.parseResult.parserErrors.length > 0) {
             return;
         }
@@ -176,7 +176,7 @@ export class BBjValidator {
         if (Array.isArray(features)) {
             const nodes: CstNode[] = [];
             for (const feature of features) {
-                nodes.push(...findNodesForKeyword(node, feature));
+                nodes.push(...GrammarUtils.findNodesForKeyword(node, feature));
             }
             return nodes;
         } else {

--- a/bbj-vscode/src/language/bbj-value-converter.ts
+++ b/bbj-vscode/src/language/bbj-value-converter.ts
@@ -4,12 +4,11 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CstNode, DefaultValueConverter, ValueType } from "langium";
-import { AbstractRule } from "langium/lib/grammar/generated/ast";
+import { CstNode, DefaultValueConverter, GrammarAST, ValueType } from "langium";
 
 export class BBjValueConverter extends DefaultValueConverter {
 
-    protected override runConverter(rule: AbstractRule, input: string, cstNode: CstNode): ValueType {
+    protected override runConverter(rule: GrammarAST.AbstractRule, input: string, cstNode: CstNode): ValueType {
         switch (rule.name.toUpperCase()) {
             case 'BBJFILEPATH': return input.replaceAll('::', '');
             case 'ID': return input.charAt(input.length - 1) === '@' ? input.slice(0, -1) : input;

--- a/bbj-vscode/src/language/bbj-ws-manager.ts
+++ b/bbj-vscode/src/language/bbj-ws-manager.ts
@@ -1,20 +1,21 @@
-import { AstNode, DefaultWorkspaceManager, LangiumDocument, LangiumDocumentFactory, LangiumSharedServices } from "langium";
+import { AstNode, DefaultWorkspaceManager, LangiumDocument, LangiumDocumentFactory,  } from "langium";
+import { LangiumSharedServices } from "langium/lsp";
 import { KeyValuePairObject, getProperties } from 'properties-file';
 import { CancellationToken, WorkspaceFolder } from 'vscode-languageserver';
 import { URI } from "vscode-uri";
-import { BBjServices } from "./bbj-module";
-import { JavaInteropService } from "./java-interop";
-import { JavadocProvider } from "./java-javadoc";
-import { builtinFunctions } from "./lib/functions";
-import { builtinSymbolicLabels } from "./lib/labels";
-import { builtinVariables } from "./lib/variables";
+import { BBjServices } from "./bbj-module.js";
+import { JavaInteropService } from "./java-interop.js";
+import { JavadocProvider } from "./java-javadoc.js";
+import { builtinFunctions } from "./lib/functions.js";
+import { builtinSymbolicLabels } from "./lib/labels.js";
+import { builtinVariables } from "./lib/variables.js";
 
 // TODO extend the FileSystemAccess or add an additional service
 // to not use 'fs' and 'os' here 
 // import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { builtinEvents } from "./lib/events";
+import { builtinEvents } from "./lib/events.js";
 
 export class BBjWorkspaceManager extends DefaultWorkspaceManager {
 
@@ -40,14 +41,14 @@ export class BBjWorkspaceManager extends DefaultWorkspaceManager {
             const confFile = content.find(file => file.isFile && file.uri.path.endsWith("project.properties"));
             let propcontents = "";
             if (confFile) {
-                propcontents = this.fileSystemProvider.readFileSync(confFile.uri);
+                propcontents = await this.fileSystemProvider.readFile(confFile.uri);
             }
             let prefixfromconfig;
             if (this.bbjdir) {
                 const bbjcfgdir = await this.fileSystemProvider.readDirectory(URI.parse(this.bbjdir + "/cfg/"));
                 const configbbx = bbjcfgdir.find(file => file.isFile && file.uri.path.endsWith("config.bbx"));
                 if (configbbx) {
-                    prefixfromconfig = this.fileSystemProvider.readFileSync(configbbx.uri).split('\n').find(line => line.startsWith("PREFIX"))?.substring(7) || "";
+                    prefixfromconfig = (await this.fileSystemProvider.readFile(configbbx.uri)).split('\n').find(line => line.startsWith("PREFIX"))?.substring(7) || "";
                 }
             } else {
                 console.warn("No bbjdir set. No classpath and prefixes loaded.")

--- a/bbj-vscode/src/language/java-interop.ts
+++ b/bbj-vscode/src/language/java-interop.ts
@@ -4,14 +4,14 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { LangiumDocument, LangiumDocuments, linkContentToContainer, Mutable } from 'langium';
+import { AstUtils, LangiumDocument, LangiumDocuments, Mutable } from 'langium';
 import { Socket } from 'net';
 import {
     CancellationToken, createMessageConnection, MessageConnection, RequestType, SocketMessageReader, SocketMessageWriter
-} from 'vscode-jsonrpc/node';
+} from 'vscode-jsonrpc/node.js';
 import { URI } from 'vscode-uri';
-import { BBjServices } from './bbj-module';
-import { Classpath, JavaClass, JavaField, JavaMethod, JavaMethodParameter } from './generated/ast';
+import { BBjServices } from './bbj-module.js';
+import { Classpath, JavaClass, JavaField, JavaMethod, JavaMethodParameter } from './generated/ast.js';
 
 const DEFAULT_PORT = 5008;
 
@@ -153,13 +153,13 @@ export class JavaInteropService {
                         $refText: parameter.type
                     };
                 }
-                linkContentToContainer(method);
+                AstUtils.linkContentToContainer(method);
             }
         } catch (e) {
             // finish linking of the class even if it has an error
             console.error(e)
         }
-        linkContentToContainer(javaClass);
+        AstUtils.linkContentToContainer(javaClass);
 
         javaClass.$type = JavaClass;
         javaClass.$container = classpath;

--- a/bbj-vscode/src/language/java-javadoc.ts
+++ b/bbj-vscode/src/language/java-javadoc.ts
@@ -7,7 +7,7 @@
 import { EmptyFileSystemProvider, FileSystemNode, FileSystemProvider } from "langium";
 import { CancellationToken } from "vscode-jsonrpc";
 import { URI } from "vscode-uri";
-import { Documented, JavaClass, NamedElement, isJavaClass, isJavaMember } from "./generated/ast";
+import { Documented, JavaClass, NamedElement, isJavaClass, isJavaMember } from "./generated/ast.js";
 
 /**
  * Provides Javadoc information for internal binary classes.

--- a/bbj-vscode/src/language/lib/fs-provider.ts
+++ b/bbj-vscode/src/language/lib/fs-provider.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
-import { builtinFunctions } from './functions';
-import { builtinVariables } from './variables';
-import { builtinSymbolicLabels } from './labels';
-import { builtinEvents } from './events';
+import { builtinFunctions } from './functions.js';
+import { builtinVariables } from './variables.js';
+import { builtinSymbolicLabels } from './labels.js';
+import { builtinEvents } from './events.js';
 
 export class BBjLibraryFileSystemProvider implements vscode.FileSystemProvider {
 

--- a/bbj-vscode/src/language/main.ts
+++ b/bbj-vscode/src/language/main.ts
@@ -4,10 +4,10 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { startLanguageServer } from 'langium';
+import { startLanguageServer } from 'langium/lsp';
 import { NodeFileSystem } from 'langium/node';
-import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
-import { createBBjServices } from './bbj-module';
+import { createConnection, ProposedFeatures } from 'vscode-languageserver/node.js';
+import { createBBjServices } from './bbj-module.js';
 
 // Create a connection to the client
 const connection = createConnection(ProposedFeatures.all);

--- a/bbj-vscode/test/bbj-test-module.ts
+++ b/bbj-vscode/test/bbj-test-module.ts
@@ -1,9 +1,10 @@
-import { DeepPartial, DefaultSharedModuleContext, IndexManager, LangiumSharedServices, Module, PartialLangiumServices, createDefaultModule, createDefaultSharedModule, inject } from "langium";
-import { BBjAddedServices, BBjModule, BBjServices, BBjSharedModule } from "../src/language/bbj-module";
-import { BBjGeneratedModule, BBjGeneratedSharedModule } from "../src/language/generated/module";
-import { registerValidationChecks } from "../src/language/bbj-validator";
-import { JavaInteropService } from "../src/language/java-interop";
-import { Classpath, JavaClass, JavaMethod } from "../src/language/generated/ast";
+import { DeepPartial, IndexManager, Module, inject } from "langium";
+import { PartialLangiumServices, createDefaultModule, createDefaultSharedModule, LangiumSharedServices, DefaultSharedModuleContext } from "langium/lsp";
+import { BBjAddedServices, BBjModule, BBjServices, BBjSharedModule } from "../src/language/bbj-module.js";
+import { BBjGeneratedModule, BBjGeneratedSharedModule } from "../src/language/generated/module.js";
+import { registerValidationChecks } from "../src/language/bbj-validator.js";
+import { JavaInteropService } from "../src/language/java-interop.js";
+import { JavaClass, JavaMethod } from "../src/language/generated/ast.js";
 
 export function createBBjTestServices(context: DefaultSharedModuleContext): {
     shared: LangiumSharedServices,

--- a/bbj-vscode/test/comment-provider.test.ts
+++ b/bbj-vscode/test/comment-provider.test.ts
@@ -1,9 +1,8 @@
-import { AstNode, EmptyFileSystem, LangiumDocument } from 'langium';
+import { EmptyFileSystem } from 'langium';
 import { parseHelper } from 'langium/test';
-import { streamAst } from 'langium';
 import { describe, expect, test } from 'vitest';
-import { createBBjServices } from '../src/language/bbj-module';
-import { CompoundStatement, LetStatement, Library, Model, PrintStatement, Program, ReadStatement, StringLiteral, SymbolRef, isAddrStatement, isBbjClass, isCallStatement, isClipFromStrStatement, isCloseStatement, isCommentStatement, isCompoundStatement, isExitWithNumberStatement, isGotoStatement, isLetStatement, isLibrary, isPrintStatement, isProgram, isRedimStatement, isRunStatement, isSqlCloseStatement, isSqlPrepStatement, isSwitchCase, isSwitchStatement, isWaitStatement } from '../src/language/generated/ast';
+import { createBBjServices } from '../src/language/bbj-module.js';
+import { Model, Program, isBbjClass } from '../src/language/generated/ast.js';
 
 
 const services = createBBjServices(EmptyFileSystem);

--- a/bbj-vscode/test/example-files.test.ts
+++ b/bbj-vscode/test/example-files.test.ts
@@ -3,8 +3,8 @@ import { parseHelper } from 'langium/test';
 import path from 'path';
 import fs from 'fs';
 import { describe, expect, test } from 'vitest';
-import { createBBjServices } from '../src/language/bbj-module';
-import { Model } from '../src/language/generated/ast';
+import { createBBjServices } from '../src/language/bbj-module.js';
+import { Model } from '../src/language/generated/ast.js';
 
 const services = createBBjServices(EmptyFileSystem);
 

--- a/bbj-vscode/test/javadoc.test.ts
+++ b/bbj-vscode/test/javadoc.test.ts
@@ -3,13 +3,13 @@ import fs from 'fs/promises';
 import path from 'path';
 import { describe, expect, test, vi } from 'vitest';
 import { URI } from 'vscode-uri';
-import { JavadocProvider, PackageDoc } from '../src/language/java-javadoc';
+import { JavadocProvider, PackageDoc } from '../src/language/java-javadoc.js';
 
 class JavadocProviderUnderTest extends JavadocProvider {
     constructor() {
         super();
     }
-    async loadJavadocFile(packageName: string, packageDocURI: URI): Promise<PackageDoc | null> {
+    override async loadJavadocFile(packageName: string, packageDocURI: URI): Promise<PackageDoc | null> {
         return super.loadJavadocFile(packageName, packageDocURI);
     }
 }
@@ -28,7 +28,7 @@ describe('Javadoc tests', () => {
         vi.spyOn(console, 'error').mockImplementation(() => { });
         try {
             const javadocProvider = new class extends JavadocProviderUnderTest {
-                protected readFile(packageDocURI: URI): Promise<string> {
+                protected override readFile(packageDocURI: URI): Promise<string> {
                     return Promise.resolve('{"name":"wrong.package.name"}');
                 }
             }
@@ -46,7 +46,7 @@ describe('Javadoc tests', () => {
         vi.spyOn(console, 'error').mockImplementation(() => { });
         try {
             const javadocProvider = new class extends JavadocProviderUnderTest {
-                protected readFile(packageDocURI: URI): Promise<string> {
+                protected override readFile(packageDocURI: URI): Promise<string> {
                     return Promise.resolve('{"name":"wrong.package.name"}');
                 }
             }
@@ -60,7 +60,7 @@ describe('Javadoc tests', () => {
 
     test('Check package documentation loaded.', async () => {
         const javadocProvider = new class extends JavadocProviderUnderTest {
-            protected async readFile(packageDocURI: URI): Promise<string> {
+            protected override async readFile(packageDocURI: URI): Promise<string> {
                 const filePath = path.resolve(__dirname, '../test/test-data/com.basis.util.json');
                 return await fs.readFile(filePath, 'utf8');
             }

--- a/bbj-vscode/test/lexer.test.ts
+++ b/bbj-vscode/test/lexer.test.ts
@@ -1,5 +1,6 @@
-import { EmptyFileSystem, expandToString } from "langium";
-import { createBBjTestServices } from "./bbj-test-module";
+import { EmptyFileSystem } from "langium";
+import { expandToString } from "langium/generate";
+import { createBBjTestServices } from "./bbj-test-module.js";
 import { describe, test, expect } from "vitest";
 
 const services = createBBjTestServices(EmptyFileSystem);

--- a/bbj-vscode/test/linking.test.ts
+++ b/bbj-vscode/test/linking.test.ts
@@ -2,18 +2,18 @@ import { DocumentValidator, EmptyFileSystem, LangiumDocument } from 'langium';
 import { parseHelper } from 'langium/test';
 import { describe, expect, test } from 'vitest';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
-import { createBBjTestServices } from './bbj-test-module';
-import { Model } from '../src/language/generated/ast';
-import { initializeWorkspace } from './test-helper';
+import { createBBjTestServices } from './bbj-test-module.js';
+import { Model } from '../src/language/generated/ast.js';
+import { initializeWorkspace } from './test-helper.js';
 
 const services = createBBjTestServices(EmptyFileSystem);
-const validate = (content: string) => parseHelper<Model>(services.BBj)(content, {validationChecks: 'all'});
+const validate = (content: string) => parseHelper<Model>(services.BBj)(content, {validation: true});
 
 describe('Linking Tests', async () => {
     await initializeWorkspace(services.shared);
 
     function findLinkingErrors(document: LangiumDocument): Diagnostic[] {
-        return document.diagnostics?.filter(err => err.code === DocumentValidator.LinkingError)??[]
+        return document.diagnostics?.filter(err => err.data?.code === DocumentValidator.LinkingError)??[]
     }
 
     function expectNoErrors(document: LangiumDocument) {

--- a/bbj-vscode/test/test-helper.ts
+++ b/bbj-vscode/test/test-helper.ts
@@ -1,4 +1,5 @@
-import { AstNode, LangiumDocument, LangiumSharedServices, streamAllContents, streamContents } from "langium";
+import { AstNode, AstUtils, LangiumDocument } from "langium";
+import { LangiumSharedServices } from "langium/lsp";
 
 /**
  * Load libraries.
@@ -9,11 +10,11 @@ export async function initializeWorkspace(shared: LangiumSharedServices) {
 }
 
 export function findFirst<T extends AstNode = AstNode>(document: LangiumDocument, filter: (item: unknown) => item is T, streamAll: boolean = false): T | undefined {
-    return (streamAll ? streamAllContents(document.parseResult.value) : streamContents(document.parseResult.value)).find(filter);
+    return (streamAll ? AstUtils.streamAllContents(document.parseResult.value) : AstUtils.streamContents(document.parseResult.value)).find(filter);
 }
 
 export function findByIndex<T extends AstNode = AstNode>(document: LangiumDocument, filter: (item: unknown) => item is T, index: number): T | undefined {
-    const matches = streamContents(document.parseResult.value).filter(filter).toArray();
+    const matches = AstUtils.streamContents(document.parseResult.value).filter(filter).toArray();
     if (index < 0 || index >= matches.length) {
         return undefined;
     }

--- a/bbj-vscode/test/utils.test.ts
+++ b/bbj-vscode/test/utils.test.ts
@@ -1,7 +1,7 @@
 
 import os from 'os';
 import { describe, expect, test } from 'vitest';
-import { parseSettings } from '../src/language/bbj-ws-manager';
+import { parseSettings } from '../src/language/bbj-ws-manager.js';
 
 const exampleInput = `
 classpath=~/git/bbj-language-server/examples/lib/com.google.guava_30.1.0.v20221112-0806.jar:~/someOtherPath.jar:~/someOtherPath2.jar

--- a/bbj-vscode/test/validation.test.ts
+++ b/bbj-vscode/test/validation.test.ts
@@ -8,9 +8,9 @@ import { EmptyFileSystem } from 'langium';
 import { describe, expect, test } from 'vitest';
 
 import { expectError, expectNoIssues, validationHelper } from 'langium/test';
-import { createBBjServices } from '../src/language/bbj-module';
-import { Program, isBinaryExpression, isEraseStatement, isInitFileStatement, isKeyedFileStatement, isKeywordStatement } from '../src/language/generated/ast';
-import { findByIndex, findFirst, initializeWorkspace } from './test-helper';
+import { createBBjServices } from '../src/language/bbj-module.js';
+import { Program, isBinaryExpression, isEraseStatement, isInitFileStatement, isKeyedFileStatement, isKeywordStatement } from '../src/language/generated/ast.js';
+import { findByIndex, findFirst, initializeWorkspace } from './test-helper.js';
 
 const services = createBBjServices(EmptyFileSystem);
 const validate = validationHelper<Program>(services.BBj);
@@ -94,7 +94,7 @@ describe('BBj validation', async () => {
         `);
         // only the parse error should be reported, not the "This line needs to be wrapped by line breaks."
         expect(validationResult.diagnostics).toHaveLength(1);
-        expect(validationResult.diagnostics[0].code).toBe('parsing-error');
+        expect(validationResult.diagnostics[0].data.code).toBe('parsing-error');
     });
     /* FIXME
     test('No newline line validation after :', async () => {

--- a/bbj-vscode/tsconfig.json
+++ b/bbj-vscode/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES6",
-    "module": "commonjs",
+    "module": "Node16",
     "lib": ["ESNext"],
     "noEmit": true,
     "strict": true,
     "noUnusedLocals": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Node16",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "bbj-language-server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Upgraded Langium & Langium CLI & dependencies
- VS Code & LSP related dependencies

Upgraded module type to ESM
- added .js suffix to imports
- adapt tsconfig and package.json

Adapt to breaking changes:
- using the proper Langium exports
- filtering of cross-references has changed
- several function signatures changed