### PR TITLE
Show parameter names loaded from Javadoc in CA #142

### DIFF
--- a/bbj-vscode/src/language/bbj-completion-provider.ts
+++ b/bbj-vscode/src/language/bbj-completion-provider.ts
@@ -17,7 +17,7 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
         if (isFunctionNodeDescription(nodeDescription)) {
 
             const label = (paramAdjust: ((param: string, index: number) => string) = (p, i) => p) =>
-                `${nodeDescription.name}(${nodeDescription.parameters.filter(p => !p.optional).map((p, idx) => paramAdjust(p.name, idx)).join(', ')})`
+                `${nodeDescription.name}(${nodeDescription.parameters.filter(p => !p.optional).map((p, idx) => paramAdjust(p.realName ?? p.name, idx)).join(', ')})`
 
             const retType = ': ' + toSimpleName(nodeDescription.returnType)
             // TODO load param names for java methods from Javadoc

--- a/bbj-vscode/src/language/bbj-document-builder.ts
+++ b/bbj-vscode/src/language/bbj-document-builder.ts
@@ -80,9 +80,6 @@ export class BBjDocumentBuilder extends DefaultDocumentBuilder {
                     langiumDocuments.addDocument(document);
                     addedDocuments.push(document.uri);
                 }
-            } else {
-                // log error?
-                // console.debug(`Imported path ${importPath} can not be resolved. Skipped.`)
             }
         }
         if (addedDocuments.length > 0) {

--- a/bbj-vscode/src/language/bbj-hover.ts
+++ b/bbj-vscode/src/language/bbj-hover.ts
@@ -135,7 +135,7 @@ function ownerClass(member: ClassMember): string {
 }
 
 export function methodSignature(nodeDescription: MethodData, typeAdjust: ((type: string) => string) = (t) => t ?? '') {
-    return `${nodeDescription.name}(${nodeDescription.parameters.map(p => `${typeAdjust(p.type)} ${p.name}${p.optional ? '?' : ''}`).join(', ')})`
+    return `${nodeDescription.name}(${nodeDescription.parameters.map(p => `${typeAdjust(p.type)} ${p.realName ?? p.name}${p.optional ? '?' : ''}`).join(', ')})`
 }
 
 function toMethodDocToMethodData(methodDoc: MethodDoc, node: JavaMethod): MethodData {

--- a/bbj-vscode/src/language/bbj-nodedescription-provider.ts
+++ b/bbj-vscode/src/language/bbj-nodedescription-provider.ts
@@ -46,4 +46,9 @@ export type MethodData = {
     returnType: string
 }
 
-export type ParameterData = { name: string, type: string, optional?: boolean }
+export type ParameterData = {
+    name: string
+    type: string
+    optional?: boolean
+    realName?: string
+}

--- a/bbj-vscode/src/language/java-javadoc.ts
+++ b/bbj-vscode/src/language/java-javadoc.ts
@@ -175,3 +175,8 @@ export type MethodDoc = NamedDoc & {
 export function isMethodDoc(item: NamedDoc | undefined): item is MethodDoc {
     return item !== undefined && (item as any).params !== undefined;
 }
+
+
+export function isClassDoc(item: NamedDoc | undefined): item is ClassDoc {
+    return item !== undefined && (item as any).methods !== undefined && (item as any).fields !== undefined;
+}

--- a/bbj-vscode/src/language/java-types.langium
+++ b/bbj-vscode/src/language/java-types.langium
@@ -46,6 +46,9 @@ interface JavaMethod extends NamedElement, Documented {
 interface JavaMethodParameter {
     name: string
     type: string
-
     resolvedType?: @JavaClass
+    /**
+     * In case of synthetic `arg` name the real name from the Javadoc if any.
+     */
+    realName: string
 }


### PR DESCRIPTION
Testplan:

Start content assist at `BBjAPI.openSysGui`

You should see completion item with a proper parameter name `openSysGui(p_alias)`  not the synthetic parameter name like `openSysGui(arg0)`

See #142 