### PR TITLE
Fix problems with START and NEXT

### DIFF
--- a/bbj-vscode/src/language/bbj-token-builder.ts
+++ b/bbj-vscode/src/language/bbj-token-builder.ts
@@ -5,8 +5,10 @@ export class BBjTokenBuilder extends DefaultTokenBuilder {
 
     override buildTokens(grammar: GrammarAST.Grammar, options?: TokenBuilderOptions | undefined): TokenVocabulary {
         const tokens = super.buildTokens(grammar, options) as TokenType[];
+        this.spliceToken(tokens, 'START_BREAK', 1);
         this.spliceToken(tokens, 'FNEND', 1);
-        this.spliceToken(tokens, 'NEXT_TOKEN', 1);
+        this.spliceToken(tokens, 'NEXT_BREAK', 1);
+        this.spliceToken(tokens, 'NEXT_ID', 1);
         this.spliceToken(tokens, 'METHODRET_END', 1);
         this.spliceToken(tokens, 'ENDLINE_PRINT_COMMA', 1);
         this.spliceToken(tokens, 'DELETE_STANDALONE', 1);
@@ -21,17 +23,31 @@ export class BBjTokenBuilder extends DefaultTokenBuilder {
     }
 
     protected override buildTerminalToken(terminal: GrammarAST.TerminalRule): TokenType {
-        if (terminal.name === 'FNEND') {
+        if (terminal.name === 'START_BREAK') {
+            const token: TokenType = {
+                name: terminal.name,
+                PATTERN: this.regexPatternFunction(/START[ \t]*(?=(;|\r?\n))/i),
+                LINE_BREAKS: false
+            };
+            return token;
+        } else if (terminal.name === 'FNEND') {
             const token: TokenType = {
                 name: terminal.name,
                 PATTERN: this.regexPatternFunction(/FNEND[ \t]*(?=(;|\r?\n))/i),
                 LINE_BREAKS: false
             };
             return token;
-        } else if (terminal.name === 'NEXT_TOKEN') {
+        } else if (terminal.name === 'NEXT_BREAK') {
             const token: TokenType = {
                 name: terminal.name,
-                PATTERN: this.regexPatternFunction(/(?<=\r?\n[ \t]*)next(?=[ \t]*([_a-zA-Z][\w_]*(!|\$|%)?)?\r?\n)/i),
+                PATTERN: this.regexPatternFunction(/(?<=\r?\n[ \t]*)next(?=[ \t]*(\r?\n))/i),
+                LINE_BREAKS: false
+            };
+            return token;
+        } else if (terminal.name === 'NEXT_ID') {
+            const token: TokenType = {
+                name: terminal.name,
+                PATTERN: this.regexPatternFunction(/(?<=\r?\n[ \t]*)next(?=[ \t]*([_a-zA-Z][\w_]*(!|\$|%)?)\r?\n)/i),
                 LINE_BREAKS: false
             };
             return token;

--- a/bbj-vscode/src/language/bbj.langium
+++ b/bbj-vscode/src/language/bbj.langium
@@ -146,7 +146,8 @@ SqlRollbackStatement:
     ;
 
 StartStatement:
-    'START' (int1=Expression (',' int2=Expression)? Err? (',' fileid=Expression)?)?
+    START_BREAK
+    | 'START' int1=Expression (',' int2=Expression)? Err? (',' fileid=Expression)?
     ;
 
 LockStatement:
@@ -376,7 +377,8 @@ UntilStatement:
 ;
 
 NextStatement:
-    NEXT_TOKEN (variable=[VariableDecl:FeatureName])?
+    NEXT_BREAK
+    | NEXT_ID variable=[VariableDecl:FeatureName]
 ;
 
 IfStatement:
@@ -782,7 +784,7 @@ EscapeId returns string:
     | 'TBL' | 'TIM' | 'BEGIN' | 'CLEAR' | 'ESCAPE' | 'DROP' | 'ENTER' | 'SETOPTS' | 'PRECISION' | 'RELEASE' | 'RENAME' | 'TO'
     | 'MKDIR' | 'RMDIR' | 'CHDIR' | 'EXECUTE' | 'KEY' | 'IND' | 'DIR' | 'ISZ' | 'DEF' | 'STOP' | 'RESET' | 'RETRY'
     | 'BACKGROUND' | 'DELETE' | 'LOCK' | 'UNLOCK' | 'DIM' | 'SQLCOMMIT' | 'SQLROLLBACK' | 'SQLEXEC' | 'SQLCLOSE' | 'START' | 'DOM' | 'CHANOPT'
-    | 'FILEOPT' | 'REMOVE'
+    | 'FILEOPT'
 ;
 
 // BBx Library
@@ -829,9 +831,11 @@ terminal COMMENT: /([rR][eE][mM])([ \t][^\n\r]*)?[\n\r]+/; // (rEm)(space or tab
 terminal DELETE_STANDALONE: /_DELETE_STANDALONE/;
 terminal PRINT_STANDALONE_NL: /_PRINT_STANDALONE_NL/;
 terminal ENDLINE_PRINT_COMMA: /_endline_print_comma/;
-terminal NEXT_TOKEN: /_next/;
+terminal NEXT_BREAK: /_next1/;
+terminal NEXT_ID: /_next2/;
 terminal METHODRET_END: /_methodret_end/;
 terminal FNEND: /_fn_end/;
+terminal START_BREAK: /_start/;
 
 terminal BBjFilePath: /::.*::/;
 

--- a/bbj-vscode/src/language/bbj.langium
+++ b/bbj-vscode/src/language/bbj.langium
@@ -784,7 +784,7 @@ EscapeId returns string:
     | 'TBL' | 'TIM' | 'BEGIN' | 'CLEAR' | 'ESCAPE' | 'DROP' | 'ENTER' | 'SETOPTS' | 'PRECISION' | 'RELEASE' | 'RENAME' | 'TO'
     | 'MKDIR' | 'RMDIR' | 'CHDIR' | 'EXECUTE' | 'KEY' | 'IND' | 'DIR' | 'ISZ' | 'DEF' | 'STOP' | 'RESET' | 'RETRY'
     | 'BACKGROUND' | 'DELETE' | 'LOCK' | 'UNLOCK' | 'DIM' | 'SQLCOMMIT' | 'SQLROLLBACK' | 'SQLEXEC' | 'SQLCLOSE' | 'START' | 'DOM' | 'CHANOPT'
-    | 'FILEOPT'
+    | 'FILEOPT' | 'REMOVE'
 ;
 
 // BBx Library

--- a/examples/next.bbj
+++ b/examples/next.bbj
@@ -1,0 +1,10 @@
+e$="hallo"
+
+next
+
+next e$
+
+next
+
+class XYZ
+classend

--- a/examples/start.bbj
+++ b/examples/start.bbj
@@ -8,3 +8,10 @@
     START 123,456,err=labelError,"file.bbx"
     START 123,err=labelError,"file.bbx"
 labelError:
+    REM these 3 compound statements should be allowed only
+    IF 1 THEN
+    START ; ELSE ; REM TODO
+    START ; FI   ; REM TODO
+    START        ; REM works
+    REM and any compound statement else should not
+    START ; START ; START 255 ; START


### PR DESCRIPTION
I made the two fixes. SQLEXEC still does not work, I fear the change needs to be bigger (having a right parenthesis with a break or without, which affects also other occurrences. So it is not so easy here...)  

```basic
    SQLOPEN(1,MODE="AUTO_COMMIT=OFF")"MyData"
    SQLPREP(1)"INSERT INTO mytable VALUES ('10', 'Sample Record')"
    SQLEXEC(1)             ; REM still makes trouble
    SQLCOMMIT(1,err=labelError)
    SQLCLOSE(1)
labelError:
```