### PR TITLE
Improve performance by removing EscapeId rule

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
                 "${workspaceFolder}/examples"
             ],
             "env": {
-                // "DEBUG_BREAK": "true"
+                "DEBUG_BREAK": "false"
             },
             "outFiles": [
                 "${workspaceFolder}/bbj-vscode/out/*.(m|c|)js",

--- a/bbj-vscode/package-lock.json
+++ b/bbj-vscode/package-lock.json
@@ -9,8 +9,8 @@
             "version": "0.0.34-SNAPSHOT",
             "license": "MIT",
             "dependencies": {
-                "chevrotain": "^10.4.2",
-                "langium": "^3.2.0",
+                "chevrotain": "^11.0.3",
+                "langium": "~3.2.0",
                 "properties-file": "~3.2.5",
                 "properties-reader": "^2.2.0",
                 "vscode-jsonrpc": "^8.2.1",
@@ -56,22 +56,24 @@
             }
         },
         "node_modules/@chevrotain/cst-dts-gen": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.4.2.tgz",
-            "integrity": "sha512-0+4bNjlndNWMoVLH/+y4uHnf6GrTipsC+YTppJxelVJo+xeRVQ0s2PpkdDCVTsu7efyj+8r1gFiwVXsp6JZ0iQ==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+            "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@chevrotain/gast": "10.4.2",
-                "@chevrotain/types": "10.4.2",
-                "lodash": "4.17.21"
+                "@chevrotain/gast": "11.0.3",
+                "@chevrotain/types": "11.0.3",
+                "lodash-es": "4.17.21"
             }
         },
         "node_modules/@chevrotain/gast": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.4.2.tgz",
-            "integrity": "sha512-4ZAn8/mjkmYonilSJ60gGj1tAF0cVWYUMlIGA0e4ATAc3a648aCnvpBw7zlPHDQjFp50XC13iyWEgWAKiRKTOA==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+            "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@chevrotain/types": "10.4.2",
-                "lodash": "4.17.21"
+                "@chevrotain/types": "11.0.3",
+                "lodash-es": "4.17.21"
             }
         },
         "node_modules/@chevrotain/regexp-to-ast": {
@@ -80,14 +82,16 @@
             "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="
         },
         "node_modules/@chevrotain/types": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
-            "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+            "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/@chevrotain/utils": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.4.2.tgz",
-            "integrity": "sha512-V34dacxWLwKcvcy32dx96ADJVdB7kOJLm7LyBkBQw5u5HC9WdEFw2G17zml+U3ivavGTrGPJHl8o9/UJm0PlUw=="
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+            "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.21.5",
@@ -1322,16 +1326,17 @@
             }
         },
         "node_modules/chevrotain": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.4.2.tgz",
-            "integrity": "sha512-gzF5GxE0Ckti5kZVuKEZycLntB5X2aj9RVY0r4/220GwQjdnljU+/t3kP74/FMWC7IzCDDEjQ9wsFUf0WCdSHg==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+            "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@chevrotain/cst-dts-gen": "10.4.2",
-                "@chevrotain/gast": "10.4.2",
-                "@chevrotain/types": "10.4.2",
-                "@chevrotain/utils": "10.4.2",
-                "lodash": "4.17.21",
-                "regexp-to-ast": "0.5.0"
+                "@chevrotain/cst-dts-gen": "11.0.3",
+                "@chevrotain/gast": "11.0.3",
+                "@chevrotain/regexp-to-ast": "11.0.3",
+                "@chevrotain/types": "11.0.3",
+                "@chevrotain/utils": "11.0.3",
+                "lodash-es": "4.17.21"
             }
         },
         "node_modules/cliui": {
@@ -2394,48 +2399,6 @@
                 "railroad-diagrams": "~1.0.0"
             }
         },
-        "node_modules/langium/node_modules/@chevrotain/cst-dts-gen": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-            "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
-            "dependencies": {
-                "@chevrotain/gast": "11.0.3",
-                "@chevrotain/types": "11.0.3",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/langium/node_modules/@chevrotain/gast": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-            "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
-            "dependencies": {
-                "@chevrotain/types": "11.0.3",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/langium/node_modules/@chevrotain/types": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-            "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="
-        },
-        "node_modules/langium/node_modules/@chevrotain/utils": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-            "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
-        },
-        "node_modules/langium/node_modules/chevrotain": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-            "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-            "dependencies": {
-                "@chevrotain/cst-dts-gen": "11.0.3",
-                "@chevrotain/gast": "11.0.3",
-                "@chevrotain/regexp-to-ast": "11.0.3",
-                "@chevrotain/types": "11.0.3",
-                "@chevrotain/utils": "11.0.3",
-                "lodash-es": "4.17.21"
-            }
-        },
         "node_modules/langium/node_modules/chevrotain-allstar": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
@@ -2494,7 +2457,8 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "node_modules/lodash-es": {
             "version": "4.17.21",
@@ -2993,11 +2957,6 @@
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
             "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
             "dev": true
-        },
-        "node_modules/regexp-to-ast": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-            "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
         },
         "node_modules/regexpp": {
             "version": "3.2.0",
@@ -4300,22 +4259,22 @@
             }
         },
         "@chevrotain/cst-dts-gen": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.4.2.tgz",
-            "integrity": "sha512-0+4bNjlndNWMoVLH/+y4uHnf6GrTipsC+YTppJxelVJo+xeRVQ0s2PpkdDCVTsu7efyj+8r1gFiwVXsp6JZ0iQ==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+            "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
             "requires": {
-                "@chevrotain/gast": "10.4.2",
-                "@chevrotain/types": "10.4.2",
-                "lodash": "4.17.21"
+                "@chevrotain/gast": "11.0.3",
+                "@chevrotain/types": "11.0.3",
+                "lodash-es": "4.17.21"
             }
         },
         "@chevrotain/gast": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.4.2.tgz",
-            "integrity": "sha512-4ZAn8/mjkmYonilSJ60gGj1tAF0cVWYUMlIGA0e4ATAc3a648aCnvpBw7zlPHDQjFp50XC13iyWEgWAKiRKTOA==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+            "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
             "requires": {
-                "@chevrotain/types": "10.4.2",
-                "lodash": "4.17.21"
+                "@chevrotain/types": "11.0.3",
+                "lodash-es": "4.17.21"
             }
         },
         "@chevrotain/regexp-to-ast": {
@@ -4324,14 +4283,14 @@
             "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="
         },
         "@chevrotain/types": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
-            "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+            "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="
         },
         "@chevrotain/utils": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.4.2.tgz",
-            "integrity": "sha512-V34dacxWLwKcvcy32dx96ADJVdB7kOJLm7LyBkBQw5u5HC9WdEFw2G17zml+U3ivavGTrGPJHl8o9/UJm0PlUw=="
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+            "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
         },
         "@esbuild/aix-ppc64": {
             "version": "0.21.5",
@@ -5054,16 +5013,16 @@
             }
         },
         "chevrotain": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.4.2.tgz",
-            "integrity": "sha512-gzF5GxE0Ckti5kZVuKEZycLntB5X2aj9RVY0r4/220GwQjdnljU+/t3kP74/FMWC7IzCDDEjQ9wsFUf0WCdSHg==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+            "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
             "requires": {
-                "@chevrotain/cst-dts-gen": "10.4.2",
-                "@chevrotain/gast": "10.4.2",
-                "@chevrotain/types": "10.4.2",
-                "@chevrotain/utils": "10.4.2",
-                "lodash": "4.17.21",
-                "regexp-to-ast": "0.5.0"
+                "@chevrotain/cst-dts-gen": "11.0.3",
+                "@chevrotain/gast": "11.0.3",
+                "@chevrotain/regexp-to-ast": "11.0.3",
+                "@chevrotain/types": "11.0.3",
+                "@chevrotain/utils": "11.0.3",
+                "lodash-es": "4.17.21"
             }
         },
         "cliui": {
@@ -5830,48 +5789,6 @@
                 "vscode-uri": "~3.0.8"
             },
             "dependencies": {
-                "@chevrotain/cst-dts-gen": {
-                    "version": "11.0.3",
-                    "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-                    "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
-                    "requires": {
-                        "@chevrotain/gast": "11.0.3",
-                        "@chevrotain/types": "11.0.3",
-                        "lodash-es": "4.17.21"
-                    }
-                },
-                "@chevrotain/gast": {
-                    "version": "11.0.3",
-                    "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-                    "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
-                    "requires": {
-                        "@chevrotain/types": "11.0.3",
-                        "lodash-es": "4.17.21"
-                    }
-                },
-                "@chevrotain/types": {
-                    "version": "11.0.3",
-                    "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-                    "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="
-                },
-                "@chevrotain/utils": {
-                    "version": "11.0.3",
-                    "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-                    "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
-                },
-                "chevrotain": {
-                    "version": "11.0.3",
-                    "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-                    "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-                    "requires": {
-                        "@chevrotain/cst-dts-gen": "11.0.3",
-                        "@chevrotain/gast": "11.0.3",
-                        "@chevrotain/regexp-to-ast": "11.0.3",
-                        "@chevrotain/types": "11.0.3",
-                        "@chevrotain/utils": "11.0.3",
-                        "lodash-es": "4.17.21"
-                    }
-                },
                 "chevrotain-allstar": {
                     "version": "0.3.1",
                     "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
@@ -5947,7 +5864,8 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "lodash-es": {
             "version": "4.17.21",
@@ -6298,11 +6216,6 @@
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
             "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
             "dev": true
-        },
-        "regexp-to-ast": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-            "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
         },
         "regexpp": {
             "version": "3.2.0",

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -287,8 +287,8 @@
         "langium:watch": "langium generate --watch"
     },
     "dependencies": {
-        "chevrotain": "^10.4.2",
-        "langium": "^3.2.0",
+        "chevrotain": "^11.0.3",
+        "langium": "~3.2.0",
         "properties-file": "~3.2.5",
         "properties-reader": "^2.2.0",
         "vscode-jsonrpc": "^8.2.1",

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -52,7 +52,7 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
     // By setting `process.env.DEBUG_BREAK` to a truthy value, the language server will wait until a debugger is attached.
     const debugOptions = { execArgv: [
         '--nolazy',
-        `--inspect${process.env.DEBUG_BREAK ? '-brk' : ''}=${process.env.DEBUG_SOCKET || '6009'}`
+        `--inspect${process.env.DEBUG_BREAK === 'true' ? '-brk' : ''}=${process.env.DEBUG_SOCKET || '6009'}`
     ] };
 
     // If the extension is launched in debug mode then the debug server options are used

--- a/bbj-vscode/src/language/bbj-linker.ts
+++ b/bbj-vscode/src/language/bbj-linker.ts
@@ -52,7 +52,7 @@ export class BbjLinker extends DefaultLinker {
             }
         }
         const elapsed = Date.now() - started
-        const threshold = 100
+        const threshold = 300
         if (elapsed > threshold) {
             console.debug(`Linking (>${threshold}ms) ${document.uri} took ${elapsed}ms`)
         }

--- a/bbj-vscode/src/language/bbj-validator.ts
+++ b/bbj-vscode/src/language/bbj-validator.ts
@@ -28,7 +28,6 @@ export function registerValidationChecks(services: BBjServices) {
         KeyedFileStatement: validator.checkKeyedFileStatement,
         DefFunction: validator.checkReturnValueInDef,
         CommentStatement: validator.checkCommentNewLines,
-        MethodDecl: validator.checkIfMethodIsChildOfInterface,
         MemberCall: validator.checkMemberCallUsingAccessLevels,
         SymbolicLabelRef: validator.checkSymbolicLabelRef
     };
@@ -128,17 +127,6 @@ export class BBjValidator {
         }
         const relativePath = relative(parentFolder, folder);
         return relativePath && !relativePath.startsWith('..') && !isAbsolute(relativePath);
-    }
-
-
-    checkIfMethodIsChildOfInterface(node: MethodDecl, accept: ValidationAcceptor): void {
-        const klass = AstUtils.getContainerOfType(node, isBbjClass)!;
-        if (klass.interface && node.endTag) {
-            accept('error', 'Methods of interfaces must not have a METHODEND keyword!', {
-                node: node,
-                property: 'endTag'
-            });
-        }
     }
 
     checkCommentNewLines(node: CommentStatement, accept: ValidationAcceptor): void {

--- a/bbj-vscode/src/language/bbj.langium
+++ b/bbj-vscode/src/language/bbj.langium
@@ -11,7 +11,7 @@ entry Model:
     Library | Program
 ;
 
-// Main programm
+// Main program
 Program:
     Statements*
 ;
@@ -292,7 +292,7 @@ ClassDecl returns BbjClass:
 ;
 InterfaceDecl returns BbjClass:
     interface?='INTERFACE' Visibility name=ValidName Extends? (';' comments+=CommentStatement)?
-        (members+=MethodDecl | Comments)*
+        (members+=InterfaceMethodDecl | Comments)*
     'INTERFACEEND'
 ;
 
@@ -324,12 +324,20 @@ FieldDecl returns FieldDecl:
 ;
 
 MethodDecl returns MethodDecl:
-    'METHOD' Visibility Static (returnType=[Class:QualifiedClassName] (array?='[' ']')? )? name=ValidName '(' (params+=ParameterDecl (',' params+=ParameterDecl)*)? RPAREN (';' comments+=CommentStatement)?
+    MethodDeclStart
     Comments?
     (
         (body+=Statement)*
         endTag='METHODEND'
     )?
+;
+
+fragment MethodDeclStart returns MethodDecl:
+    'METHOD' Visibility Static (returnType=[Class:QualifiedClassName] (array?='[' ']')? )? name=ValidName '(' (params+=ParameterDecl (',' params+=ParameterDecl)*)? RPAREN (';' comments+=CommentStatement)?
+;
+
+InterfaceMethodDecl returns MethodDecl:
+   MethodDeclStart
 ;
 
 MethodReturnStatement:
@@ -798,35 +806,21 @@ QualifiedClassName returns string:
     QualifiedBBjClassName | QualifiedJavaClassName;
 
 QualifiedJavaClassName returns string:
-    IdAndString ('.' IdAndString)*;
+    ID ('.' ID)*;
 
 QualifiedBBjClassName returns string:
-    BBjFilePath IdAndString;
+    BBjFilePath ID;
 
 FeatureName returns string:
-    EscapeId | ID_WITH_SUFFIX | IdAndString;
+    ID | ID_WITH_SUFFIX;
 
 ValidName returns string:
-    EscapeId | IdAndString
-;
-
-IdAndString returns string:
-    'STRING' | ID
-;
-
-EscapeId returns string:
-    'NEXT' | 'PRINT' | 'AND' | 'OR' | 'ERR' | 'FIELD' | 'WRITE' | 'END' | 'CLIPFROMSTR' | 'ADDR' | 'CONTINUE' | 'SQLOPEN' | 'SQLPREP' | 'MODE'
-    | 'READ' | 'INPUT' | 'EXTRACT' | 'FIND' | 'CLOSE' | 'OPEN' | 'WAIT' | 'SETERR' | 'SETESC'| 'CLASS' | 'REDIM'
-    | 'BREAK' | 'RETURN' | 'EXIT' | 'PRINTRECORD' | 'READRECORD' | 'WRITERECORD' | 'EXTRACTRECORD' | 'FINDRECORD' | 'INPUTRECORD' | 'RUN' | 'CALL'
-    | 'TBL' | 'TIM' | 'BEGIN' | 'CLEAR' | 'ESCAPE' | 'DROP' | 'ENTER' | 'SETOPTS' | 'PRECISION' | 'RELEASE' | 'RENAME' | 'TO'
-    | 'MKDIR' | 'RMDIR' | 'CHDIR' | 'EXECUTE' | 'KEY' | 'IND' | 'DIR' | 'ISZ' | 'DEF' | 'STOP' | 'RESET' | 'RETRY' | 'KNUM' | 'LEN' | 'SIZ'
-    | 'BACKGROUND' | 'DELETE' | 'LOCK' | 'UNLOCK' | 'DIM' | 'SQLCOMMIT' | 'SQLROLLBACK' | 'SQLEXEC' | 'SQLCLOSE' | 'START' | 'DOM' | 'CHANOPT'
-    | 'FILEOPT' | 'REMOVE' | 'SAVE' | 'SORT' | 'FULLTEXT' | 'INDEXED' | 'RESTORE' | 'SETDAY' | 'SETTERM' | 'SETTIME' | 'INTERFACE' | 'ENDIF' | 'FI'
+    ID
 ;
 
 // BBx Library
 Library:
-    'library' 
+    'library'
     (
         declarations+=LibMember
         | declarations+=LibEventType
@@ -840,16 +834,16 @@ LibMember:
 
 LibFunction returns LibFunction:
     (docu=DOCU)?
-    name=ValidName '(' parameters+=LibParameter? (',' parameters+=LibParameter)* RPAREN_NO_NL ':' returnType=IdAndString
+    name=ValidName '(' parameters+=LibParameter? (',' parameters+=LibParameter)* RPAREN_NO_NL ':' returnType=ID
 ;
 
 LibParameter returns LibParameter:
-    name=ValidName optional?='?'?  refByName?='!'? (':' type=IdAndString)?
+    name=ValidName optional?='?'?  refByName?='!'? (':' type=ID)?
 ;
 
 LibVariable returns LibVariable:
     (docu=DOCU)?
-    'var' name=ValidName (':' type=IdAndString)?
+    'var' name=ValidName (':' type=ID)?
 ;
 
 LibSymbolicLabel returns LibSymbolicLabelDecl:

--- a/bbj-vscode/test/parser.test.ts
+++ b/bbj-vscode/test/parser.test.ts
@@ -1603,16 +1603,14 @@ describe('Parser Tests', () => {
         expectNoParserLexerErrors(result);
     });
 
-    test("Check INTERFACE statement with method body", async () => {
+    test("Check INTERFACE statement with two methods", async () => {
         const result = await parse(`
             interface Chris
-                method public BBjNumber doIt()
-                methodend
+                method public String doIt(String foo!)
+                method public int doIt(String foo2!)
             interfaceend
         `, { validation: true });
-        expect(result.diagnostics ?? []).toHaveLength(2);
-        expect(result.diagnostics![0].message).toBe("Could not resolve reference to Class named 'BBjNumber'.");
-        expect(result.diagnostics![1].message).toBe("Methods of interfaces must not have a METHODEND keyword!");
+        expectNoParserLexerErrors(result);
     });
 
     test("Check LOCK and UNLOCK statement", async () => {

--- a/bbj-vscode/test/parser.test.ts
+++ b/bbj-vscode/test/parser.test.ts
@@ -1943,4 +1943,18 @@ describe('Parser Tests', () => {
         expectNoValidationErrors(result);
     });
 
+    test('Performance test', async () => {
+        const count = 5;
+        const startTime = performance.now();
+        for (let index = 0; index < count; index++) {
+            const result = await parse(`
+                print x;
+                `, { validation: false });
+        }
+        const endTime = performance.now();
+        const timeInSeconds = (endTime - startTime) / 1000;
+        console.log(`Parse ${count} times took: ${timeInSeconds} seconds`);
+        // In a bad state it took 48 seconds
+        expect(timeInSeconds, 'Parser is too slow').toBeLessThan(5);
+    });
 });


### PR DESCRIPTION
Using `keywordToken.CATEGORIES` to achieve the same effect as with synthetic `EscapeId` but with much better performance.

See #216

Other changes:
- extracted an explicit `InterfaceMethodDecl` rule as Interface methods don't have body and `methodend`
- prevent loading package Javadoc multiple times  