### PR TITLE
Remove ambiguity in MemberCall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 .DS_Store
 *.vsix
 bbj-vscode/LICENSE
+bbj-vscode/java-interop/bin/
+bbj-vscode/java-interop/lib/

--- a/bbj-vscode/src/language/bbj-type-inferer.ts
+++ b/bbj-vscode/src/language/bbj-type-inferer.ts
@@ -1,5 +1,5 @@
 import { BBjServices } from "./bbj-module.js";
-import { Expression, Class, Assignment, isArrayDecl, isAssignment, isClass, isConstructorCall, isFieldDecl, isJavaField, isJavaMethod, isLibFunction, isMemberCall, isMethodDecl, isStringLiteral, isSymbolRef, isVariableDecl } from "./generated/ast.js";
+import { Expression, Class, Assignment, isArrayDecl, isAssignment, isClass, isConstructorCall, isFieldDecl, isJavaField, isJavaMethod, isLibFunction, isMemberCall, isMethodDecl, isStringLiteral, isSymbolRef, isVariableDecl, isMethodCall } from "./generated/ast.js";
 import { JavaInteropService } from "./java-interop.js";
 
 export interface TypeInferer {
@@ -48,6 +48,8 @@ export class BBjTypeInferer implements TypeInferer {
             }
         } else if (isStringLiteral(expression)) {
             return this.javaInterop.getResolvedClass('java.lang.String')
+        } else if(isMethodCall(expression)) {
+            return this.getType(expression.method);
         }
         return undefined;
     }

--- a/bbj-vscode/src/language/bbj-validator.ts
+++ b/bbj-vscode/src/language/bbj-validator.ts
@@ -50,6 +50,10 @@ export class BBjValidator {
     }
 
     checkMemberCallUsingAccessLevels(memberCall: MemberCall, accept: ValidationAcceptor): void {
+        if(!memberCall.member) {
+            //for broken syntax like "obj!.   "
+            return;
+        }
         const type = memberCall.member.$nodeDescription?.type ?? memberCall.member.ref?.$type;
         if (!type || ![JavaField, JavaMethod, MethodDecl, FieldDecl].includes(type)) {
             return;

--- a/bbj-vscode/src/language/bbj.langium
+++ b/bbj-vscode/src/language/bbj.langium
@@ -750,10 +750,10 @@ PrefixExpression infers Expression:
 MemberCall infers Expression:
     PrimaryExpression
     (
-        {infer MemberCall.receiver=current} '.' member=[ClassMember:FeatureName] (isMethodCall?='(' (args+=ParameterCall (',' args+=ParameterCall)* )? RPAREN)?
+        {infer MemberCall.receiver=current} '.' member=[ClassMember:FeatureName]
         | {infer ArrayElement.receiver=current} "[" indices+=Expression (',' indices+=Expression)* "]"
+        | {infer MethodCall.method=current} '(' (args+=ParameterCall (',' args+=ParameterCall)* )? RPAREN
     )*
-    ({infer SubstringExpresion.receiver=current} '(' position = Expression (',' length = Expression)? RPAREN)? // substring
 ;
 
 ParameterCall:

--- a/bbj-vscode/test/parser.test.ts
+++ b/bbj-vscode/test/parser.test.ts
@@ -1968,4 +1968,12 @@ describe('Parser Tests', () => {
         expectNoParserLexerErrors(result);
         expectNoValidationErrors(result);
     });
+
+    test('Issue #225 Check substring after fid call ', async () => {
+        const result = await parse(`
+        ch = 2
+        PgmDirectory$=fid(ch)(9)(1,max(pos("\"=pgm(-2),-1),pos("/"=pgm(-2),-1)))
+        `, { validation: true });
+        expectNoParserLexerErrors(result);
+    });
 });

--- a/bbj-vscode/test/parser.test.ts
+++ b/bbj-vscode/test/parser.test.ts
@@ -1,6 +1,6 @@
 import { AstNode, EmptyFileSystem, LangiumDocument } from 'langium';
 import { AstUtils } from 'langium';
-import { expectError, parseHelper } from 'langium/test';
+import { parseHelper } from 'langium/test';
 import { beforeAll, describe, expect, test } from 'vitest';
 import { createBBjServices } from '../src/language/bbj-module';
 import { CompoundStatement, LetStatement, Library, Model, OutputItem, PrintStatement, Program, ReadStatement, StringLiteral, SymbolRef, isAddrStatement, isCallStatement, isClipFromStrStatement, isCloseStatement, isCommentStatement, isCompoundStatement, isExitWithNumberStatement, isGotoStatement, isLetStatement, isLibrary, isPrintStatement, isProgram, isRedimStatement, isRunStatement, isSqlCloseStatement, isSqlPrepStatement, isSwitchCase, isSwitchStatement, isWaitStatement } from '../src/language/generated/ast';

--- a/examples/issue225-multiple-substrings.bbj
+++ b/examples/issue225-multiple-substrings.bbj
@@ -1,0 +1,2 @@
+ch = 2
+PgmDirectory$=fid(ch)(9)(1,max(pos("\"=pgm(-2),-1),pos("/"=pgm(-2),-1)))


### PR DESCRIPTION
Closes #225 

Which removes an ambiguity warning.

Both old paths were applicable. This grammar allows only one, `MethodCall` and removes the `SubstringExpression`.