### PR TITLE
Fix syntax after "next VAR"

### DIFF
--- a/bbj-vscode/package-lock.json
+++ b/bbj-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bbj-vscode",
-    "version": "0.0.37-SNAPSHOT",
+    "version": "0.0.38-SNAPSHOT",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bbj-vscode",
-            "version": "0.0.37-SNAPSHOT",
+            "version": "0.0.38-SNAPSHOT",
             "license": "MIT",
             "dependencies": {
                 "chevrotain": "^11.0.3",

--- a/bbj-vscode/src/language/bbj-token-builder.ts
+++ b/bbj-vscode/src/language/bbj-token-builder.ts
@@ -72,7 +72,7 @@ export class BBjTokenBuilder extends DefaultTokenBuilder {
             const token: TokenType = {
                 name: terminal.name,
                 // may match `next` or `<NL>next`, but not `*next`
-                PATTERN: this.regexPatternFunction(/(?<=\r?\n?[^\*][ \t]*)next(?=[ \t]*(\r?\n))/i),
+                PATTERN: this.regexPatternFunction(/(?<=\r?\n?[^\*][ \t]*)next(?=[ \t]*(?=(;|\r?\n)))/i),
                 LINE_BREAKS: false
             };
             return token;
@@ -80,7 +80,7 @@ export class BBjTokenBuilder extends DefaultTokenBuilder {
             const token: TokenType = {
                 name: terminal.name,
                 // may match `next ID` or `<NL>next ID`
-                PATTERN: this.regexPatternFunction(/(?<=\r?\n?[ \t]*)next(?=[ \t]*([_a-zA-Z][\w_]*(!|\$|%)?)\r?\n)/i),
+                PATTERN: this.regexPatternFunction(/(?<=\r?\n?[ \t]*)next(?=[ \t]*([_a-zA-Z][\w_]*(!|\$|%)?)[ \t]*(?=(;|\r?\n)))/i),
                 LINE_BREAKS: false
             };
             return token;

--- a/bbj-vscode/src/language/bbj-token-builder.ts
+++ b/bbj-vscode/src/language/bbj-token-builder.ts
@@ -103,7 +103,7 @@ export class BBjTokenBuilder extends DefaultTokenBuilder {
         } else if (terminal.name === 'PRINT_STANDALONE_NL') {
             const token: TokenType = {
                 name: terminal.name,
-                PATTERN: this.regexPatternFunction(/(\?|PRINT|WRITE)\s*(\r?\n)/i),
+                PATTERN: this.regexPatternFunction(/(\?|PRINT|WRITE)\s*(?=(;|\r?\n))/i),
                 LINE_BREAKS: true
             };
             return token;

--- a/bbj-vscode/test/parser.test.ts
+++ b/bbj-vscode/test/parser.test.ts
@@ -1977,4 +1977,18 @@ describe('Parser Tests', () => {
         `, { validation: true });
         expectNoParserLexerErrors(result);
     });
+
+    test('Issue #227 Space after NEXT ID ', async () => {
+        const result = await parse(`
+        rem both is valid - either give the variable with NEXT or omit it. 
+        for i=0 to 10
+            print i
+        next i 
+
+        for j=0 to 10
+            print j
+        next 
+        `, { validation: true });
+        expectNoParserLexerErrors(result);
+    });
 });

--- a/examples/issue227-space-breaks-parser.bbj
+++ b/examples/issue227-space-breaks-parser.bbj
@@ -1,0 +1,10 @@
+rem both is valid - either give the variable with NEXT or omit it. 
+
+for i=0 to 10
+    print i
+next i 
+rem   ^--- one space
+
+for j=0 to 10
+    print j
+next 


### PR DESCRIPTION
Closes #227 

Reason was a missing assumption, that a semicolon and spaces can follow after the variable.
I also adjusted similar patterns.