### PR TITLE
Adjusted Java class resolution to better handle nested classes - Fixes #310

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: 20
     - name: Build
       shell: bash
       run: |

--- a/bbj-vscode/package-lock.json
+++ b/bbj-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bbj-lang",
-  "version": "0.2.6",
+  "version": "0.2.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bbj-lang",
-      "version": "0.2.6",
+      "version": "0.2.14",
       "license": "MIT",
       "dependencies": {
         "chevrotain": "^11.0.3",
@@ -18,7 +18,7 @@
         "vscode-uri": "^3.0.2"
       },
       "devDependencies": {
-        "@types/node": "^18.0.0",
+        "@types/node": "^20.0.0",
         "@types/vscode": "^1.67.0",
         "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.28.0",
@@ -832,12 +832,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
-      "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/semver": {
@@ -3435,10 +3436,11 @@
       "dev": true
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -4686,12 +4688,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.19.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
-      "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/semver": {
@@ -6541,9 +6543,9 @@
       "dev": true
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "universalify": {

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -301,7 +301,7 @@
     "vscode-uri": "^3.0.2"
   },
   "devDependencies": {
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.0.0",
     "@types/vscode": "^1.67.0",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",

--- a/bbj-vscode/src/language/bbj-scope-local.ts
+++ b/bbj-vscode/src/language/bbj-scope-local.ts
@@ -238,6 +238,10 @@ export class BbjScopeComputation extends DefaultScopeComputation {
                 console.warn(e)
             }
         }
+        if (!javaClass?.$container) {
+            console.error(`Check Java class '${javaClassName}' has no container.`)
+            return undefined;
+        }
         return javaClass;
     }
 

--- a/bbj-vscode/test/linking.test.ts
+++ b/bbj-vscode/test/linking.test.ts
@@ -236,5 +236,20 @@ describe('Linking Tests', async () => {
             `)
             expectNoErrors(document)
         });
+
+        test('Resolve nested class in use statement', async () => {
+            const document = await validate(`
+                use java.util.Map.Entry
+            `)
+            expectNoErrors(document)
+        });
+
+        test('Resolve nested class FQN', async () => {
+            const document = await validate(`
+                e = new java.util.Map.Entry()
+                comp = e.getValue()
+            `)
+            expectNoErrors(document)
+        });
     });
 });

--- a/java-interop/build.gradle
+++ b/java-interop/build.gradle
@@ -1,5 +1,16 @@
 plugins {
+    id 'java'
     id 'application'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release.set(17)
 }
 
 repositories {


### PR DESCRIPTION
Nested classes are now properly added to the corresponding package with their qualified name.
E.g.: `java.util.Map.Entry` will be added as child of `java.util` package with simple name `Map.Entry`

On the Java side `java.util.Map.Entry` can't be loaded by the class loader as requested from the frontend, hence the FQN is turned to `java.util.Map$Entry` following the Java name convention rules.
