### PR TITLE
ci: publish IntelliJ preview snapshots to JetBrains Marketplace

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -93,16 +93,17 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Build IntelliJ plugin
+      - name: Publish IntelliJ preview to JetBrains Marketplace
         working-directory: bbj-intellij
-        run: ./gradlew buildPlugin -Pversion=${{ needs.publish-preview.outputs.version }}
-
-      - name: Extract plugin for upload
-        run: unzip -o bbj-intellij/build/distributions/bbj-intellij-*.zip -d bbj-intellij/build/distributions/extracted
+        run: >-
+          ./gradlew publishPlugin
+          -Pversion=${{ needs.publish-preview.outputs.version }}
+          -PintellijChannel=preview
+          -PintellijPlatformPublishingToken=${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
 
       - name: Upload IntelliJ plugin
         uses: actions/upload-artifact@v4
         with:
           name: bbj-intellij-${{ needs.publish-preview.outputs.version }}
-          path: bbj-intellij/build/distributions/extracted/*
+          path: bbj-intellij/build/distributions/bbj-intellij-*.zip
           retention-days: 7

--- a/bbj-intellij/build.gradle.kts
+++ b/bbj-intellij/build.gradle.kts
@@ -73,6 +73,10 @@ intellijPlatform {
 
     publishing {
         token = providers.gradleProperty("intellijPlatformPublishingToken")
+        // Channel to publish to on JetBrains Marketplace. Defaults to "default" (the
+        // stable channel) so releases are unaffected; preview builds pass
+        // -PintellijChannel=preview to publish snapshots to a separate opt-in channel.
+        channels = listOf(providers.gradleProperty("intellijChannel").getOrElse("default"))
     }
 }
 


### PR DESCRIPTION
## What

Publish IntelliJ **preview snapshots** to the JetBrains Marketplace on every push to `main`, mirroring what the preview workflow already does for VSCode pre-releases.

Until now `preview.yml` only *built* the IntelliJ plugin and uploaded it as a GitHub Actions artifact — there was no auto-updating preview channel like VSCode's `--pre-release`.

## Changes

- **`bbj-intellij/build.gradle.kts`** — the publish channel is now configurable via the `intellijChannel` gradle property, defaulting to `"default"` (the stable channel). `manual-release.yml` passes no channel, so **releases are unaffected**.
- **`.github/workflows/preview.yml`** — the `build-intellij` job now runs `publishPlugin` on the `preview` channel using the existing `JETBRAINS_MARKETPLACE_TOKEN` secret (the same one release publishing uses). The plugin `.zip` is still uploaded as an artifact.

## How it works

- Releases → `default`/stable channel (unchanged).
- Every push to `main` → new patch version (already bumped by the `publish-preview` job) published to the `preview` channel. Preview versions are `x.y.{1,2,3…}` and releases are `x.y.0`, so there's no version collision.

## Opting in (for users)

In IntelliJ: **Settings → Plugins → ⚙ → Manage Plugin Repositories → +** and add:

```
https://plugins.jetbrains.com/plugins/preview/list
```

Then preview builds arrive as normal plugin updates.

## Verification

- `./gradlew help -PintellijChannel=preview` configures cleanly (validates the new `channels` assignment).
- Default path (no `-PintellijChannel`, as release uses) still resolves to the stable channel.

## Note

The `preview` channel and its custom repository URL become live only after the **first** snapshot is published (i.e. after this merges and the workflow runs once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)