### PR TITLE
chore: tell dependabot to ignore chevrotain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     directory: "/bbj-vscode"
     schedule:
       interval: "weekly"
+    ignore:
+      # chevrotain is pinned to the version Langium depends on. Bumping it above
+      # Langium's own chevrotain breaks grammar generation ("non exhaustive match"
+      # during `langium generate`) — see PR #347. It should only move when a Langium
+      # upgrade pulls in a newer chevrotain, so let Langium drive it.
+      - dependency-name: "chevrotain"


### PR DESCRIPTION
chevrotain is effectively controlled by Langium. Bumping our direct `chevrotain` dependency above the version Langium (`~4.1.3`) depends on breaks grammar generation — `langium generate` fails with `Error: non exhaustive match`. This was verified locally when dependabot proposed chevrotain 11.1.1 in #347 (now closed).

Adding a dependabot `ignore` rule so chevrotain isn't re-proposed on every release; it should only move when a Langium upgrade pulls in a newer chevrotain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)