### PR TITLE
fix(intellij): stop using internal PluginManagerCore.getPlugin API

### DIFF
--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjEMLoginAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjEMLoginAction.java
@@ -4,7 +4,7 @@ import com.basis.bbj.intellij.BbjSettings;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.execution.process.ProcessOutput;
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationNamesInfo;
@@ -158,7 +158,7 @@ public final class BbjEMLoginAction extends AnAction {
     private static String getEMLoginBbjPath() {
         try {
             var pluginId = PluginId.getId("com.basis.bbj");
-            var plugin = PluginManagerCore.getPlugin(pluginId);
+            var plugin = PluginManager.getInstance().findEnabledPlugin(pluginId);
             if (plugin == null) return null;
             Path emLogin = plugin.getPluginPath().resolve("lib/tools/em-login.bbj");
             return Files.exists(emLogin) ? emLogin.toString() : null;

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunActionBase.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunActionBase.java
@@ -231,8 +231,7 @@ public abstract class BbjRunActionBase extends AnAction {
     @Nullable
     protected String getWebBbjPath() {
         try {
-            com.intellij.ide.plugins.PluginManagerCore pluginManagerCore = com.intellij.ide.plugins.PluginManagerCore.INSTANCE;
-            com.intellij.ide.plugins.IdeaPluginDescriptor plugin = pluginManagerCore.getPlugin(
+            com.intellij.ide.plugins.IdeaPluginDescriptor plugin = com.intellij.ide.plugins.PluginManager.getInstance().findEnabledPlugin(
                 com.intellij.openapi.extensions.PluginId.getId("com.basis.bbj")
             );
             if (plugin == null) {
@@ -261,7 +260,7 @@ public abstract class BbjRunActionBase extends AnAction {
             if (pluginId == null) {
                 return null;
             }
-            com.intellij.ide.plugins.IdeaPluginDescriptor plugin = com.intellij.ide.plugins.PluginManagerCore.getPlugin(pluginId);
+            com.intellij.ide.plugins.IdeaPluginDescriptor plugin = com.intellij.ide.plugins.PluginManager.getInstance().findEnabledPlugin(pluginId);
             if (plugin == null) {
                 return null;
             }

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjLanguageServer.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjLanguageServer.java
@@ -5,7 +5,7 @@ import com.basis.bbj.intellij.BbjNodeDownloader;
 import com.basis.bbj.intellij.BbjSettings;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.server.OSProcessStreamConnectionProvider;
@@ -68,7 +68,7 @@ public final class BbjLanguageServer extends OSProcessStreamConnectionProvider {
     private String resolveServerPath() {
         // Try plugin installation path first
         PluginId pluginId = PluginId.getId("com.basis.bbj");
-        IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(pluginId);
+        IdeaPluginDescriptor plugin = PluginManager.getInstance().findEnabledPlugin(pluginId);
         if (plugin != null) {
             Path serverPath = plugin.getPluginPath().resolve("lib").resolve("language-server").resolve("main.cjs");
             if (Files.exists(serverPath)) {


### PR DESCRIPTION
## Why

The JetBrains plugin compatibility report flags **4 usages of internal API** — `PluginManagerCore.getPlugin(PluginId)` — with *"Internal API is private and must not be used outside of the IntelliJ Platform itself."* Internal API can break in any IDE release with no deprecation cycle, and it's the item the Marketplace report calls out for action.

All four calls do the same thing: resolve the plugin's own install path (`getPluginPath()`) to locate a bundled file.

## Change

Replace with the public, supported equivalent `PluginManager.getInstance().findEnabledPlugin(PluginId)` (same return type `IdeaPluginDescriptor`, same semantics):

| File | Bundled resource |
|------|------------------|
| `lsp/BbjLanguageServer.java` | language server `main.cjs` |
| `actions/BbjRunActionBase.java` | `web.bbj`, `em-validate-token.bbj` |
| `actions/BbjEMLoginAction.java` | `em-login.bbj` |

## Verification

- `./gradlew compileJava` → **BUILD SUCCESSFUL**
- No `PluginManagerCore` references remain in `bbj-intellij/src`.

## Not addressed (intentionally)

The report's **19 experimental-API usages** are all LSP4IJ classes (`LSPClientFeatures`, `LSPCompletionFeature`, `LSPDocumentLinkFeature`) — that's LSP4IJ's customization surface with no non-experimental alternative. LSP4IJ stays pinned (`0.19.0`); re-verify on any bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)