### PR TITLE
chore(deps): migrate to Langium 4.3 (LSP 3.18 stack)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 20
+        node-version: 22
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install tools
         run: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies and build
         working-directory: bbj-vscode

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20  # Updated from 18 to 20
+          node-version: 22  # langium 4.3 toolchain requires Node 22+
 
       - name: Install CLI Tools
         run: |

--- a/bbj-vscode/package-lock.json
+++ b/bbj-vscode/package-lock.json
@@ -1,38 +1,38 @@
 {
   "name": "bbj-lang",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bbj-lang",
-      "version": "0.8.14",
+      "version": "0.8.15",
       "license": "MIT",
       "dependencies": {
         "@vscode/vsce": "^3.7.1",
-        "chevrotain": "~11.0.3",
-        "langium": "~4.1.3",
+        "chevrotain": "~12.0.0",
+        "langium": "~4.3.1",
         "properties-file": "^3.6.3",
         "properties-reader": "^2.3.0",
         "vscode-jsonrpc": "^8.2.1",
-        "vscode-languageclient": "^9.0.1",
+        "vscode-languageclient": "^10.1.0",
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
         "@types/node": "^26.1.1",
-        "@types/vscode": "^1.67.0",
+        "@types/vscode": "^1.91.0",
         "@vitest/coverage-v8": "^4.1.10",
         "concurrently": "^8.2.2",
         "esbuild": "^0.28.1",
         "eslint": "^9.39.5",
-        "langium-cli": "~4.1.0",
+        "langium-cli": "~4.3.0",
         "shx": "^0.4.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.64.0",
         "vitest": "^4.1.10"
       },
       "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -298,42 +298,40 @@
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
       }
     },
     "node_modules/@chevrotain/gast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
+        "@chevrotain/types": "12.0.0"
       }
     },
     "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/types": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
@@ -2793,29 +2791,31 @@
       }
     },
     "node_modules/chevrotain": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.0.3",
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/regexp-to-ast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "@chevrotain/utils": "11.0.3",
-        "lodash-es": "4.17.21"
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/chevrotain-allstar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
+      "integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
       "license": "MIT",
       "dependencies": {
-        "lodash-es": "^4.17.21"
+        "lodash-es": "^4.18.1"
       },
       "peerDependencies": {
-        "chevrotain": "^11.0.0"
+        "chevrotain": "^12.0.0"
       }
     },
     "node_modules/chownr": {
@@ -2880,13 +2880,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/concat-map": {
@@ -3869,9 +3869,9 @@
       "optional": true
     },
     "node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4606,15 +4606,18 @@
       }
     },
     "node_modules/langium": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-4.1.3.tgz",
-      "integrity": "sha512-53IBMnzMkULRVnavSaqPUfPriMAJQiK7lpHENRRGihwcuF5esISMn/L8FqX3NvaBmWqiom25FCaX6kq4yJ74yA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.3.1.tgz",
+      "integrity": "sha512-4lmkLHytLXD5pvyL0PKUj1LCNpgzv9s8luH+GbWXHG45QLmO6PlFXrCUghDN5BfcFTlaQyXpXiaSl8A28Xep8w==",
       "license": "MIT",
       "dependencies": {
-        "chevrotain": "~11.0.3",
-        "chevrotain-allstar": "~0.3.0",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.11",
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.3",
+        "vscode-languageserver": "~10.0.1",
+        "vscode-languageserver-protocol": "~3.18.1",
+        "vscode-languageserver-textdocument": "~1.0.13",
+        "vscode-languageserver-types": "~3.18.0",
         "vscode-uri": "~3.1.0"
       },
       "engines": {
@@ -4623,19 +4626,19 @@
       }
     },
     "node_modules/langium-cli": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-4.1.0.tgz",
-      "integrity": "sha512-MhjE6R/K+oBjHhOP5j3orSR3q3FKeFNgJ533tOC+dJw/6WMDFMc9tROCbJGx6Aj+3Dt3jkuHDD6npa+dH/dV6Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-4.3.0.tgz",
+      "integrity": "sha512-+TtgkhX8Z3exRBJvTFWV1semhWUCnWMhMP+ZKjpKIeyY6GgnQHehf3ZWyCvVL5T95uqgWZb77aoq9rhI2MPNTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "~5.4.1",
-        "commander": "~14.0.0",
-        "fs-extra": "~11.3.0",
+        "chalk": "~5.6.2",
+        "commander": "~15.0.0",
+        "fs-extra": "~11.3.5",
         "jsonschema": "~1.5.0",
-        "langium": "~4.1.0",
-        "langium-railroad": "~4.1.0",
-        "lodash": "~4.17.21"
+        "langium": "~4.3.0",
+        "langium-railroad": "~4.3.0",
+        "lodash": "~4.18.1"
       },
       "bin": {
         "langium": "bin/langium.js"
@@ -4646,9 +4649,9 @@
       }
     },
     "node_modules/langium-cli/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4659,13 +4662,13 @@
       }
     },
     "node_modules/langium-railroad": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-4.1.0.tgz",
-      "integrity": "sha512-3m9TeMNnS/rMYaueGDIAPnxhBz7eJLy4iEmMrmSt5FycxAgGtGIVbWT2ry3YRqBy/ICOaAwu530gp4IWcRM5Jg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-4.3.0.tgz",
+      "integrity": "sha512-dbuv149MQe8XcgM48FagH22JBaqN0MvN9RRJKBdRQWDeHUYAASliiOtLdMfgOl3kV+nLx7idSc+LLdcBSduvHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "langium": "~4.1.0",
+        "langium": "~4.3.0",
         "railroad-diagrams": "~1.0.0"
       }
     },
@@ -4991,15 +4994,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -6274,9 +6277,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7537,82 +7540,117 @@
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+      "integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
       "license": "MIT",
       "dependencies": {
-        "minimatch": "^5.1.0",
-        "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.5"
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
+        "vscode-languageserver-protocol": "3.18.2",
+        "vscode-languageserver-textdocument": "1.0.13"
       },
       "engines": {
-        "vscode": "^1.82.0"
+        "vscode": "^1.91.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/vscode-languageclient/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.0.1.tgz",
+      "integrity": "sha512-hfERoZvpaHWzQa7t5mMIrHkEOhF7aTs1dpktem0TW/Xs4QZD7NtcHjIq/aE1CZJEj6Rb8LSGUkBhvTRDdpyGig==",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
+        "vscode-languageserver-protocol": "3.18.1"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
     "node_modules/vscode-languageserver-protocol/node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+      "integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==",
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0.tgz",
+      "integrity": "sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.1.tgz",
+      "integrity": "sha512-RTiiVHdpxpYcJVI5sq6S5TLjQ4WDR/rBrIWru+kPXe6sGQ9PFQ3GamrTKLvPqbR4ylr1SoodhmcqbFII0WXVuw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.0",
+        "vscode-languageserver-types": "3.18.0"
+      }
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",

--- a/bbj-vscode/package-lock.json
+++ b/bbj-vscode/package-lock.json
@@ -20,7 +20,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.1.1",
-        "@types/vscode": "^1.91.0",
+        "@types/vscode": "^1.101.0",
         "@vitest/coverage-v8": "^4.1.10",
         "concurrently": "^8.2.2",
         "esbuild": "^0.28.1",
@@ -32,7 +32,7 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "vscode": "^1.91.0"
+        "vscode": "^1.101.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -8,7 +8,7 @@
   "icon": "images/icon.png",
   "type": "module",
   "engines": {
-    "vscode": "^1.67.0"
+    "vscode": "^1.91.0"
   },
   "categories": [
     "Programming Languages"
@@ -555,22 +555,22 @@
   },
   "dependencies": {
     "@vscode/vsce": "^3.7.1",
-    "chevrotain": "~11.0.3",
-    "langium": "~4.1.3",
+    "chevrotain": "~12.0.0",
+    "langium": "~4.3.1",
     "properties-file": "^3.6.3",
     "properties-reader": "^2.3.0",
     "vscode-jsonrpc": "^8.2.1",
-    "vscode-languageclient": "^9.0.1",
+    "vscode-languageclient": "^10.1.0",
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
-    "@types/vscode": "^1.67.0",
+    "@types/vscode": "^1.91.0",
     "@vitest/coverage-v8": "^4.1.10",
     "concurrently": "^8.2.2",
     "esbuild": "^0.28.1",
     "eslint": "^9.39.5",
-    "langium-cli": "~4.1.0",
+    "langium-cli": "~4.3.0",
     "shx": "^0.4.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.64.0",

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -8,7 +8,7 @@
   "icon": "images/icon.png",
   "type": "module",
   "engines": {
-    "vscode": "^1.91.0"
+    "vscode": "^1.101.0"
   },
   "categories": [
     "Programming Languages"
@@ -565,7 +565,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
-    "@types/vscode": "^1.91.0",
+    "@types/vscode": "^1.101.0",
     "@vitest/coverage-v8": "^4.1.10",
     "concurrently": "^8.2.2",
     "esbuild": "^0.28.1",

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import {
     LanguageClient, LanguageClientOptions, ServerOptions, TransportKind
-} from 'vscode-languageclient/node.js';
+} from 'vscode-languageclient/node';
 import { BBjLibraryFileSystemProvider } from './language/lib/fs-provider.js';
 import { DocumentFormatter } from './document-formatter.js';
 import {

--- a/bbj-vscode/src/language/bbj-document-builder.ts
+++ b/bbj-vscode/src/language/bbj-document-builder.ts
@@ -367,14 +367,17 @@ export class BBjDocumentBuilder extends DefaultDocumentBuilder {
 
             const originalLength = document.diagnostics.length;
             document.diagnostics = document.diagnostics.filter(diag => {
+                // LSP 3.18 widened Diagnostic.message to `string | MarkupContent`; our
+                // diagnostics use plain string messages, so read the string form.
+                const message = typeof diag.message === 'string' ? diag.message : diag.message.value;
                 // Only re-check our specific USE file-path diagnostics
-                if (!diag.message.startsWith(USE_FILE_NOT_RESOLVED_PREFIX)) {
+                if (!message.startsWith(USE_FILE_NOT_RESOLVED_PREFIX)) {
                     return true; // keep all other diagnostics
                 }
 
                 // Extract the clean path from the diagnostic message
                 // Message format: "File 'some/path.bbj' could not be resolved..."
-                const pathMatch = diag.message.match(/^File '([^']+)'/);
+                const pathMatch = message.match(/^File '([^']+)'/);
                 if (!pathMatch) {
                     return true; // keep if we can't parse
                 }

--- a/bbj-vscode/src/language/bbj.langium
+++ b/bbj-vscode/src/language/bbj.langium
@@ -365,7 +365,7 @@ MethodDecl returns MethodDecl:
     )?
 ;
 
-fragment MethodDeclStart returns MethodDecl:
+fragment MethodDeclStart:
     'METHOD' Visibility Static (voidReturn?='void' | (returnType=QualifiedClass (array?='[' ']')?) )? name=ValidName '(' (params+=ParameterDecl (',' params+=ParameterDecl)*)? RPAREN (';' comments+=CommentStatement)?
 ;
 
@@ -510,7 +510,7 @@ PrintStatement:
     ;
 
 //actual intent: ('('channelno?options?')')? (items(',' items)*)? ','?
-fragment WithChannelAndOptionsAndOutputItems infers WithChannelAndOptionsAndOutputItems:
+fragment WithChannelAndOptionsAndOutputItems:
     '(' channelno=Expression? Options? (
         RPAREN_NL
         | RPAREN_NO_NL items+=OutputItem (',' items+=OutputItem)* ENDLINE_PRINT_COMMA?
@@ -611,7 +611,7 @@ ReadRecordStatement infers ReadStatement:
 ;
 
 //actual intent: ('('channelno?options?')')? (items(','items)*)?
-fragment WithChannelAndOptionsAndInputItems infers WithChannelAndOptionsAndInputItems:
+fragment WithChannelAndOptionsAndInputItems:
     '(' channelno=Expression? Options? (RPAREN_NL | RPAREN_NO_NL items+=InputItem (','items+=InputItem)* ENDLINE_PRINT_COMMA?)
     | items+=InputItem (','items+=InputItem)* ENDLINE_PRINT_COMMA?
 ;

--- a/bbj-vscode/src/language/main.ts
+++ b/bbj-vscode/src/language/main.ts
@@ -6,7 +6,7 @@
 
 import { startLanguageServer } from 'langium/lsp';
 import { NodeFileSystem } from 'langium/node';
-import { createConnection, ProposedFeatures } from 'vscode-languageserver/node.js';
+import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
 import { DocumentState } from 'langium';
 import { createBBjServices } from './bbj-module.js';
 import { BBjWorkspaceManager } from './bbj-ws-manager.js';


### PR DESCRIPTION
Completes the Langium 4.3 upgrade dependabot #399 opened — but as the **coordinated LSP-stack migration** it actually requires.

## What moved (interlocked versions)
| Package | From | To | Why |
|---------|------|----|-----|
| langium | ~4.1.3 | **~4.3.1** | the upgrade |
| langium-cli | ~4.1.0 | **~4.3.0** | must match langium runtime |
| chevrotain | ~11.0.3 | **~12.0.0** | required by langium 4.2.2+ |
| vscode-languageclient | ^9.0.1 | **^10.1.0** | LSP protocol 3.18 |
| @types/vscode + engines.vscode | ^1.67.0 | **^1.101.0** | see runtime floor below |
| CI Node | 20 | **22** | toolchain requirement below |

## Code changes the upgrade forced
- **`bbj.langium`** — Langium 4.3 forbids a type on `fragment` rules; removed the redundant `returns MethodDecl` / `infers …` from three fragments. **Generated files are byte-identical** (types folded into callers anyway).
- **`main.ts` / `extension.ts`** — vscode-languageserver/client 10 changed the node entry export `/node.js` → `/node`.
- **`bbj-document-builder.ts`** — LSP 3.18 widened `Diagnostic.message` to `string | MarkupContent`; read the string form before string ops.

## ⚠️ Node 22 / VS Code 1.101 floor (the notable consequence)
Chevrotain 12 and langium-cli use **`Object.groupBy` (Node 21+)**:
- **Build/dev:** `langium generate` fails on Node 20 (`Object.groupBy is not a function`) → CI Node bumped 20→22 across build/pr-validation/preview/manual-release.
- **Runtime:** Chevrotain emits `Object.groupBy` into the shipped LS bundle (grammar validation at parser construction). The LS is forked on **VS Code's bundled Node**, and VS Code ≤ 1.100 ships Node 20 → the server would crash at startup. **1.101 is the first VS Code on Node 22**, so that's the new floor.

*(Alternative considered: polyfill `Object.groupBy` and keep the ^1.91 floor. Rejected as default because the polyfill's Node-20 path is untestable in our CI, which runs Node 22. Easy to add if we want to keep supporting VS Code 1.91–1.100.)*

## Supersedes / folds in
- Supersedes **#399** (langium-only → breaks `langium generate`).
- Folds in **#396** (`@types/vscode` tied to the real `engines.vscode` floor).

## Verification
- `npm run build` clean · `vitest run` **495 passed / 20 skipped** (chevrotain-12 lexer, completion, linking, validation) · `npm run lint` 0 errors
- **Runtime LSP smoke test** — server boots on vscode-languageserver 10, completes `initialize`, opens a doc, publishes diagnostics over the wire
- **CI green** on Node 22: build, tests, `vsce package`, and the IntelliJ `buildPlugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)