### PR TITLE
chore: ignore TypeScript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
       # during `langium generate`) — see PR #347. It should only move when a Langium
       # upgrade pulls in a newer chevrotain, so let Langium drive it.
       - dependency-name: "chevrotain"
+      # TypeScript major versions are gated by typescript-eslint, which supports
+      # only `typescript >=4.8.4 <6.1.0` — TS 6/7 (the native compiler) crash
+      # `npm run lint`. See PR #397. Allow 5.x updates; block majors until
+      # typescript-eslint adds support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
TypeScript major versions are gated by **typescript-eslint**, whose latest release still declares `typescript >=4.8.4 <6.1.0`. TS 6/7 (the native Go compiler) crash `npm run lint` — `@typescript-eslint/typescript-estree` reads TypeScript internals the native compiler doesn't expose (`TypeError: Cannot read properties of undefined (reading 'Cjs')`). Verified in #397 (closed).

Adds a dependabot `ignore` for `typescript` **major** updates only:
- ✅ 5.x minor/patch updates still flow
- 🚫 6.0 / 7.0 blocked until typescript-eslint adds support

Consistent with the existing chevrotain ignore (Langium-driven). Both are cases where a dependency is effectively pinned by a tool that consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)