### PR TITLE
fix(java-interop): stop depth-limit flood re-stubbing cached Java classes

### DIFF
--- a/bbj-vscode/src/language/java-interop.ts
+++ b/bbj-vscode/src/language/java-interop.ts
@@ -38,7 +38,7 @@ export class JavaInteropService {
     /** In-flight resolution promises keyed by class name, preventing duplicate concurrent resolution of the same class. */
     private readonly _pendingResolutions: Map<string, Promise<JavaClass>> = new Map();
     /** Maximum recursion depth for Java class resolution to prevent runaway resolution chains. */
-    private static readonly MAX_RESOLUTION_DEPTH = 20;
+    private static readonly MAX_RESOLUTION_DEPTH = 50;
     /** Maximum time (ms) allowed for a single resolveClassByName call chain before aborting. */
     private static readonly RESOLUTION_TIMEOUT_MS = 30_000;
     private interopHost: string = '127.0.0.1';
@@ -264,21 +264,31 @@ export class JavaInteropService {
      * @returns the resolved JavaClass with all dependencies linked
      */
     async resolveClassByName(className: string, token?: CancellationToken, _depth: number = 0): Promise<JavaClass> {
-        // Safeguard 2: depth limit to prevent runaway recursive resolution chains
-        if (_depth > JavaInteropService.MAX_RESOLUTION_DEPTH) {
-            logger.warn(`Java class resolution depth limit (${JavaInteropService.MAX_RESOLUTION_DEPTH}) exceeded for '${className}', returning partial class`);
-            return this.createStubClass(className);
-        }
-
-        // Fast path: already fully resolved
+        // Fast path: already fully resolved. Checked *before* the depth limit because a
+        // cached class triggers no further recursion — the depth limit is irrelevant to it,
+        // and returning it here avoids re-stubbing already-resolved leaf types (int, void,
+        // java.lang.Object, ...) that are reached deep inside a legitimate type graph.
         if (this.resolvedClasses.has(className)) {
             return this.resolvedClasses.get(className)!;
         }
 
-        // Safeguard 3: deduplicate — if another caller is already resolving this class, wait for it
+        // Safeguard 3: deduplicate — if another caller is already resolving this class, wait for it.
+        // Also checked before the depth limit: the in-flight resolution owns the recursion budget.
         const pending = this._pendingResolutions.get(className);
         if (pending) {
             return pending;
+        }
+
+        // Safeguard 2: depth limit to prevent runaway recursive resolution chains. Only applies
+        // to genuinely new classes we are about to fetch and resolve — cycles among already-seen
+        // classes are broken by the resolvedClasses cache above (resolveClass registers a class
+        // before recursing into its member types).
+        if (_depth > JavaInteropService.MAX_RESOLUTION_DEPTH) {
+            logger.warn(`Java class resolution depth limit (${JavaInteropService.MAX_RESOLUTION_DEPTH}) exceeded for '${className}', returning partial class`);
+            // Do NOT cache this stub: a later, shallower resolution of the same class must still be
+            // able to resolve it fully. Caching here would permanently freeze the class as a
+            // member-less stub for every subsequent reference (via the fast path above).
+            return this.createStubClass(className, false);
         }
 
         const resolutionPromise = this.doResolveClassByName(className, token, _depth);
@@ -324,8 +334,11 @@ export class JavaInteropService {
     /**
      * Creates a minimal stub JavaClass for cases where resolution fails or is aborted.
      * This prevents callers from receiving undefined and allows partial results.
+     * @param cache when true (default), the stub is stored in resolvedClasses so subsequent lookups
+     *   reuse it — appropriate for genuine resolution failures. Pass false for transient stubs (e.g.
+     *   the depth-limit backstop), so a later shallower resolution can still populate the real class.
      */
-    private createStubClass(className: string): JavaClass {
+    private createStubClass(className: string, cache: boolean = true): JavaClass {
         const existing = this.resolvedClasses.get(className);
         if (existing) return existing;
 
@@ -343,7 +356,9 @@ export class JavaInteropService {
             deprecated: false,
             error: `Resolution failed or depth limit exceeded`,
         } as unknown as Mutable<JavaClass>;
-        this.resolvedClasses.set(className, stub);
+        if (cache) {
+            this.resolvedClasses.set(className, stub);
+        }
         return stub;
     }
 


### PR DESCRIPTION
## Problem

A flood of `Java class resolution depth limit (20) exceeded ... returning partial class` errors (reported against v0.8.17 / v0.8.18), dominated by trivial cached types — `int`, `void`, `java.lang.Object`, `java.lang.String` — and deep `com.basis.sql.sqlengine2.*` / Apache POI classes.

## Root cause

In `resolveClassByName` (`java-interop.ts`), the **depth-limit check ran before the `resolvedClasses` cache check**. `resolveClass` resolves each field/method/parameter type by recursing with `_depth + 1`, so along a deep-but-legitimate type graph `_depth` climbs past the limit. Once it does, *every* subsequent reference on that chain — including types already fully resolved and cached — tripped the depth guard before the cache, logging an error and returning a throwaway stub each time.

Worse, `createStubClass` **cached** that stub, so the first class reached past the limit was permanently frozen as a member-less stub for every later reference (silent hover/completion degradation).

Regression introduced in `decb021` ("enhance class resolution with safeguards"); before it, the cache check came first and recursion was bounded solely by the cache.

## Fix

- **Cache/in-flight fast-paths run before the depth limit.** A cached or `_pendingResolutions` class triggers no new recursion, so the depth limit is irrelevant to it. Cycles remain broken by the cache (`resolveClass` registers a class before recursing into its member types) — this restores the pre-regression behavior.
- **Depth-limit stub is non-caching** (`createStubClass` gains a `cache` flag, default `true`). An uncached stub lets a later, shallower resolution populate the real class; genuine resolution failures still cache their stub.
- **`MAX_RESOLUTION_DEPTH` 20 → 50** for headroom, now that exceeding it is non-destructive. The `resolvedClasses` cache (cycle-safety) and the 30 s timeout (runaway) remain the real backstops.

## Verification

- `npm run build` — clean (tsc + esbuild)
- `npx vitest run` — 495 passed, 20 skipped
- `npm run lint` — 0 errors

## Notes

Scoped to a single file (`bbj-vscode/src/language/java-interop.ts`). The deeper design point — that resolving one class eagerly pulls its entire transitive type closure synchronously — is real but out of scope here; worth a separate issue if eager-resolution latency ever bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)