### PR TITLE
fix: stop registering "--" config file for DWC/BUI apps (#382)

### DIFF
--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunActionBase.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunActionBase.java
@@ -339,15 +339,27 @@ public abstract class BbjRunActionBase extends AnAction {
     }
 
     /**
-     * Returns the config.bbx path from settings.
+     * Returns the config.bbx path from settings, falling back to the
+     * installation default ({bbjHome}/cfg/config.bbx) when not configured.
      *
-     * @return config path string, or empty string if not configured
+     * The web.bbj registration stub writes this into the EM app's config file,
+     * so it must be a real path: leaving it empty makes BBj report the "--"
+     * sentinel, which registers an unusable config (issue #382).
+     *
+     * @return config path string, or empty string if neither is available
      */
     @NotNull
     protected String getConfigPath() {
         BbjSettings.State state = BbjSettings.getInstance().getState();
         String configPath = state.configPath;
-        return (configPath != null) ? configPath : "";
+        if (configPath != null && !configPath.isEmpty()) {
+            return configPath;
+        }
+        String bbjHome = state.bbjHomePath;
+        if (bbjHome != null && !bbjHome.isEmpty()) {
+            return Paths.get(bbjHome, "cfg", "config.bbx").toString();
+        }
+        return "";
     }
 
     /**

--- a/bbj-vscode/src/Commands/Commands.cjs
+++ b/bbj-vscode/src/Commands/Commands.cjs
@@ -99,8 +99,10 @@ const runWeb = (params, client, credentials) => {
       .slice(0, -1)
       .join(".");
 
-  // Get custom config.bbx path if configured
-  const configPath = vscode.workspace.getConfiguration('bbj').configPath || '';
+  // Get custom config.bbx path if configured; otherwise fall back to the
+  // installation default. This must be a real path so the app registered in EM
+  // never ends up with the "--" sentinel as its config file (issue #382).
+  const configPath = vscode.workspace.getConfiguration('bbj').configPath || `${home}/cfg/config.bbx`;
 
   const cmd = `"${bbj}" -q -WD"${webRunnerWorkingDir}" "${webRunnerWorkingDir}/web.bbj" - "${client}" "${name}" "${programme}" "${workingDir}" "${username}" "${password}" "${sscp}" "${token}" "${configPath}"`;
 

--- a/bbj-vscode/tools/web.bbj
+++ b/bbj-vscode/tools/web.bbj
@@ -59,11 +59,24 @@ app!.setString(app!.NAME, name!)
 app!.setString(app!.PROGRAM, programme!)
 app!.setString(app!.WORKING_DIRECTORY , wd!)
 
-rem Use custom config file if provided, otherwise use system default
+rem Resolve the config file for the registered app.
+rem "--" is the EM Config sentinel meaning "not configured". When no real config
+rem was passed on the command line, fall back to this session's config file - but
+rem only if it too resolves to a real path. getConfigFileName() returns the "--"
+rem sentinel when BBj was started without an explicit -c, which would otherwise
+rem register an unusable config file (issue #382).
+if (configFile! = null() or configFile! = "" or configFile! = "--") then
+    configFile! = ""
+    sessionConfig! = BBjAPI().getConfig().getConfigFileName()
+    if (sessionConfig! <> null() and sessionConfig! > "" and sessionConfig! <> "--") then
+        configFile! = sessionConfig!
+    fi
+fi
+
+rem Only set the config file when we have a real path; never write the "--"
+rem sentinel or an empty value, both of which break the EM launch.
 if (configFile! <> null() and configFile! > "") then
     app!.setString(app!.CONFIG_FILE, configFile!)
-else
-    app!.setString(app!.CONFIG_FILE, BBjAPI().getConfig().getConfigFileName())
 fi
 
 if sscp! <> null() and sscp! > "" and sscp! <> "--" then


### PR DESCRIPTION
Fixes #382

## Problem
When a program is published as a **DWC** or **BUI** app, it gets registered in Enterprise Manager via the `web.bbj` stub. If `bbj.configPath` is **not** set, the registered app's config file ends up as `--`, so launching from EM fails with `/opt/basis/cfg/-- does not exist`. Blanking the field manually then fails with `/opt/basis/cfg/` (empty); the only workaround was to set `bbj.configPath` explicitly.

## Root cause
The extension launches `web.bbj` **without** a `-c` option. When `bbj.configPath` is unset, the stub falls into its fallback branch and writes `BBjAPI().getConfig().getConfigFileName()` into `CONFIG_FILE`. Because the interpreter was started without an explicit config, that call returns the BASIS "not configured" sentinel `--` — the exact same sentinel the classpath code two lines below already guards against.

## Fix
Defense on both the callers and the stub:

- **`bbj-vscode/src/Commands/Commands.cjs`** (`runWeb`): default `configPath` to `{home}/cfg/config.bbx` so a real path is always passed as `ARGV(9)`.
- **`bbj-intellij/.../BbjRunActionBase.java`** (`getConfigPath()`): same `{bbjHome}/cfg/config.bbx` default, covering both `BbjRunDwcAction` and `BbjRunBuiAction`.
- **`bbj-vscode/tools/web.bbj`**: treat an incoming `--`/empty config as "not provided", only accept the session's `getConfigFileName()` fallback when it resolves to a real path, and never write `--` or an empty value into `CONFIG_FILE`.

The GUI `run()` path already passed `-c` and is unaffected.

## Testing
- `Commands.cjs` passes `node --check`; `Paths` was already imported in the Java file.
- No existing automated tests cover the `runWeb`/`web.bbj` registration path (the one `-c` test is for the unrelated compiler flag).
- **Manual smoke test recommended** (requires a live BBj server): with `bbj.configPath` unset, run a program in DWC/BUI and confirm the EM app's config file shows the real `config.bbx` path instead of `--`, and that the app launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)