### PR TITLE
fix: restore BBjAPI()/method-call completions broken after Langium 4.3

### DIFF
--- a/bbj-vscode/src/language/bbj-scope.ts
+++ b/bbj-vscode/src/language/bbj-scope.ts
@@ -80,7 +80,10 @@ export class BbjScopeProvider extends DefaultScopeProvider {
             case 'SimpleTypeRef': {
                 const property = context.property as CrossReferencesOfAstNodeType<typeof container>;
                 if (property === 'simpleClass') {
-                    return this.resolveClassScopeByName(context, container.simpleClass.$refText);
+                    // Read the reference text from context.reference, not from the container:
+                    // during completion Langium passes a synthetic container whose cross-ref
+                    // property is undefined, so container.simpleClass.$refText would throw.
+                    return this.resolveClassScopeByName(context, context.reference.$refText);
                 }
                 return EMPTY_SCOPE;
             }
@@ -88,7 +91,7 @@ export class BbjScopeProvider extends DefaultScopeProvider {
                 assertType<BBjTypeRef>(container);
                 const property = context.property as CrossReferencesOfAstNodeType<typeof container>;
                 if (property === 'klass') {
-                    return this.resolveClassScopeByName(context, container.klass?.$refText);
+                    return this.resolveClassScopeByName(context, context.reference.$refText);
                 }
                 return EMPTY_SCOPE;
             }

--- a/bbj-vscode/src/language/bbj-type-inferer.ts
+++ b/bbj-vscode/src/language/bbj-type-inferer.ts
@@ -1,7 +1,7 @@
 import { AstNode } from "langium";
 import { BBjServices } from "./bbj-module.js";
 import { getClass } from "./bbj-nodedescription-provider.js";
-import { Assignment, Class, Expression, isArrayDecl, isAssignment, isBBjTypeRef, isCastExpression, isClass, isConstructorCall, isFieldDecl, isJavaField, isJavaMethod, isJavaPackage, isMemberCall, isMethodDecl, isSimpleTypeRef, isStringLiteral, isSymbolRef, isVariableDecl, JavaPackage } from "./generated/ast.js";
+import { Assignment, Class, Expression, isArrayDecl, isAssignment, isBBjTypeRef, isCastExpression, isClass, isConstructorCall, isFieldDecl, isJavaField, isJavaMethod, isJavaPackage, isMemberCall, isMethodCall, isMethodDecl, isSimpleTypeRef, isStringLiteral, isSymbolRef, isVariableDecl, JavaPackage } from "./generated/ast.js";
 import { JavaInteropService } from "./java-interop.js";
 
 export interface TypeInferer {
@@ -90,6 +90,11 @@ export class BBjTypeInferer implements TypeInferer {
             return undefined;
         } else if (isStringLiteral(expression)) {
             return this.javaInterop.getResolvedClass('java.lang.String')
+        } else if (isMethodCall(expression)) {
+            // A call expression (e.g. BBjAPI(), obj.foo()) has the type of the
+            // thing being called: for BBjAPI() the method symbol resolves to the
+            // BBjAPI class, for obj.foo() the receiver member yields its return type.
+            return this.getType(expression.method);
         } else if(isBBjTypeRef(expression)) {
             return expression.klass.ref;
         }

--- a/bbj-vscode/test/completion-test.test.ts
+++ b/bbj-vscode/test/completion-test.test.ts
@@ -1,7 +1,7 @@
 
 import { EmptyFileSystem } from 'langium';
 import { expectCompletion } from 'langium/test';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { createBBjTestServices } from './bbj-test-module';
 
 describe('BBJ completion provider', async () => {
@@ -157,6 +157,57 @@ w! = new MyWidget(<|>)
                 // Verify no method (doWork) appears as constructor item
                 const doWorkItem = ctorItems.find(i => i.label.includes('doWork'));
                 expect(doWorkItem).toBeUndefined();
+            }
+        });
+    });
+
+    test('class-reference completion after `new` does not crash (issue: Langium 4.3 synthetic node)', async () => {
+        // Regression: getScope read container.simpleClass.$refText on a synthetic
+        // completion node where simpleClass is undefined, throwing a TypeError that
+        // Langium swallows via console.error inside completionForCrossReference.
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+        try {
+            const text = `
+class public MyClass
+classend
+x! = new <|>
+            `
+            await completion({
+                text,
+                index: 0,
+                assert: () => { }
+            });
+            const refTextCrash = errorSpy.mock.calls.some(args =>
+                args.some(a => a instanceof Error && /\$refText/.test(a.message)));
+            expect(refTextCrash).toBe(false);
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+
+    test('member access on a method-call result infers the return type (regression: BBjAPI())', async () => {
+        // A variable assigned from a call expression must take the call's return
+        // type so member completion works on it. This is the same inference path
+        // that `a! = BBjAPI()` relies on; the isMethodCall branch in the type
+        // inferer was removed as "dead code" and broke it. Uses in-document BBj
+        // classes so it resolves without a populated Java index.
+        const text = `
+class public MyClass
+    method public MyClass getSelf()
+    methodend
+    method public void doWork()
+    methodend
+classend
+declare MyClass m!
+y! = m!.getSelf()
+y!.<|>
+        `
+        await completion({
+            text,
+            index: 0,
+            assert: (completions) => {
+                const methodItems = completions.items.filter(i => i.label.startsWith('doWork'));
+                expect(methodItems.length).toBeGreaterThanOrEqual(1);
             }
         });
     });


### PR DESCRIPTION
## Symptoms (post-Langium 4.3 snapshot)
Code completion broke on `BBjAPI()`-style expressions: `a! = BBjAPI()` then `a!.` shows nothing, and the LS log fills with:

```
TypeError: Cannot read properties of undefined (reading '$refText')
    at BbjScopeProvider.getScope (.../main.cjs)
    at _BBjCompletionProvider.getReferenceCandidates (...)
```

These are two independent regressions.

## 1. `getScope` crash on class-reference completion
Langium 4.3's `completionForCrossReference` now builds a **synthetic container** (`node = { $type: next.type, ... }`) and initializes it with `assignMandatoryProperties`, which leaves single cross-reference properties `undefined`. Our `getScope` read `container.simpleClass.$refText` unconditionally (unlike the sibling `BBjTypeRef` case which used `?.`), so every class-ref completion candidate — e.g. after `new ` — threw. Langium swallows the throw via `console.error`, hence the log spam.

**Fix:** read the reference text from `context.reference.$refText` (which Langium populates in both linking and completion) instead of the container property. Applied to both `SimpleTypeRef` and `BBjTypeRef`.

## 2. No members on a call result (the actual `BBjAPI()` symptom)
Commit 9178757 ("remove dead MethodCall CAST branches") deleted the whole `isMethodCall` branch from the type inferer — but that branch ended in a **live** fallthrough:

```ts
return this.getType(expression.method);
```

Only the CAST-specific sub-branches were dead (CAST has its own `CastExpression` grammar rule). Without the fallthrough, `getType(BBjAPI())` — and any `x = someCall()` — returned `undefined`, leaving the variable untyped so member completion produced nothing.

**Fix:** restore just the fallthrough; the dead CAST sub-branches stay removed.

## Tests
- `console.error` spy asserting the `$refText` crash no longer fires on `new <|>` completion.
- In-document method-call inference case (`y! = m!.getSelf()` → `y!.` offers `doWork`) guarding the restored branch. It uses BBj classes so it resolves without a populated Java index — verified to fail before the fix and pass after.
- Full suite green: **497 passed / 20 skipped**, `tsc --noEmit` clean.

### Note on `BBjAPI()` under EmptyFileSystem
The literal `a! = BBjAPI()` case can't be unit-tested in `EmptyFileSystem` because the fake Java classpath isn't indexed (`IndexManager.allElements(JavaClass)` is empty), so the `bbjapi` linker fallback can't resolve. The added test exercises the identical inference path with resolvable in-document classes. Worth a manual smoke test against a live install to confirm `a! = BBjAPI(); a!.` lists members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)