### PR TITLE
fix: silence LS output-channel noise (ambiguity spam, expected skips)

### DIFF
--- a/bbj-vscode/src/language/bbj-document-builder.ts
+++ b/bbj-vscode/src/language/bbj-document-builder.ts
@@ -316,9 +316,11 @@ export class BBjDocumentBuilder extends DefaultDocumentBuilder {
                     // Could not load from any PREFIX directory; will be reported as a diagnostic
                 }
                 if (docFileData) {
-                    // Skip binary/tokenized BBj files that can't be parsed
+                    // Skip binary/tokenized BBj files that can't be parsed.
+                    // Routine/expected — log at debug so it doesn't surface as an
+                    // error in the output channel for workspaces with tokenized files.
                     if (docFileData.text.startsWith('<<bbj>>')) {
-                        logger.warn(`Skipping binary/tokenized file: ${docFileData.uri.fsPath}`);
+                        logger.debug(`Skipping binary/tokenized file: ${docFileData.uri.fsPath}`);
                         continue;
                     }
                     const document = documentFactory.fromString(docFileData.text, docFileData.uri);

--- a/bbj-vscode/src/language/bbj-module.ts
+++ b/bbj-vscode/src/language/bbj-module.ts
@@ -6,8 +6,10 @@
 
 import {
     DeepPartial,
+    LangiumCompletionParser,
     LangiumParser,
     Module,
+    createParser,
     inject,
     prepareLangiumParser
 } from 'langium';
@@ -101,6 +103,7 @@ export const BBjModule: Module<BBjServices, PartialLangiumServices & BBjAddedSer
     },
     parser: {
         LangiumParser: (services) => createBBjParser(services),
+        CompletionParser: (services) => createBBjCompletionParser(services),
         ValueConverter: () => new BBjValueConverter(),
         TokenBuilder: () => new BBjTokenBuilder(),
         Lexer: services => new BbjLexer(services)
@@ -112,10 +115,14 @@ export const BBjModule: Module<BBjServices, PartialLangiumServices & BBjAddedSer
 
 let ambiguitiesReported = false;
 
-function createBBjParser(services: LangiumServices): LangiumParser {
-    const parser = prepareLangiumParser(services);
-    // Customize ambiguity logging
-    const lookaheadStrategy = (parser as any).wrapper.lookaheadStrategy
+/**
+ * Reroute Chevrotain's ambiguity logging (from chevrotain-allstar's LLStar
+ * lookahead strategy) so it doesn't spam the LS output channel. The strategy
+ * captures `this.logging` into its per-alternation prediction closures during
+ * `finalize()`, so this MUST run before `finalize()` to take effect at runtime.
+ */
+function overrideAmbiguityLogging(parser: LangiumParser | LangiumCompletionParser): void {
+    const lookaheadStrategy = (parser as any).wrapper?.lookaheadStrategy;
     if (lookaheadStrategy) {
         lookaheadStrategy.logging = (message: string) => {
             if (logger.isDebug()) {
@@ -126,6 +133,27 @@ function createBBjParser(services: LangiumServices): LangiumParser {
             }
         }
     }
+}
+
+function createBBjParser(services: LangiumServices): LangiumParser {
+    const parser = prepareLangiumParser(services);
+    overrideAmbiguityLogging(parser);
+    parser.finalize();
+    return parser;
+}
+
+/**
+ * Mirror of Langium's createCompletionParser, but overriding ambiguity logging
+ * before finalize(). Without a custom CompletionParser the default one keeps
+ * chevrotain's console.log logging, leaking "Ambiguous Alternatives Detected"
+ * noise during completion (the main LangiumParser is already handled above).
+ */
+function createBBjCompletionParser(services: LangiumServices): LangiumCompletionParser {
+    const grammar = services.Grammar;
+    const lexer = services.parser.Lexer;
+    const parser = new LangiumCompletionParser(services);
+    createParser(grammar, parser, lexer.definition);
+    overrideAmbiguityLogging(parser);
     parser.finalize();
     return parser;
 }

--- a/bbj-vscode/src/language/bbj-scope-local.ts
+++ b/bbj-vscode/src/language/bbj-scope-local.ts
@@ -156,7 +156,11 @@ export class BbjScopeComputation extends DefaultScopeComputation {
                     return;
                 }
                 if (javaClass.error) {
-                    logger.warn(`Java '${javaClassName}' class resolution error: ${javaClass.error}`)
+                    // An unresolved USE also surfaces as a linking diagnostic on the
+                    // reference (the class is not added to scope below), so keep this
+                    // at debug to avoid alarming [error] noise for classes that simply
+                    // aren't on the BBj classpath (e.g. org.mockito.Mockito in tests).
+                    logger.debug(`Java '${javaClassName}' class resolution error: ${javaClass.error}`)
                     return;
                 }
                 const program = node.$container;

--- a/bbj-vscode/test/parser-ambiguity-logging.test.ts
+++ b/bbj-vscode/test/parser-ambiguity-logging.test.ts
@@ -1,0 +1,35 @@
+import { EmptyFileSystem } from 'langium';
+import { expectCompletion } from 'langium/test';
+import { describe, expect, test, vi } from 'vitest';
+import { createBBjTestServices } from './bbj-test-module';
+
+// Regression: chevrotain-allstar's lookahead strategy logs "Ambiguous Alternatives
+// Detected" via console.log. The main LangiumParser reroutes that to the debug
+// logger, but the CompletionParser was left with the default logging and leaked
+// raw messages into the LS output channel during completion. Both parsers must
+// suppress it now.
+describe('parser ambiguity logging', () => {
+    const services = createBBjTestServices(EmptyFileSystem).BBj;
+
+    test('both main and completion parsers reroute ambiguity logging', () => {
+        for (const parser of [services.parser.LangiumParser, services.parser.CompletionParser]) {
+            const logging = (parser as any).wrapper?.lookaheadStrategy?.logging;
+            expect(typeof logging).toBe('function');
+            expect(String(logging)).toContain('isDebug');
+        }
+    });
+
+    test('completion does not print raw ambiguity noise to console.log', async () => {
+        const spy = vi.spyOn(console, 'log').mockImplementation(() => { });
+        try {
+            const completion = expectCompletion(services);
+            // Statement-position completion exercises the ambiguous SingleStatement OR.
+            await completion({ text: `bye\n<|>`, index: 0, assert: () => { } });
+            const leaked = spy.mock.calls.some(args =>
+                args.some(a => typeof a === 'string' && /Ambiguous Alternatives|prefix path/.test(a)));
+            expect(leaked).toBe(false);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+});


### PR DESCRIPTION
Follow-up to the Langium 4.3 shakeout (#411). Examines and quiets three sources of alarming output-channel noise seen in the v0.8.19 snapshot, none of which indicate a real problem.

## 1. `Ambiguous Alternatives Detected …` spam during completion
chevrotain-allstar's LLStar lookahead strategy logs grammar ambiguities via `console.log`. The main `LangiumParser` already reroutes this to the debug logger (`createBBjParser` → `overrideAmbiguityLogging`), but the **`CompletionParser`** used Langium's default builder, which kept chevrotain's `console.log`. That's why the messages appeared *during completion* (interleaved with the crashes in #411).

chevrotain captures the `logging` callback into its per-alternation prediction closures at `finalize()` time, so patching `.logging` after `createCompletionParser` (which finalizes internally) is too late. Added `createBBjCompletionParser` that mirrors Langium's builder (`new LangiumCompletionParser` → `createParser` → override → `finalize`) and wired it as the `CompletionParser` service.

Verified: before, `CompletionParser.wrapper.lookaheadStrategy.logging` was `(message) => console.log(message)`; after, it's the debug-routed override — same as the main parser.

## 2. `Skipping binary/tokenized file: …` at `[error]`
Logged at `warn` (renders as `[error]`) for every tokenized `.bbj` reached during `USE` resolution. This is routine/expected behavior — downgraded to `debug`.

## 3. `Java '…' class resolution error: …` at `[error]`
Logged at `warn` when a `USE`d Java class isn't on the BBj classpath (e.g. `org.mockito.Mockito`). The unresolved reference already produces a linking diagnostic (scope-local returns early without adding it to scope), so the log line is redundant — downgraded to `debug`.

All three remain visible with `bbj.debug: true` (which raises the logger to `DEBUG`).

## Tests
- New `parser-ambiguity-logging.test.ts`: asserts both the main and completion parsers reroute ambiguity logging, and that a completion request prints no raw `Ambiguous Alternatives` / `prefix path` text to `console.log`.
- Full suite: **499 passed / 20 skipped**, `tsc --noEmit` clean.

### Note
The underlying grammar ambiguities themselves are pre-existing and intentional (e.g. `SingleStatement` orders `KeywordStatement` first on purpose). This PR only stops the noise; it does not change parsing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)