### PR TITLE
Fix #240: resolve #field! instance access to inherited fields on assignment LHS

### DIFF
--- a/bbj-vscode/src/language/bbj-scope.ts
+++ b/bbj-vscode/src/language/bbj-scope.ts
@@ -27,6 +27,7 @@ import { logger } from './logger.js';
 import {
     BBjAstType,
     BbjClass, BBjTypeRef, Class,
+    isAssignment,
     isBbjClass,
     isBinaryExpression,
     isCallbackStatement,
@@ -217,7 +218,11 @@ export class BbjScopeProvider extends DefaultScopeProvider {
             var membersStream = EMPTY_STREAM;
             const bbjType = AstUtils.getContainerOfType(context.container, isBbjClass)
             if (bbjType) {
-                if (context.container.instanceAccess) {
+                // Instance access is either flagged on the SymbolRef itself (e.g. `#field!`
+                // in expression position) or, on an assignment LHS like `#field! = value`,
+                // consumed by the enclosing Assignment's `instanceAccess` (the grammar binds
+                // the `#` to the Assignment rule, not the inner SymbolRef).
+                if (context.container.instanceAccess || isInstanceAccessAssignment(context.container)) {
                     membersStream = this.createBBjClassMemberScope(bbjType, false, new Set()).getAllElements()
                 }
             }
@@ -474,6 +479,24 @@ export class BbjNameProvider extends DefaultNameProvider {
     }
 }
 
+
+/**
+ * Detects whether `node` is the head symbol of an assignment LHS that carries
+ * instance access, i.e. `#field! = value` or `#field!.member = value`. In the
+ * grammar the leading `#` is consumed by the `Assignment.instanceAccess` slot
+ * rather than the inner `SymbolRef`, so the SymbolRef's own `instanceAccess`
+ * flag is false and must be recovered from the enclosing Assignment.
+ */
+function isInstanceAccessAssignment(node: AstNode): boolean {
+    // Walk up any `receiver` chain (e.g. `#a!.b! = v` links from the `a!` receiver).
+    let current: AstNode = node;
+    while (isMemberCall(current.$container) && current.$containerProperty === 'receiver') {
+        current = current.$container;
+    }
+    return isAssignment(current.$container)
+        && current.$containerProperty === 'variable'
+        && current.$container.instanceAccess === true;
+}
 
 export function collectAllUseStatements(program: Program): Use[] {
     // Check if USE statements are already cached in the document

--- a/bbj-vscode/test/linking.test.ts
+++ b/bbj-vscode/test/linking.test.ts
@@ -269,6 +269,29 @@ describe('Linking Tests', async () => {
         expectNoErrors(document)
     })
 
+    test('Instance access (#field!) to super class field on assignment LHS - issue #240', async () => {
+        // The leading `#` of an assignment LHS is consumed by the Assignment rule,
+        // not the inner SymbolRef, so instance access must still resolve inherited fields.
+        const document = await validate(`
+            class public SuperParent
+            classend
+
+            class public Parent extends SuperParent
+                field public Parent someField!
+            classend
+
+            class public Child extends Parent
+                method public void someMethod()
+                    #someField! = new Parent()  REM <== inherited field, instance access on LHS
+                methodend
+            classend
+
+            c! = new Child()
+            c!.someMethod()
+        `)
+        expectNoErrors(document)
+    })
+
     describe.runIf(isInteropRunning)("Interop related tests", () => {
         test('All BBj classes extends Object', async () => {
             const document = await validate(`


### PR DESCRIPTION
## Summary

Fixes #240. Shortened member access via `#field!` on an **assignment left-hand side** (e.g. `#SomeString! = "TEST"`) failed to link to fields inherited from a super class, reporting `Could not resolve reference to NamedElement named 'SomeString!'`. Explicit `#super!.setField(...)` access already worked; this covers the `#field!` shorthand form from the issue.

## Root cause

In `bbj.langium`, the assignment rule binds the leading `#` to the **Assignment** node, not the inner reference:

```
Assignment: instanceAccess?='#'? variable=MemberCall '=' value=Expression;
```

So for `#SomeString! = ...` the `#` is consumed by `Assignment.instanceAccess`, and the inner `SomeString!` becomes a `SymbolRef` whose **own** `instanceAccess` is `false`. The scope provider only pulled inherited class members into scope when `context.container.instanceAccess` (the SymbolRef's flag) was true, so an assignment LHS never saw super-class members. The `.`-member path (`obj!.field!`) was unaffected, which is why earlier inheritance fixes didn't catch this.

## Fix

`bbj-scope.ts` — in the `isSymbolRef` scope branch, also treat the reference as instance access when it is the head symbol of an assignment `variable` whose `Assignment` carries `instanceAccess`. New `isInstanceAccessAssignment` helper walks up any `receiver` chain, so both `#field! = v` and `#a!.b! = v` are covered.

## Testing

- New regression test in `linking.test.ts` ("Instance access (#field!) to super class field on assignment LHS - issue #240").
- Full suite green: **498 passed / 20 skipped**; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)