### PR TITLE
Fix #389: identifiers starting with "rem" no longer lexed as remarks

### DIFF
--- a/bbj-vscode/src/language/bbj.langium
+++ b/bbj-vscode/src/language/bbj.langium
@@ -917,7 +917,7 @@ LibEventType returns LibEventType:
 SymbolicLabelName returns string: ASTERISK_EXPRESSION ValidName;
 
 hidden terminal WS: /\s+/;
-terminal COMMENT: /([rR][eE][mM])([ \t][^\n\r]*)?([\n\r]+)?/; // (rEm)(space or tab)(all but linebreak)(optional linebreak)
+terminal COMMENT: /([rR][eE][mM])(?![\w!$%@])([ \t][^\n\r]*)?([\n\r]+)?/; // (rEm)(not an identifier/suffix char, so "rem15"/"remark" stay identifiers)(space or tab)(all but linebreak)(optional linebreak)
 
 terminal KEYWORD_STANDALONE: /_KEYWORD_STANDALONE/;
 terminal PRINT_STANDALONE_NL: /_PRINT_STANDALONE_NL/;

--- a/bbj-vscode/test/document-symbol.test.ts
+++ b/bbj-vscode/test/document-symbol.test.ts
@@ -49,6 +49,38 @@ describe('DocumentSymbol Tests', async () => {
 
     })
 
+    test('issue #389: variables starting with "rem" keep the class in the outline', async () => {
+        // "rem" is the remark/comment keyword, but identifiers such as rem15, remark1,
+        // remmedOutStuff! or remainingSeconds must NOT be lexed as a comment — otherwise
+        // the whole class (and every class after it) drops out of the outline.
+        const document = await validate(`
+            class public Test
+                method public static BBjString doTheThing()
+                    predictedSecs = 42
+                    rem15 = mod(predictedSecs, 15)
+                    predictedSecs = predictedSecs - rem15
+                    predictedSecs = predictedSecs - remark1
+                    mySales = remmedOutStuff!
+                    remainingSeconds = 18
+                    print "Seconds: ", remainingSeconds
+                methodend
+            classend
+
+            class public AfterTest
+                method public void other()
+                methodend
+            classend
+        `)
+        expectNoErrors(document)
+
+        const symbols = await documentSymbolProvider.getSymbols(document, { textDocument: { uri: document.uri.toString() } });
+        const allNames = flattenSymbolNames(symbols);
+        expect(allNames).toContain('Test');
+        expect(allNames).toContain('doTheThing');
+        // The class after the offending lines must still appear as well
+        expect(allNames).toContain('AfterTest');
+    })
+
     test('symbols survive broken method body', async () => {
         // A class with a broken method body (lexer error mid-body) followed by a valid method.
         // The BBj parser recovers at METHODEND and continues, so both methods appear in the AST.


### PR DESCRIPTION
## Problem

Fixes #389. Any variable whose name begins with `rem` (e.g. `rem15`, `remark1`, `remmedOutStuff!`, `remainingSeconds`) caused the containing method and class — and **every class after it in the file** — to disappear from the Outline.

## Root cause

The `COMMENT` terminal in `bbj.langium` recognizes BBj remarks (`rem`):

```
/([rR][eE][mM])([ \t][^\n\r]*)?([\n\r]+)?/
```

Both the trailing-text and newline groups are optional, so it matched a bare `rem` even when immediately followed by identifier characters. Langium's Chevrotain lexer selects the **first** token type in definition order that matches at the current position (not the longest match), and `COMMENT` is defined before `ID`. So `remainingSeconds` lexed as `COMMENT("rem")` + `ID("ainingSeconds")`, which broke the statement and dropped the enclosing class (and all following classes) from the parse tree / Outline.

## Fix

Add a negative lookahead so `rem` is only treated as a remark when it is a complete word — not followed by a word char or a BBj variable suffix (`!`, `$`, `%`, `@`):

```
/([rR][eE][mM])(?![\w!$%@])([ \t][^\n\r]*)?([\n\r]+)?/
```

Genuine remarks (`rem`, `REM comment`, `rem` at end-of-line, `x;REM …`) are unchanged; identifiers beginning with `rem` now stay identifiers.

## Tests

- Added a regression test in `test/document-symbol.test.ts` using the reporter's own examples, asserting the class, its method, and a following class all remain in the outline.
- Full suite green: 501 passed, 20 skipped (skips require a live BBj/Java-interop backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)