### PR TITLE
Fix #226: parse single-line DEF FN inside class methods

### DIFF
--- a/bbj-vscode/src/language/bbj.langium
+++ b/bbj-vscode/src/language/bbj.langium
@@ -360,7 +360,7 @@ MethodDecl returns MethodDecl:
     MethodDeclStart
     Comments?
     (
-        (body+=(Statement | DefFunction))*
+        (body+=(DefFunction | Statement))*
         endTag='METHODEND'
     )?
 ;

--- a/bbj-vscode/test/validation.test.ts
+++ b/bbj-vscode/test/validation.test.ts
@@ -9,7 +9,7 @@ import { beforeAll, describe, expect, test } from 'vitest';
 
 import { expectError, expectNoIssues, validationHelper } from 'langium/test';
 import { createBBjServices } from '../src/language/bbj-module.js';
-import { Program, isBinaryExpression, isEraseStatement, isInitFileStatement, isKeyedFileStatement, isKeywordStatement, isSymbolicLabelRef, isMemberCall, BbjClass, FieldDecl, MethodDecl, isLabelDecl } from '../src/language/generated/ast.js';
+import { Program, isBinaryExpression, isDefFunction, isEraseStatement, isInitFileStatement, isKeyedFileStatement, isKeywordStatement, isSymbolicLabelRef, isMemberCall, BbjClass, FieldDecl, MethodDecl, isLabelDecl } from '../src/language/generated/ast.js';
 import { findByIndex, findFirst, initializeWorkspace } from './test-helper.js';
 
 describe('BBj validation', async () => {
@@ -214,13 +214,11 @@ describe('BBj validation', async () => {
         });
     });
 
-    test.skip('Single-line DEF FN inside class method has no line-break errors', async () => {
-        // SKIP: This test reveals a parser bug where single-line DEF FN inside methods
-        // is not being parsed as DefFunction by the validate helper, even though it works
-        // in the parser.test.ts (which uses parseHelper with validation:false).
-        // The validation fix (isDefFunction in isStandaloneStatement) IS correct and would
-        // prevent line-break errors IF the parser correctly identified the DefFunction node.
-        // Multi-line DEF FN works correctly, proving the validation fix is effective.
+    test('Single-line DEF FN inside class method has no line-break errors (#226)', async () => {
+        // Regression for #226: single-line `DEF FN(...)=expr` inside a method must be parsed
+        // as a DefFunction. Because the DEF keyword is also in the ID category, the parser used
+        // to prefer the `Statement` alternative and split the line into `def` + `FNSquare(X)=X*X`,
+        // producing spurious line-break errors. The method-body rule now tries DefFunction first.
         const validationResult = await validate(`
             class public MathHelper
                 method public doMath()
@@ -230,8 +228,25 @@ describe('BBj validation', async () => {
                 methodend
             classend
         `);
+        // The single-line DEF FN must actually be parsed as a DefFunction node...
+        expect(findFirst(validationResult.document, isDefFunction, true)).toBeDefined();
+        // ...and produce no line-break errors.
         const lineBreakErrors = validationResult.diagnostics.filter(d => d.message.includes('line break'));
-        expect(lineBreakErrors.length).toBe(0);
+        expect(lineBreakErrors.map(d => d.message)).toEqual([]);
+    });
+
+    test('Single-line DEF FN with nested call inside class method (#226)', async () => {
+        // The exact reproducer from issue #226.
+        const validationResult = await validate(`
+            class public BBDialog
+                method public void get_active_func(BBjNamespaceEvent pEvent!)
+                    def fnstr_pos(tmp0$,tmp1$,tmp0)=int((pos(tmp0$=tmp1$,tmp0)+tmp0-1)/tmp0)
+                methodend
+            classend
+        `);
+        expect(findFirst(validationResult.document, isDefFunction, true)).toBeDefined();
+        const lineBreakErrors = validationResult.diagnostics.filter(d => d.message.includes('line break'));
+        expect(lineBreakErrors.map(d => d.message)).toEqual([]);
     });
 
     test('Multi-line DEF FN inside class method still works', async () => {


### PR DESCRIPTION
## Problem

Fixes #226. A single-line `DEF FN(...)=expr` inside a class method was flagged with spurious line-break errors:

```
class public BBDialog
    method public void get_active_func(BBjNamespaceEvent pEvent!)
        def fnstr_pos(tmp0$,tmp1$,tmp0)=int((pos(tmp0$=tmp1$,tmp0)+tmp0-1)/tmp0)
    methodend
classend
```

→ `This statement needs to end with a line break: def` and `This statement needs to start in a new line: fnstr_pos(...)`.

## Root cause

The `DEF` keyword is registered in the `ID` token category (in `bbj-token-builder.ts`) so it can also be used as an identifier. In a method body — `body+=(Statement | DefFunction)` — that made `def` a valid start for the `Statement` alternative, so the parser split the line into a bare `def` expression statement plus a `fnstr_pos(...)=…` `LetStatement`, and the line-break validator then (correctly, given that broken parse) complained.

Confirmed by dumping the AST: the same line parses as a `DefFunction` at program scope but as `ExpressionStatement("def")` + `LetStatement` inside a method.

## Fix

Try `DefFunction` before `Statement` in the method-body rule so `def` is recognized as the start of a function definition — matching how the program-scope rule already resolves it:

```diff
-        (body+=(Statement | DefFunction))*
+        (body+=(DefFunction | Statement))*
```

Multi-line `DEF FN … FNEND` and program-scope single-line `DEF FN` were already correct (handled by an earlier validation fix); this completes the parser side.

## Tests

- Un-skipped the previously blocked regression test `Single-line DEF FN inside class method has no line-break errors (#226)` and strengthened it to assert the line is actually parsed as a `DefFunction` node.
- Added a second test using the exact reproducer from the issue.
- Full suite green: 501 passed, 19 skipped (skips require a live BBj/Java-interop backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)