### PR TITLE
Fix #269: consistent coloring of instance-access "#"

### DIFF
--- a/bbj-vscode/src/language/bbj-semantic-token-provider.ts
+++ b/bbj-vscode/src/language/bbj-semantic-token-provider.ts
@@ -1,6 +1,6 @@
 import { AstNode } from "langium";
 import { AbstractSemanticTokenProvider, LangiumServices, SemanticTokenAcceptor } from "langium/lsp";
-import { SymbolRef, ParameterDecl, MethodCall } from "./generated/ast.js";
+import { SymbolRef, ParameterDecl, MethodCall, Assignment } from "./generated/ast.js";
 import { SemanticTokenTypes } from "vscode-languageserver-types";
 
 export class BBjSemanticTokenProvider extends AbstractSemanticTokenProvider {
@@ -16,6 +16,11 @@ export class BBjSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 return this.highlightSymbolRef(node as SymbolRef, acceptor);
             case MethodCall.$type:
                 return this.highlightMethodCall(node as MethodCall, acceptor);
+            case Assignment.$type:
+                // Highlight the leading '#' (instance access) so it matches the '#' on a
+                // SymbolRef; otherwise `#field! = ...` colors the '#' differently than
+                // `#field!.method()` (issue #269).
+                return acceptor({ node: node as Assignment, property: 'instanceAccess', type: SemanticTokenTypes.keyword });
         }
     }
     

--- a/bbj-vscode/test/functional/lsp-features.test.ts
+++ b/bbj-vscode/test/functional/lsp-features.test.ts
@@ -256,6 +256,44 @@ describe('LSP Feature Verification Tests', async () => {
                 expect(semanticTokenProvider).toBeDefined();
             }
         });
+
+        test('instance-access "#" is highlighted consistently in assignment and member call (#269)', async () => {
+            // Regression for #269: the leading '#' was highlighted on a SymbolRef
+            // (`#field!.method()`) but NOT on an assignment LHS (`#field! = ...`),
+            // so the same '#' got different colors.
+            const src = [
+                'class public MyApp',
+                '    field private BBjString myString!',
+                '    method public MyApp()',
+                '        #myString! = "asdf"',              // assignment LHS '#'
+                '        #myString! = #myString! + "1234"',  // LHS '#' and member-ref '#'
+                '    methodend',
+                'classend',
+            ].join('\n');
+            const document = await parse(src, { validation: true });
+            expectNoErrors(document);
+
+            const provider = services.BBj.lsp.SemanticTokenProvider!;
+            const tokens = await provider.semanticHighlight(document, { textDocument: { uri: document.uri.toString() } });
+
+            // Decode the relative-encoded token stream and keep the ones sitting on a '#'.
+            const lines = src.split('\n');
+            const data = tokens.data;
+            const hashTypes: number[] = [];
+            let line = 0, char = 0;
+            for (let i = 0; i < data.length; i += 5) {
+                line += data[i];
+                char = data[i] === 0 ? char + data[i + 1] : data[i + 1];
+                const length = data[i + 2];
+                if (length === 1 && lines[line]?.charAt(char) === '#') {
+                    hashTypes.push(data[i + 3]);
+                }
+            }
+
+            // All three '#' occurrences must be highlighted, and with the same token type.
+            expect(hashTypes.length).toBe(3);
+            expect(new Set(hashTypes).size).toBe(1);
+        });
     });
 
     // Combined test: Multiple LSP features working together


### PR DESCRIPTION
## Problem

Fixes #269. The instance-access `#` prefix was colored inconsistently: black on an assignment LHS (`#field! = ...`) but highlighted (keyword color) when used as a member-call receiver (`#field!.method()`).

## Root cause

The `#` is the `instanceAccess` property on two AST nodes: `SymbolRef` (line 819 of `bbj.langium`) and `Assignment` (line 317). `BBjSemanticTokenProvider` emitted a `keyword` token for `SymbolRef.instanceAccess` but had **no case for `Assignment`**, so the `#` on an assignment LHS got no semantic token and fell back to the default color.

## Fix

Add an `Assignment` case that highlights its `instanceAccess` property as a `keyword`, matching `SymbolRef`:

```ts
case Assignment.$type:
    return acceptor({ node: node as Assignment, property: 'instanceAccess', type: SemanticTokenTypes.keyword });
```

## Tests

Added a regression test in `test/functional/lsp-features.test.ts` that decodes the semantic-token stream and asserts all three `#` occurrences (two assignment LHS + one member-ref) are highlighted with the same token type. Verified the test fails without the fix (`expected 1 to be 3`) and passes with it.

Full suite green: 500 passed, 20 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)