### PR TITLE
Fix #64: recognize line-numbered programs and offer denumber / read-only

### DIFF
--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -306,6 +306,12 @@
           "description": "When opening a tokenized (binary) BBj program, prompt to decompile it to editable source (replacing the file) or open a read-only decompiled copy.",
           "scope": "window"
         },
+        "bbj.denumber.promptOnOpen": {
+          "type": "boolean",
+          "default": true,
+          "description": "When opening a line-numbered BBj program, prompt to denumber it (replacing the file with editable source) or open it read-only.",
+          "scope": "window"
+        },
         "bbj.formatter.indentWidth": {
           "type": "number",
           "default": 2,

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -14,6 +14,7 @@ import {
 import { BBjLibraryFileSystemProvider } from './language/lib/fs-provider.js';
 import { DocumentFormatter } from './document-formatter.js';
 import { isTokenizedBBjHeader, TOKENIZED_BBJ_MAGIC_LENGTH } from './tokenized-bbj.js';
+import { isLineNumberedSource } from './line-numbering.js';
 import {
     OPTION_GROUP_ORDER,
     getOptionsGrouped,
@@ -531,6 +532,42 @@ async function maybePromptTokenized(uri: vscode.Uri | undefined): Promise<void> 
     }
 }
 
+// Tracks documents we've already prompted about this session, so switching
+// back to a line-numbered editor doesn't nag the user again.
+const promptedLineNumberedDocs = new Set<string>();
+
+/**
+ * When a line-numbered BBj program is opened, ask whether to denumber it
+ * (replacing the file with editable source) or open it read-only (issue #64).
+ */
+async function maybePromptLineNumbered(editor: vscode.TextEditor | undefined): Promise<void> {
+    if (!editor) return;
+    const doc = editor.document;
+    if (doc.languageId !== 'bbj' || doc.uri.scheme !== 'file') return;
+    if (!vscode.workspace.getConfiguration('bbj').get<boolean>('denumber.promptOnOpen', true)) return;
+
+    const key = doc.uri.toString();
+    if (promptedLineNumberedDocs.has(key)) return;
+    if (!isLineNumberedSource(doc.getText())) return;
+    promptedLineNumberedDocs.add(key);
+
+    const denumberAction = 'Denumber & Replace';
+    const readOnlyAction = 'Open Read-only';
+    const choice = await vscode.window.showInformationMessage(
+        `"${path.basename(doc.fileName)}" is a line-numbered BBj program. Denumber it to editable source, or open it read-only?`,
+        denumberAction, readOnlyAction
+    );
+    if (choice === denumberAction) {
+        // bbj.denumber runs bbjlst and replaces the file in place with denumbered source.
+        vscode.commands.executeCommand('bbj.denumber', doc.uri);
+    } else if (choice === readOnlyAction) {
+        // Make sure our editor is the active one before flipping it read-only in-session,
+        // in case the user navigated away while the prompt was open.
+        await vscode.window.showTextDocument(doc, { preview: false });
+        await vscode.commands.executeCommand('workbench.action.files.setActiveEditorReadonlyInSession');
+    }
+}
+
 // This function is called when the extension is activated.
 export function activate(context: vscode.ExtensionContext): void {
     BBjLibraryFileSystemProvider.register(context);
@@ -715,6 +752,13 @@ export function activate(context: vscode.ExtensionContext): void {
             void maybePromptTokenized(uriFromTab(tab));
         }
     }
+
+    // Offer to denumber (or open read-only) when a line-numbered BBj program is opened.
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor((editor) => { void maybePromptLineNumbered(editor); })
+    );
+    // Handle the editor that is already active when the extension activates.
+    void maybePromptLineNumbered(vscode.window.activeTextEditor);
 
     // Diagnostic suppression status bar indicator
     const suppressionStatusBar = vscode.window.createStatusBarItem(

--- a/bbj-vscode/src/line-numbering.ts
+++ b/bbj-vscode/src/line-numbering.ts
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright 2024 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+/**
+ * Detects whether a BBj source text is a classic *line-numbered* program.
+ *
+ * Legacy BBx/BBj programs prefix every statement line with an incrementing
+ * integer line number, e.g.:
+ *
+ *     0010 LET A=5
+ *     0020 PRINT A
+ *     0030 END
+ *
+ * Modern (unnumbered) BBj source never does this. The check is intentionally
+ * strict — it only reports `true` when *every* inspected non-blank line carries
+ * a line number — so it does not nag users who are editing ordinary source.
+ * Numeric labels such as `0010:` are not line numbers (no whitespace separates
+ * the digits from the statement) and are therefore not counted.
+ *
+ * @param text raw file contents
+ * @returns true if the text looks like a uniformly line-numbered program
+ */
+export function isLineNumberedSource(text: string): boolean {
+    // A line number is a run of digits followed by horizontal whitespace and
+    // then the start of a statement. `0010:` (a numeric label) does not match.
+    const numberedLine = /^\s*\d+[ \t]+\S/;
+    // Sample enough non-blank lines to be confident without scanning huge files.
+    const maxLinesToInspect = 20;
+    // Require a few lines so a one-liner starting with a number can't false-trigger.
+    const minLinesToDecide = 3;
+
+    let inspected = 0;
+    for (const line of text.split(/\r?\n/)) {
+        if (line.trim().length === 0) {
+            continue;
+        }
+        // A numbered program is uniform: a single unnumbered statement rejects it.
+        if (!numberedLine.test(line)) {
+            return false;
+        }
+        if (++inspected >= maxLinesToInspect) {
+            break;
+        }
+    }
+    return inspected >= minLinesToDecide;
+}

--- a/bbj-vscode/test/line-numbering.test.ts
+++ b/bbj-vscode/test/line-numbering.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+import { isLineNumberedSource } from '../src/line-numbering.js';
+
+describe('isLineNumberedSource', () => {
+    test('detects a classic line-numbered program', () => {
+        expect(isLineNumberedSource(
+            '0010 LET A=5\n' +
+            '0020 PRINT A\n' +
+            '0030 END\n'
+        )).toBe(true);
+    });
+
+    test('ignores blank lines between numbered statements', () => {
+        expect(isLineNumberedSource(
+            '\n' +
+            '0010 LET A=5\n' +
+            '\n' +
+            '0020 PRINT A\n' +
+            '0030 GOTO 0010\n'
+        )).toBe(true);
+    });
+
+    test('accepts numbered REM lines (whole program is numbered)', () => {
+        expect(isLineNumberedSource(
+            '00010 REM my program\n' +
+            '00020 PRINT "hi"\n' +
+            '00030 STOP\n'
+        )).toBe(true);
+    });
+
+    test('rejects modern unnumbered source', () => {
+        expect(isLineNumberedSource(
+            'class public MyApp\n' +
+            '    method public void run()\n' +
+            '        print "hi"\n' +
+            '    methodend\n' +
+            'classend\n'
+        )).toBe(false);
+    });
+
+    test('rejects a mix (a single unnumbered statement disqualifies)', () => {
+        expect(isLineNumberedSource(
+            '0010 LET A=5\n' +
+            'PRINT A\n' +
+            '0030 END\n'
+        )).toBe(false);
+    });
+
+    test('does not treat numeric labels as line numbers', () => {
+        // `0010:` is a label, not a line number — no whitespace before the statement.
+        expect(isLineNumberedSource(
+            '0010:\n' +
+            '    print "hi"\n' +
+            '    goto 0010\n'
+        )).toBe(false);
+    });
+
+    test('too few lines to decide → false', () => {
+        expect(isLineNumberedSource('0010 PRINT "hi"\n')).toBe(false);
+    });
+
+    test('handles CRLF line endings', () => {
+        expect(isLineNumberedSource(
+            '0010 LET A=5\r\n' +
+            '0020 PRINT A\r\n' +
+            '0030 END\r\n'
+        )).toBe(true);
+    });
+
+    test('empty input → false', () => {
+        expect(isLineNumberedSource('')).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

Fixes #64. When a classic **line-numbered** BBj program is opened, the extension now detects it and prompts:

> `"foo.bbj" is a line-numbered BBj program. Denumber it to editable source, or open it read-only?`
> **[ Denumber & Replace ]  [ Open Read-only ]**

- **Denumber & Replace** — invokes the existing `bbj.denumber` command, which runs `bbjlst` and replaces the file in place with editable, unnumbered source.
- **Open Read-only** — flips the editor to read-only for the session (`workbench.action.files.setActiveEditorReadonlyInSession`), so the numbered listing can be viewed without accidental edits.
- Dismissing the prompt leaves the file as-is.

## Detection

Detection lives in a small pure helper, `isLineNumberedSource(text)` (no `vscode` import, so it's unit-testable). It is deliberately **strict** — every inspected non-blank line must begin with a line number (`0010 LET A=5`) — so:
- ordinary modern source is never flagged (no nagging), and
- numeric labels like `0010:` are **not** mistaken for line numbers (no whitespace before the statement).

At least 3 non-blank lines are required before it will decide, and at most 20 are sampled.

## Wiring & config

- Hooked via `onDidChangeActiveTextEditor` plus the already-active editor at activation time; each document is prompted at most once per session.
- New setting **`bbj.denumber.promptOnOpen`** (boolean, default `true`) to disable the behavior.

## Tests

- Added `test/line-numbering.test.ts` (9 cases): numbered programs, blank-line handling, numbered REM lines, CRLF, and negative cases (modern source, mixed, numeric labels, too-few-lines, empty).
- `npm run build` (tsc + esbuild) and `eslint` clean.
- Full suite: 508 passed, 20 skipped.

## Note

The prompt/read-only wiring in `extension.ts` runs only in the VS Code extension host and isn't covered by the (non-extension-host) unit tests, consistent with the rest of `extension.ts`; the detection logic it depends on is fully unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)