### PR TITLE
Fix #65: detect tokenized BBj programs on open and offer to decompile

### DIFF
--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -137,6 +137,16 @@
           "dark": "./images/bbj-denumber-dark.svg"
         },
         "key": "alt+n"
+      },
+      {
+        "category": "BBj",
+        "command": "bbj.decompile",
+        "title": "Decompile Tokenized BBj Program (Replace)"
+      },
+      {
+        "category": "BBj",
+        "command": "bbj.decompileReadonly",
+        "title": "Decompile Tokenized BBj Program (Read-only)"
       }
     ],
     "keybindings": [
@@ -288,6 +298,12 @@
           "type": "boolean",
           "default": false,
           "description": "Auto Save upon run of BBj program",
+          "scope": "window"
+        },
+        "bbj.decompile.promptOnOpen": {
+          "type": "boolean",
+          "default": true,
+          "description": "When opening a tokenized (binary) BBj program, prompt to decompile it to editable source (replacing the file) or open a read-only decompiled copy.",
           "scope": "window"
         },
         "bbj.formatter.indentWidth": {
@@ -533,7 +549,9 @@
     "onCommand:bbj.autoComment",
     "onCommand:bbj.compile",
     "onCommand:bbj.configureCompileOptions",
-    "onCommand:bbj.denumber"
+    "onCommand:bbj.denumber",
+    "onCommand:bbj.decompile",
+    "onCommand:bbj.decompileReadonly"
   ],
   "main": "./out/extension.cjs",
   "scripts": {

--- a/bbj-vscode/src/Commands/Commands.cjs
+++ b/bbj-vscode/src/Commands/Commands.cjs
@@ -121,12 +121,39 @@ const runWeb = (params, client, credentials) => {
   });
 };
 
+const bbjlstBin = (home) =>
+  `"${home}/bin/bbjlst${os.platform() === 'win32' ? '.exe' : ''}"`;
+
+/**
+ * Resolve the target file for a decompile/denumber operation.
+ * Prefers an explicit uri/params argument (needed for tokenized binary files,
+ * which open in a non-text editor so `activeTextEditor` may be absent or wrong),
+ * falling back to the active editor.
+ */
+const resolveTargetFileName = (params) => {
+  if (params && params.fsPath) {
+    return params.fsPath;
+  }
+  const active = vscode.window.activeTextEditor;
+  return active ? active.document.fileName : undefined;
+};
+
 const decompile = (params, options = {}) => {
   const home = getBBjHome();
   if (!home) return;
   const active = vscode.window.activeTextEditor;
   const fileName = active ? active.document.fileName : params.fsPath;
-  const resolvedFileName = path.resolve(fileName);
+  decompileInPlace(path.resolve(fileName), options);
+};
+
+/**
+ * Run bbjlst on an already-resolved file, replacing it in place with the result,
+ * then open the result. `options.denumber` selects denumbered (clean) source.
+ */
+const decompileInPlace = (resolvedFileName, options = {}) => {
+  const home = getBBjHome();
+  if (!home) return;
+  const fileName = resolvedFileName;
   const resolvedLstFileName = resolvedFileName.endsWith('.lst')
     ? resolvedFileName
     : resolvedFileName + '.lst';
@@ -135,9 +162,7 @@ const decompile = (params, options = {}) => {
 
   const flags = options.denumber ? `-l ${resolvedFileName.endsWith('.lst') ? '-xlst' : ''}` : '';
 
-  const cmd = `"${home}/bin/bbjlst${
-    os.platform() === 'win32' ? '.exe' : ''
-  }" ${flags} "${resolvedFileName}"`;
+  const cmd = `${bbjlstBin(home)} ${flags} "${resolvedFileName}"`;
 
   const title = options.denumber ? "Denumbering BBj Program..." : "Decompiling BBj Program...";
 
@@ -322,6 +347,54 @@ const Commands = {
   },
   denumber: function (params) {
     decompile(params, { denumber: true });
+  },
+  /**
+   * Decompile a tokenized (binary) BBj program to denumbered source and replace
+   * the file on disk (issue #65). Resolves the target from the passed uri so it
+   * works for binary files that have no active text editor.
+   */
+  decompileReplace: function (params) {
+    const fileName = resolveTargetFileName(params);
+    if (!fileName) return;
+    decompileInPlace(path.resolve(fileName), { denumber: true });
+  },
+  /**
+   * Decompile a tokenized (binary) BBj program to a temporary, read-only source
+   * view, leaving the original binary file untouched (issue #65).
+   */
+  decompileReadonly: function (params) {
+    const home = getBBjHome();
+    if (!home) return;
+    const fileName = resolveTargetFileName(params);
+    if (!fileName) return;
+    const resolvedFileName = path.resolve(fileName);
+    const lstFile = resolvedFileName + '.lst';
+    const cmd = `${bbjlstBin(home)} -l "${resolvedFileName}"`;
+
+    vscode.window.withProgress({
+      location: vscode.ProgressLocation.Notification,
+      title: "Decompiling BBj Program...",
+      cancellable: false
+    }, async () => {
+      try {
+        await execWithProgress(cmd);
+        // Move the generated listing into a temp file so the original binary is
+        // left intact; open that copy read-only. copyFile+unlink avoids EXDEV
+        // when the temp dir is on a different filesystem than the source.
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bbj-decompiled-'));
+        const base = path.basename(resolvedFileName).replace(/\.[^.]*$/, '') || 'program';
+        const tmpFile = path.join(tmpDir, base + '.bbj');
+        await fs.promises.copyFile(lstFile, tmpFile);
+        await fs.promises.unlink(lstFile).catch(() => { });
+
+        const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(tmpFile));
+        await vscode.window.showTextDocument(doc, { preview: false });
+        await vscode.commands.executeCommand('workbench.action.files.setActiveEditorReadonlyInSession');
+      } catch (err) {
+        const errorMsg = `Failed to decompile "${fileName}": ${err.message || err}${err.stderr ? '\n\nDetails:\n' + err.stderr : ''}`;
+        vscode.window.showErrorMessage(errorMsg);
+      }
+    });
   },
 };
 

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -13,6 +13,7 @@ import {
 } from 'vscode-languageclient/node';
 import { BBjLibraryFileSystemProvider } from './language/lib/fs-provider.js';
 import { DocumentFormatter } from './document-formatter.js';
+import { isTokenizedBBjHeader, TOKENIZED_BBJ_MAGIC_LENGTH } from './tokenized-bbj.js';
 import {
     OPTION_GROUP_ORDER,
     getOptionsGrouped,
@@ -475,6 +476,61 @@ async function ensureValidToken(context: vscode.ExtensionContext): Promise<{user
     return creds;
 }
 
+// Tracks files we've already prompted about this session so re-focusing the tab
+// (or reopening it) doesn't nag the user again.
+const promptedTokenizedFiles = new Set<string>();
+
+/** Read the first `length` bytes of a file, or undefined if it can't be read. */
+async function readLeadingBytes(fsPath: string, length: number): Promise<Uint8Array | undefined> {
+    let handle: fs.promises.FileHandle | undefined;
+    try {
+        handle = await fs.promises.open(fsPath, 'r');
+        const buffer = Buffer.alloc(length);
+        const { bytesRead } = await handle.read(buffer, 0, length, 0);
+        return buffer.subarray(0, bytesRead);
+    } catch {
+        return undefined;
+    } finally {
+        await handle?.close().catch(() => { });
+    }
+}
+
+/** Extract a file URI from any tab whose input carries one (text, custom, notebook…). */
+function uriFromTab(tab: vscode.Tab): vscode.Uri | undefined {
+    const input = tab.input as { uri?: vscode.Uri } | undefined;
+    return input?.uri instanceof vscode.Uri ? input.uri : undefined;
+}
+
+/**
+ * When a tokenized (binary) BBj program is opened, offer to decompile it to
+ * editable source (replacing the file) or open a read-only decompiled copy (#65).
+ * Detection is content-based (magic bytes), so it works regardless of the file's
+ * extension — tokenized programs are often named `.pub`, `.src`, or extensionless.
+ */
+async function maybePromptTokenized(uri: vscode.Uri | undefined): Promise<void> {
+    if (!uri || uri.scheme !== 'file') return;
+    if (!vscode.workspace.getConfiguration('bbj').get<boolean>('decompile.promptOnOpen', true)) return;
+
+    const key = uri.toString();
+    if (promptedTokenizedFiles.has(key)) return;
+
+    const bytes = await readLeadingBytes(uri.fsPath, TOKENIZED_BBJ_MAGIC_LENGTH);
+    if (!bytes || !isTokenizedBBjHeader(bytes)) return;
+    promptedTokenizedFiles.add(key);
+
+    const decompileAction = 'Decompile & Replace';
+    const readOnlyAction = 'Open Read-only';
+    const choice = await vscode.window.showInformationMessage(
+        `"${path.basename(uri.fsPath)}" is a tokenized (binary) BBj program. Decompile it to editable source, or open a read-only copy?`,
+        decompileAction, readOnlyAction
+    );
+    if (choice === decompileAction) {
+        Commands.decompileReplace(uri);
+    } else if (choice === readOnlyAction) {
+        Commands.decompileReadonly(uri);
+    }
+}
+
 // This function is called when the extension is activated.
 export function activate(context: vscode.ExtensionContext): void {
     BBjLibraryFileSystemProvider.register(context);
@@ -580,6 +636,8 @@ export function activate(context: vscode.ExtensionContext): void {
     });
     vscode.commands.registerCommand("bbj.compile", Commands.compile);
     vscode.commands.registerCommand("bbj.denumber", Commands.denumber);
+    vscode.commands.registerCommand("bbj.decompile", Commands.decompileReplace);
+    vscode.commands.registerCommand("bbj.decompileReadonly", Commands.decompileReadonly);
     vscode.commands.registerCommand("bbj.configureCompileOptions", configureCompileOptions);
 
     vscode.commands.registerCommand("bbj.refreshJavaClasses", async () => {
@@ -640,6 +698,23 @@ export function activate(context: vscode.ExtensionContext): void {
         "bbj",
         DocumentFormatter
     );
+
+    // Offer to decompile (or open read-only) when a tokenized/binary BBj program is
+    // opened. Tokenized files are binary, so they may open in a non-text editor —
+    // the Tabs API sees them regardless, and detection reads the file's magic bytes.
+    context.subscriptions.push(
+        vscode.window.tabGroups.onDidChangeTabs((event) => {
+            for (const tab of event.opened) {
+                void maybePromptTokenized(uriFromTab(tab));
+            }
+        })
+    );
+    // Inspect tabs already open when the extension activates.
+    for (const group of vscode.window.tabGroups.all) {
+        for (const tab of group.tabs) {
+            void maybePromptTokenized(uriFromTab(tab));
+        }
+    }
 
     // Diagnostic suppression status bar indicator
     const suppressionStatusBar = vscode.window.createStatusBarItem(

--- a/bbj-vscode/src/tokenized-bbj.ts
+++ b/bbj-vscode/src/tokenized-bbj.ts
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * Copyright 2024 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+/**
+ * Magic bytes at the start of a tokenized (compiled/binary) BBj program: the
+ * ASCII string `<<bbj>>`. Verified against real tokenized programs, e.g.:
+ *
+ *     $ hexdump _util | head -1
+ *     0000000 3c3c 6262 3e6a 843e 0000 ...   (little-endian words)
+ *
+ * Unswapping the words gives the byte stream `3c 3c 62 62 6a 3e 3e 84 ...`,
+ * i.e. `<<bbj>>` followed by a format/version marker byte.
+ */
+export const TOKENIZED_BBJ_MAGIC = Uint8Array.from([0x3c, 0x3c, 0x62, 0x62, 0x6a, 0x3e, 0x3e]); // "<<bbj>>"
+
+/** Number of leading bytes needed to decide whether a file is tokenized. */
+export const TOKENIZED_BBJ_MAGIC_LENGTH = TOKENIZED_BBJ_MAGIC.length;
+
+/**
+ * Returns true if the given leading bytes begin with the tokenized-BBj magic.
+ * Tokenized programs are binary and cannot be edited as text; callers use this
+ * to offer decompilation instead.
+ *
+ * @param bytes the first bytes of a file (at least {@link TOKENIZED_BBJ_MAGIC_LENGTH})
+ */
+export function isTokenizedBBjHeader(bytes: Uint8Array): boolean {
+    if (bytes.length < TOKENIZED_BBJ_MAGIC.length) {
+        return false;
+    }
+    for (let i = 0; i < TOKENIZED_BBJ_MAGIC.length; i++) {
+        if (bytes[i] !== TOKENIZED_BBJ_MAGIC[i]) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/bbj-vscode/test/tokenized-bbj.test.ts
+++ b/bbj-vscode/test/tokenized-bbj.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import { isTokenizedBBjHeader, TOKENIZED_BBJ_MAGIC_LENGTH } from '../src/tokenized-bbj.js';
+
+describe('isTokenizedBBjHeader', () => {
+    // First 16 bytes of a real tokenized program (_util), taken from the
+    // little-endian hexdump words: 3c3c 6262 3e6a 843e 0000 001f f700 da09
+    const realHeader = Uint8Array.from([
+        0x3c, 0x3c, 0x62, 0x62, 0x6a, 0x3e, 0x3e, 0x84,
+        0x00, 0x00, 0x1f, 0x00, 0x00, 0xf7, 0x09, 0xda
+    ]);
+
+    test('detects the "<<bbj>>" magic of a real tokenized program', () => {
+        expect(isTokenizedBBjHeader(realHeader)).toBe(true);
+    });
+
+    test('detects when given exactly the magic-length prefix', () => {
+        expect(isTokenizedBBjHeader(realHeader.subarray(0, TOKENIZED_BBJ_MAGIC_LENGTH))).toBe(true);
+    });
+
+    test('rejects plain-text BBj source', () => {
+        const text = new TextEncoder().encode('rem hello\nprint "hi"\n');
+        expect(isTokenizedBBjHeader(text)).toBe(false);
+    });
+
+    test('rejects a near-miss (wrong angle brackets)', () => {
+        const bytes = new TextEncoder().encode('<bbj>>>');
+        expect(isTokenizedBBjHeader(bytes)).toBe(false);
+    });
+
+    test('rejects a truncated prefix shorter than the magic', () => {
+        expect(isTokenizedBBjHeader(Uint8Array.from([0x3c, 0x3c, 0x62]))).toBe(false);
+    });
+
+    test('rejects empty input', () => {
+        expect(isTokenizedBBjHeader(new Uint8Array(0))).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

Fixes #65 (the remaining "auto-detect on open" part). Tokenized (compiled/binary) BBj programs begin with the magic bytes **`<<bbj>>`** (`3C 3C 62 62 6A 3E 3E`). VS Code shows them as an unreadable binary blob. When one is opened, the extension now detects it and prompts:

> `"_stdinp.pub" is a tokenized (binary) BBj program. Decompile it to editable source, or open a read-only copy?`
> **[ Decompile & Replace ]  [ Open Read-only ]**

- **Decompile & Replace** — decompiles to denumbered source (`bbjlst -l`) and replaces the file on disk with editable source.
- **Open Read-only** — decompiles to a temporary copy and opens it read-only, leaving the original binary untouched.
- Dismiss — nothing happens.

## Magic bytes

Verified against real tokenized programs (from the issue thread):

```
$ hexdump _util | head -1
0000000 3c3c 6262 3e6a 843e 0000 ...      (little-endian words)
          <<    bb    j>    >·             → bytes: 3c 3c 62 62 6a 3e 3e 84 ...
```

So the signature is `<<bbj>>` followed by a format/version marker.

## Detection & interception

- Detection is **content-based**, not extension-based — tokenized programs are frequently named `.pub`, `.src`, or have no extension, so an extension filter would miss them. Only the first 7 bytes are read (`fs.open` + partial read).
- Uses the **Tabs API** (`window.tabGroups.onDidChangeTabs`) rather than `onDidChangeActiveTextEditor`: binary files open in a non-text editor that the active-text-editor event doesn't see, but the Tabs API does. Already-open tabs are inspected at activation.
- Each file is prompted at most once per session; new setting **`bbj.decompile.promptOnOpen`** (default `true`) disables it.

## Commands & refactor

- Adds `bbj.decompile` (replace) and `bbj.decompileReadonly` for manual use.
- The `Commands` decompile core is refactored into a path-based `decompileInPlace(resolvedFileName, options)` so it can target an explicit URI — tokenized files have no reliable active text editor. **`denumber`'s existing behavior is unchanged** (same active-editor resolution as before).

## Tests

- `test/tokenized-bbj.test.ts` (6 cases) covers the detector against the real header bytes and negative cases (plain text, near-miss, truncated, empty).
- `npm run build` (tsc + esbuild), `eslint`, full suite: **505 passed, 20 skipped**.

## Verification boundary

The magic-byte detector and the tab/prompt wiring are exercised by unit tests and the type/build system. The actual `bbjlst` invocation paths can't be run here (no BBj install in this environment); they reuse the same `bbjlst -l` mechanism and `<file>.lst` output assumption as the existing, shipped `bbj.denumber` command. Worth a manual smoke test against a real tokenized program before release — in particular the read-only temp-copy path (new) and behavior when the source directory isn't writable.

Relationship to #64: that PR handles line-numbered **text** programs (denumber); this handles **binary tokenized** programs (decompile). Complementary, non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)