### PR TITLE
Fix #65: handle bbjlst async-output / in-place-rewrite race on decompile

### DIFF
--- a/bbj-vscode/src/Commands/Commands.cjs
+++ b/bbj-vscode/src/Commands/Commands.cjs
@@ -40,6 +40,8 @@ const execWithProgress = (cmd) => {
   });
 };
 
+const { isTokenizedFile, waitForDecompileOutput } = require("../decompile-io");
+
 const getBBjHome = () => {
   const home = vscode.workspace.getConfiguration("bbj").home;
 
@@ -172,29 +174,23 @@ const decompileInPlace = (resolvedFileName, options = {}) => {
     cancellable: false
   }, async () => {
     try {
+      // Capture up-front whether the input is tokenized: only then can bbjlst
+      // legitimately rewrite it in place (denumbering plain text always emits `.lst`).
+      const wasTokenized = await isTokenizedFile(resolvedFileName);
       await execWithProgress(cmd);
 
-      if (!options.denumber) {
-        await new Promise((resolve, reject) => {
-          fs.unlink(resolvedFileName, (unlinkErr) => {
-            if (unlinkErr) {
-              reject(unlinkErr);
-            } else {
-              resolve();
-            }
-          });
-        });
-      }
+      // bbjlst may return before its output is on disk, and may either produce
+      // `<input>.lst` or rewrite the input in place — wait for whichever happens.
+      const { inPlace } = await waitForDecompileOutput(resolvedFileName, { canRewriteInPlace: wasTokenized });
 
-      await new Promise((resolve, reject) => {
-        fs.rename(resolvedLstFileName, newFileName, (renameErr) => {
-          if (renameErr) {
-            reject(renameErr);
-          } else {
-            resolve();
-          }
-        });
-      });
+      if (!inPlace) {
+        if (!options.denumber && resolvedFileName !== newFileName) {
+          await fs.promises.unlink(resolvedFileName).catch(() => { });
+        }
+        await fs.promises.rename(resolvedLstFileName, newFileName);
+      }
+      // When inPlace, bbjlst already wrote the source into `resolvedFileName`
+      // (=== newFileName for denumber), so there is nothing to move.
 
       const uri = vscode.Uri.file(newFileName);
       const doc = await vscode.workspace.openTextDocument(uri);
@@ -368,8 +364,6 @@ const Commands = {
     const fileName = resolveTargetFileName(params);
     if (!fileName) return;
     const resolvedFileName = path.resolve(fileName);
-    const lstFile = resolvedFileName + '.lst';
-    const cmd = `${bbjlstBin(home)} -l "${resolvedFileName}"`;
 
     vscode.window.withProgress({
       location: vscode.ProgressLocation.Notification,
@@ -377,15 +371,24 @@ const Commands = {
       cancellable: false
     }, async () => {
       try {
-        await execWithProgress(cmd);
-        // Move the generated listing into a temp file so the original binary is
-        // left intact; open that copy read-only. copyFile+unlink avoids EXDEV
-        // when the temp dir is on a different filesystem than the source.
+        // Run bbjlst against a private copy in a temp dir, so the original binary
+        // is never touched — regardless of whether bbjlst emits `<input>.lst` or
+        // rewrites its input in place.
         const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bbj-decompiled-'));
         const base = path.basename(resolvedFileName).replace(/\.[^.]*$/, '') || 'program';
+        const tmpInput = path.join(tmpDir, base + path.extname(resolvedFileName));
+        await fs.promises.copyFile(resolvedFileName, tmpInput);
+
+        const wasTokenized = await isTokenizedFile(tmpInput);
+        await execWithProgress(`${bbjlstBin(home)} -l "${tmpInput}"`);
+
+        // Wait for the output, then normalise it to a `.bbj` file so the editor
+        // opens it with BBj language support.
+        const { sourcePath } = await waitForDecompileOutput(tmpInput, { canRewriteInPlace: wasTokenized });
         const tmpFile = path.join(tmpDir, base + '.bbj');
-        await fs.promises.copyFile(lstFile, tmpFile);
-        await fs.promises.unlink(lstFile).catch(() => { });
+        if (sourcePath !== tmpFile) {
+          await fs.promises.rename(sourcePath, tmpFile);
+        }
 
         const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(tmpFile));
         await vscode.window.showTextDocument(doc, { preview: false });

--- a/bbj-vscode/src/decompile-io.ts
+++ b/bbj-vscode/src/decompile-io.ts
@@ -1,0 +1,84 @@
+/******************************************************************************
+ * Copyright 2024 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import * as fs from 'fs';
+
+/** Magic bytes at the start of a tokenized (binary) BBj program: "<<bbj>>". */
+const TOKENIZED_MAGIC = Buffer.from([0x3c, 0x3c, 0x62, 0x62, 0x6a, 0x3e, 0x3e]);
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** True if the file still starts with the tokenized-BBj magic (i.e. not yet decompiled). */
+export async function isTokenizedFile(file: string): Promise<boolean> {
+    let handle: fs.promises.FileHandle | undefined;
+    try {
+        handle = await fs.promises.open(file, 'r');
+        const buffer = Buffer.alloc(TOKENIZED_MAGIC.length);
+        const { bytesRead } = await handle.read(buffer, 0, TOKENIZED_MAGIC.length, 0);
+        return bytesRead === TOKENIZED_MAGIC.length && buffer.equals(TOKENIZED_MAGIC);
+    } catch {
+        return false;
+    } finally {
+        await handle?.close().catch(() => { });
+    }
+}
+
+async function statSize(file: string): Promise<number> {
+    try {
+        return (await fs.promises.stat(file)).size;
+    } catch {
+        return -1;
+    }
+}
+
+export interface DecompileOutput {
+    /** Path where the decompiled ASCII source ended up. */
+    sourcePath: string;
+    /** True if bbjlst rewrote the input file in place instead of emitting `<input>.lst`. */
+    inPlace: boolean;
+}
+
+export interface WaitOptions {
+    timeoutMs?: number;
+    pollMs?: number;
+    /**
+     * Allow the "input is no longer tokenized → rewritten in place" detection.
+     * Set this only when the input started out tokenized; otherwise (e.g.
+     * denumbering line-numbered text) bbjlst always emits `<input>.lst` and the
+     * heuristic would fire spuriously on the very first poll.
+     */
+    canRewriteInPlace?: boolean;
+}
+
+/**
+ * bbjlst can return before its output is flushed, and — depending on version —
+ * either writes `<input>.lst` or rewrites `<input>` in place. This polls until the
+ * output is actually ready and reports where the decompiled source landed.
+ *
+ * When `<input>.lst` is used, it waits until the file's size settles across two
+ * polls so a partially-written listing is never consumed. Rejects on timeout.
+ */
+export async function waitForDecompileOutput(inputPath: string, opts: WaitOptions = {}): Promise<DecompileOutput> {
+    const { timeoutMs = 20000, pollMs = 150, canRewriteInPlace = false } = opts;
+    const lstPath = inputPath + '.lst';
+    const deadline = Date.now() + timeoutMs;
+    let lastLstSize = -2;
+    while (Date.now() < deadline) {
+        const lstSize = await statSize(lstPath);
+        if (lstSize >= 0) {
+            // `.lst` exists — wait until its size settles so we never read a partial file.
+            if (lstSize === lastLstSize) {
+                return { sourcePath: lstPath, inPlace: false };
+            }
+            lastLstSize = lstSize;
+        } else if (canRewriteInPlace && !(await isTokenizedFile(inputPath))) {
+            // No `.lst`, and a once-tokenized input is no longer tokenized → rewritten in place.
+            return { sourcePath: inputPath, inPlace: true };
+        }
+        await delay(pollMs);
+    }
+    throw new Error(`Timed out waiting for bbjlst to produce the decompiled output of "${inputPath}"`);
+}

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -513,10 +513,16 @@ async function maybePromptTokenized(uri: vscode.Uri | undefined): Promise<void> 
 
     const key = uri.toString();
     if (promptedTokenizedFiles.has(key)) return;
+    // Reserve synchronously: the same file can surface from both the tab-change
+    // event and the activation scan, and we must not prompt (or decompile) twice.
+    promptedTokenizedFiles.add(key);
 
     const bytes = await readLeadingBytes(uri.fsPath, TOKENIZED_BBJ_MAGIC_LENGTH);
-    if (!bytes || !isTokenizedBBjHeader(bytes)) return;
-    promptedTokenizedFiles.add(key);
+    if (!bytes || !isTokenizedBBjHeader(bytes)) {
+        // Not tokenized after all — allow a later check (e.g. if the file changes).
+        promptedTokenizedFiles.delete(key);
+        return;
+    }
 
     const decompileAction = 'Decompile & Replace';
     const readOnlyAction = 'Open Read-only';

--- a/bbj-vscode/test/decompile-io.test.ts
+++ b/bbj-vscode/test/decompile-io.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { isTokenizedFile, waitForDecompileOutput } from '../src/decompile-io.js';
+
+const MAGIC = Buffer.from([0x3c, 0x3c, 0x62, 0x62, 0x6a, 0x3e, 0x3e]); // "<<bbj>>"
+
+describe('decompile-io', () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'decompile-io-test-'));
+    });
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    describe('isTokenizedFile', () => {
+        test('true for a file starting with the "<<bbj>>" magic', async () => {
+            const f = path.join(dir, 'prog');
+            fs.writeFileSync(f, Buffer.concat([MAGIC, Buffer.from([0x84, 0, 0])]));
+            expect(await isTokenizedFile(f)).toBe(true);
+        });
+        test('false for plain text', async () => {
+            const f = path.join(dir, 'prog.bbj');
+            fs.writeFileSync(f, 'rem hi\nprint "x"\n');
+            expect(await isTokenizedFile(f)).toBe(false);
+        });
+        test('false for a missing file', async () => {
+            expect(await isTokenizedFile(path.join(dir, 'nope'))).toBe(false);
+        });
+    });
+
+    describe('waitForDecompileOutput', () => {
+        const fast = { pollMs: 5, timeoutMs: 2000 };
+
+        test('resolves to the .lst path once it appears and its size settles', async () => {
+            const input = path.join(dir, 'prog.bbj');
+            fs.writeFileSync(input, MAGIC);
+            const lst = input + '.lst';
+            // Write the listing shortly after the wait starts, simulating async bbjlst output.
+            setTimeout(() => fs.writeFileSync(lst, '0010 print "hi"\n'), 30);
+
+            const result = await waitForDecompileOutput(input, fast);
+            expect(result).toEqual({ sourcePath: lst, inPlace: false });
+        });
+
+        test('detects in-place rewrite when a once-tokenized input becomes ASCII', async () => {
+            const input = path.join(dir, 'prog.bbj');
+            fs.writeFileSync(input, MAGIC); // starts tokenized
+            // No .lst ever appears; instead the input itself is rewritten to source.
+            setTimeout(() => fs.writeFileSync(input, 'print "hi"\n'), 30);
+
+            const result = await waitForDecompileOutput(input, { ...fast, canRewriteInPlace: true });
+            expect(result).toEqual({ sourcePath: input, inPlace: true });
+        });
+
+        test('does NOT treat a non-tokenized input as in-place (waits for .lst)', async () => {
+            // e.g. denumbering line-numbered text: bbjlst always emits .lst.
+            const input = path.join(dir, 'numbered.bbj');
+            fs.writeFileSync(input, '0010 print "hi"\n'); // never tokenized
+            const lst = input + '.lst';
+            setTimeout(() => fs.writeFileSync(lst, 'print "hi"\n'), 30);
+
+            // canRewriteInPlace defaults to false → must resolve to .lst, not in-place.
+            const result = await waitForDecompileOutput(input, fast);
+            expect(result).toEqual({ sourcePath: lst, inPlace: false });
+        });
+
+        test('rejects on timeout when no output ever appears', async () => {
+            const input = path.join(dir, 'prog.bbj');
+            fs.writeFileSync(input, MAGIC);
+            await expect(waitForDecompileOutput(input, { pollMs: 5, timeoutMs: 120 }))
+                .rejects.toThrow(/Timed out/);
+        });
+
+        test('a not-yet-stable .lst is not resolved until its size settles', async () => {
+            const input = path.join(dir, 'prog.bbj');
+            fs.writeFileSync(input, MAGIC);
+            const lst = input + '.lst';
+            // Grow the listing on every poll for a while, then stop — resolution must
+            // only happen after the size stops changing.
+            let bytes = 0;
+            const grower = setInterval(() => { bytes += 4; fs.writeFileSync(lst, 'x'.repeat(bytes)); }, 5);
+            setTimeout(() => clearInterval(grower), 60);
+
+            const result = await waitForDecompileOutput(input, { pollMs: 8, timeoutMs: 2000 });
+            expect(result.sourcePath).toBe(lst);
+            // Final observed size must equal what's on disk (i.e. it settled, not a partial read).
+            expect(fs.statSync(lst).size).toBe(bytes);
+        });
+    });
+});


### PR DESCRIPTION
## Problem

Follow-up to #65 (PR #418). Decompiling a tokenized program on open frequently failed with:

```
Failed to decompile "…/_browse.bbj": ENOENT: no such file or directory,
copyfile '…/_browse.bbj.lst' -> '…/T/bbj-decompiled-…/_browse.bbj'
```

…and only worked *intermittently*. Two root causes, both confirmed by the report:

1. **Async output** — `bbjlst` returns before its output is flushed to disk, so the immediate `copyFile`/`rename` on `<file>.lst` hits ENOENT (a race — "every once in a while it works").
2. **In-place rewrite** — depending on the `bbjlst` version, it sometimes rewrites the *input* to ASCII rather than emitting `<file>.lst`. That's why, after the error on "Decompile & Replace", the file was already ASCII: the tool did its job, we just looked in the wrong place / too early.

## Fix

- **`waitForDecompileOutput()`** — after `bbjlst` exits, poll until the output is genuinely ready:
  - `<file>.lst` appears **and its size settles across two polls** (never read a half-written listing), or
  - a **once-tokenized** input is no longer tokenized → it was rewritten in place.
  - Rejects on a timeout with a clear message instead of a raw ENOENT.
- **`decompileInPlace`** (replace / denumber) waits for the output and **skips the rename** when `bbjlst` already rewrote the file in place.
- **`decompileReadonly`** now runs `bbjlst` against a **private temp copy**, so the original binary is never modified regardless of `bbjlst`'s output mode, then opens the decompiled copy read-only.
- The in-place heuristic is **gated on the input having started out tokenized**, so denumbering line-numbered *text* (which always emits `.lst`) is unaffected.
- **`maybePromptTokenized`** reserves the file key *synchronously* to prevent a double prompt/decompile when the tab-change event and the activation scan race on the same file.

This also makes the existing `bbj.denumber` more robust (it shares `decompileInPlace`, so it now waits for `.lst` too).

## Tests

The race-handling logic is extracted into a `vscode`-free module (`src/decompile-io.ts`) and unit-tested against a real temp directory (`test/decompile-io.test.ts`, 8 cases): `.lst`-appears-late, in-place rewrite, the non-tokenized guard, timeout, size-settling, and the magic-byte check. Full suite: **518 passed, 19 skipped**; `tsc`/`build`/`eslint` clean.

## Verification boundary

I still can't run `bbjlst` in this environment, so the polling/branching logic is validated by unit tests simulating both output modes, not against the real tool. Please smoke-test on a real tokenized program (both actions, and ideally a `bbjlst` that writes `.lst` **and** one that rewrites in place). If your `bbjlst` reliably uses one mode, this handles both anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)