### PR TITLE
Make hover resilient to malformed Java data (fixes "textDocument/hover failed")

### DIFF
--- a/bbj-vscode/src/language/bbj-hover.ts
+++ b/bbj-vscode/src/language/bbj-hover.ts
@@ -37,9 +37,17 @@ export class BBjHoverProvider extends AstNodeHoverProvider {
         if (cstNode && cstNode.offset + cstNode.length > offset) {
             // Store reference context for inherited field detection
             this.referenceCstNode = cstNode;
-            const result = await super.getHoverContent(document, params);
-            this.referenceCstNode = undefined;
-            return result;
+            try {
+                return await super.getHoverContent(document, params);
+            } catch (e) {
+                // A hover computation error must never surface as a failed LSP request
+                // (the user just sees repeated "textDocument/hover failed" noise). Log
+                // the stack for diagnosis and degrade gracefully to "no hover".
+                logger.warn(`Hover failed at offset ${offset}: ${e instanceof Error ? (e.stack ?? e.message) : String(e)}`);
+                return undefined;
+            } finally {
+                this.referenceCstNode = undefined;
+            }
         }
         return undefined;
     }
@@ -173,8 +181,9 @@ export function documentationHeader(node: AstNode): string | undefined {
     return undefined;
 }
 
-function javaTypeAdjust(typeFqn: string): string {
-    return typeFqn.replace(/^java\.lang\./, '')
+function javaTypeAdjust(typeFqn: string | undefined): string {
+    // Java type strings come from external data and may be missing on a malformed payload.
+    return (typeFqn ?? '').replace(/^java\.lang\./, '')
 }
 
 function ownerClass(member: ClassMember): string {
@@ -183,14 +192,19 @@ function ownerClass(member: ClassMember): string {
 }
 
 export function methodSignature(nodeDescription: MethodData, typeAdjust: ((type: string) => string) = (t) => t ?? '') {
-    return `${nodeDescription.name}(${nodeDescription.parameters.map(p => `${typeAdjust(p.type)} ${p.realName ?? p.name}${p.optional ? '?' : ''}`).join(', ')})`
+    // `parameters` originates from external Java data (java-interop socket / javadoc
+    // JSON); guard against a missing array so hover never crashes on a malformed payload.
+    const parameters = nodeDescription.parameters ?? [];
+    return `${nodeDescription.name}(${parameters.map(p => `${typeAdjust(p.type)} ${p.realName ?? p.name}${p.optional ? '?' : ''}`).join(', ')})`
 }
 
 function toMethodDocToMethodData(methodDoc: MethodDoc, node: JavaMethod): MethodData {
-    const javaParams = node.parameters
+    // Both arrays come from external sources (classpath payload / javadoc JSON) and may
+    // be absent for a given method — default to empty so index access can't throw.
+    const javaParams = node.parameters ?? []
     return {
         name: methodDoc.name,
-        parameters: methodDoc.params.map((p, idx) => ({ name: p.name, type: javaParams[idx]?.type ?? 'Object', optional: false })),
+        parameters: (methodDoc.params ?? []).map((p, idx) => ({ name: p.name, type: javaParams[idx]?.type ?? 'Object', optional: false })),
         returnType: node.returnType
     }
 }

--- a/bbj-vscode/test/hover.test.ts
+++ b/bbj-vscode/test/hover.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+import { documentationHeader, methodSignature } from '../src/language/bbj-hover.js';
+import { JavaMethod, JavaField } from '../src/language/generated/ast.js';
+
+describe('hover helpers are robust against malformed Java data', () => {
+    // Java data comes from the java-interop socket / javadoc JSON and can arrive with
+    // fields missing (e.g. a no-arg method serialized without a `parameters` array).
+    // Hover must never throw on such payloads.
+
+    test('methodSignature tolerates a missing parameters array', () => {
+        expect(() => methodSignature({ name: 'foo', parameters: undefined as never, returnType: 'void' }))
+            .not.toThrow();
+        expect(methodSignature({ name: 'foo', parameters: undefined as never, returnType: 'void' }))
+            .toBe('foo()');
+    });
+
+    test('methodSignature renders provided parameters', () => {
+        expect(methodSignature({
+            name: 'put',
+            parameters: [{ name: 'k', type: 'String' }, { name: 'v', type: 'Object' }],
+            returnType: 'Object'
+        })).toBe('put(String k, Object v)');
+    });
+
+    test('documentationHeader tolerates a JavaMethod with no parameters array', () => {
+        const method = { $type: JavaMethod.$type, name: 'size', returnType: 'int', parameters: undefined } as never;
+        expect(() => documentationHeader(method)).not.toThrow();
+        expect(documentationHeader(method)).toContain('size()');
+    });
+
+    test('documentationHeader tolerates a JavaField with no type', () => {
+        const field = { $type: JavaField.$type, name: 'count', type: undefined } as never;
+        expect(() => documentationHeader(field)).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Context

Reported by Nick — repeated log entries while hovering:

```
Request textDocument/hover failed.
  Message: Request textDocument/hover failed with message: Cannot read properties of undefined (reading '0')
  Code: -32603
```

## Why it happens

The hover text is assembled from data supplied by the **java-interop socket** and **javadoc JSON**. Those payloads can arrive with fields absent for a given member — a method serialized without a `parameters` array, a field without a `type`, a javadoc entry whose `params` list doesn't line up with the method's. The old code indexed / mapped those arrays directly, so a missing field threw a `TypeError` straight out of the LSP hover handler, which the client surfaces as a failed request (and the user gets no hover).

It only reproduces with real classpath/javadoc data (the in-repo fake Java classes always populate `parameters: []`), which is why it shows up in real projects but not in the test suite.

## Fix

Two layers:

1. **Never fail the request.** `getHoverContent` now wraps the computation in try/catch: on error it logs the stack (`logger.warn`) and returns `undefined` (a graceful "no hover") instead of throwing. This stops the user-visible noise immediately **and** captures the exact stack for any edge case not covered below.
2. **Don't throw in the first place.** Harden the Java-data-derived accesses:
   - `methodSignature` tolerates a missing `parameters` array.
   - `toMethodDocToMethodData` tolerates a missing `node.parameters` / `methodDoc.params`.
   - `javaTypeAdjust` tolerates an `undefined` type string (this one surfaced a second latent crash — `undefined.replace(...)` — while writing the tests).

## Tests

`test/hover.test.ts` unit-tests the hardened exported helpers against malformed payloads (missing parameters array, missing field type). Full suite: **531 passed, 19 skipped**; `tsc`/`build`/`eslint` clean.

## Note

I could not reproduce the *exact* `(reading '0')` line without a live classpath, so layer 1 is deliberately a safety net: if some other malformed-data path remains, hover now degrades gracefully and the `logger.warn` stack will pinpoint it from a real session. Worth keeping an eye on the LS log after this ships — if the warning still appears, its stack tells us the next spot to harden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)