### PR TITLE
Fix #388: false line-break errors on single-line ELSE/IF after `;`

### DIFF
--- a/bbj-vscode/src/language/validations/line-break-validation.ts
+++ b/bbj-vscode/src/language/validations/line-break-validation.ts
@@ -255,6 +255,11 @@ function getSiblings(container: AstNode | undefined): AstNode[] {
         return container.statements;
     } else if (isMethodDecl(container) || isDefFunction(container)) {
         return container.body;
+    } else if (isCompoundStatement(container)) {
+        // Statements chained by `;` on one line (e.g. `red = 0; else ...`) live in a
+        // CompoundStatement. Without this, previousStatement() can't walk in/out of the
+        // compound and single-line IF/ELSE constructs get spurious "new line" errors (#388).
+        return container.statements;
     }
     return [];
 }

--- a/bbj-vscode/test/bbj-test-module.ts
+++ b/bbj-vscode/test/bbj-test-module.ts
@@ -55,7 +55,8 @@ class JavaInteropTestService extends JavaInteropService {
         const fakeJavaClasses: JavaClass[] = [
             createBBjApiClass(this.classpath),
             createHashMapClass(this.classpath),
-            createJavaLangStringClass(this.classpath)
+            createJavaLangStringClass(this.classpath),
+            createJavaLangClassClass(this.classpath)
         ]
         fakeJavaClasses.forEach(clazz => {
             this.classpath.classes.push(clazz)
@@ -109,6 +110,39 @@ function createHashMapClass(container: Classpath) {
             $containerProperty: 'methods',
             $container: clazz,
             returnType: 'java.lang.Object',
+            $type: JavaMethod,
+            parameters: []
+        },
+        {
+            // inherited from java.lang.Object; needed so `obj!.getClass()` resolves
+            name: 'getClass',
+            $containerProperty: 'methods',
+            $container: clazz,
+            returnType: 'java.lang.Class',
+            $type: JavaMethod,
+            parameters: []
+        }
+    ]
+    return clazz
+}
+
+function createJavaLangClassClass(container: Classpath): JavaClass {
+    const clazz: JavaClass = {
+        $type: JavaClass,
+        name: 'java.lang.Class',
+        packageName: 'java.lang',
+        $container: container,
+        $containerProperty: 'classes',
+        classes: [],
+        fields: [],
+        methods: []
+    }
+    clazz.methods = [
+        {
+            name: 'getName',
+            $containerProperty: 'methods',
+            $container: clazz,
+            returnType: 'java.lang.String',
             $type: JavaMethod,
             parameters: []
         }

--- a/bbj-vscode/test/linking.test.ts
+++ b/bbj-vscode/test/linking.test.ts
@@ -391,6 +391,15 @@ describe('Linking Tests', async () => {
             expectNoErrors(document)
         });
 
+        test('.class pseudo-member resolves on a Java object - issue #373', async () => {
+            const document = await validate(`
+                hm! = new java.util.HashMap()
+                PRINT hm!.class
+                PRINT hm!.getClass()
+            `)
+            expectNoErrors(document)
+        });
+
         test('Package scope as most outer scope', async () => {
             const document = await validate(`
                 declare java.lang.String com

--- a/bbj-vscode/test/parser.test.ts
+++ b/bbj-vscode/test/parser.test.ts
@@ -2642,4 +2642,26 @@ classend
         expectNoParserLexerErrors(result);
     });
 
+    test('Issue #379 initialized object-suffix (!) field does not break class parsing', async () => {
+        // A `field ... name! = <expr>` initializer followed by a static method must parse
+        // cleanly. Previously this produced a parser error at the `=` and cascaded into the
+        // whole CLASS..CLASSEND being misparsed as loose statements.
+        const result = await parse(`
+                CLASS PUBLIC BBjString
+                CLASSEND
+
+                class public ClassA
+
+                    field protected BBjString releaseVersion! = "Release 15 build of October 2019, change-level: 15.000"
+
+                    method public static void doSomething()
+                    methodend
+                classend
+
+                releaseVersion$ = "TEST"
+        `, { validation: true });
+        expectNoParserLexerErrors(result);
+        expectNoValidationErrors(result);
+    });
+
 });

--- a/bbj-vscode/test/validation.test.ts
+++ b/bbj-vscode/test/validation.test.ts
@@ -414,6 +414,17 @@ describe('BBj validation', async () => {
         expectNoIssues(validationResult);
     });
 
+    test('ELSE after semicolon on single line does not require a new line', async () => {
+        // Issue #388: `if (cond) stmt; else if (cond) stmt` (no THEN keyword, chained via `;`)
+        // wrongly reported "This statement needs to start in a new line" for `else` and the
+        // following `if`, because previousStatement() could not traverse a CompoundStatement.
+        const validationResult = await validate(`
+        red = -8
+        if (red < 0) red = 0; else if (red > 255) red = 255
+        `);
+        expectNoIssues(validationResult);
+    });
+
     test('IF as last child of a compound statement', async () => {
         const validationResult = await validate(`
         debug = 1

--- a/bbj-vscode/test/validation.test.ts
+++ b/bbj-vscode/test/validation.test.ts
@@ -418,11 +418,69 @@ describe('BBj validation', async () => {
         // Issue #388: `if (cond) stmt; else if (cond) stmt` (no THEN keyword, chained via `;`)
         // wrongly reported "This statement needs to start in a new line" for `else` and the
         // following `if`, because previousStatement() could not traverse a CompoundStatement.
+        // The `else` lives in the `red = 0; else` CompoundStatement; resolving its line-break
+        // mask must walk back through the compound's first element (`red = 0`) and out to the
+        // leading `if (red < 0)` on the same line.
         const validationResult = await validate(`
         red = -8
         if (red < 0) red = 0; else if (red > 255) red = 255
         `);
         expectNoIssues(validationResult);
+    });
+
+    test('ELSE as a later element of a multi-statement compound walks back to the leading IF', async () => {
+        // Issue #388, deeper case: here `else` is the 3rd element of the compound
+        // `red = 0; red = 1; else`. Resolving it exercises previousStatement() twice through
+        // non-first elements (index > 0 branch) AND once through the first element (`red = 0`,
+        // index === 0 branch that recurses out of the compound) before reaching the governing
+        // `if (red < 0)`. All of them must be reachable or the false "new line" errors return.
+        const validationResult = await validate(`
+        red = -8
+        if (red < 0) red = 0; red = 1; else if (red > 255) red = 255
+        `);
+        expectNoIssues(validationResult);
+    });
+
+    test('Compound statement at program start does not crash the backward walk', async () => {
+        // Guards the termination case: a compound (`red = 0; red = 1`) that is itself the first
+        // statement in the program. Walking back from its first element must resolve to
+        // `undefined` (nothing precedes it) rather than looping or throwing.
+        const validationResult = await validate(`
+        red = 0; red = 1
+        `);
+        expectNoIssues(validationResult);
+    });
+
+    test('Single-line IF ... FI followed by `;`-chained statement is accepted', async () => {
+        // `fi` becomes the last element of a compound wrapping the single-line IF, and the
+        // trailing `print x` is chained after it. The governing `if x then` sits on the same
+        // line, so no line-break error should be raised for `fi`.
+        const validationResult = await validate(`
+        x = 0
+        if x then x = 1 fi; print x
+        `);
+        expectNoIssues(validationResult);
+    });
+
+    test('ELSE with no governing IF on the line is still flagged', async () => {
+        // Negative guard: the fix must not over-suppress. With no `if` preceding `else` on the
+        // same line, the backward walk terminates without finding one, so `else` (and the
+        // trailing statement) must still get "new line" / "line break" diagnostics.
+        const validationResult = await validate(`
+        red = 0; else red = 1
+        `);
+        const lineBreakErrors = validationResult.diagnostics.filter(d => /new line|line break/.test(d.message));
+        expect(lineBreakErrors.length).toBeGreaterThan(0);
+    });
+
+    test('ENDIF with no governing IF on the line is still flagged', async () => {
+        // Negative guard, endif variant: `fi` chained after `red = 0` with no matching `if`
+        // must still be reported as needing to start on a new line.
+        const validationResult = await validate(`
+        red = 0; fi
+        `);
+        const lineBreakErrors = validationResult.diagnostics.filter(d => /new line|line break/.test(d.message));
+        expect(lineBreakErrors.length).toBeGreaterThan(0);
     });
 
     test('IF as last child of a compound statement', async () => {


### PR DESCRIPTION
## What

Fixes **#388** and adds regression tests locking two issues (**#379**, **#373**) that are already resolved on the current codebase.

### #388 — the actual fix

Input that BBj runs fine but the extension flagged with 4 errors:

```bbj
red = -8
if (red < 0) red = 0; else if (red > 255) red = 255
```

**Root cause:** `getSiblings()` in `line-break-validation.ts` did not handle a `CompoundStatement` container. Statements chained by `;` on one line (`red = 0; else …`) live in a `CompoundStatement`, so `previousStatement()` returned `undefined` when trying to walk in/out of it. The walk never reached the preceding `if (…)`, and `else` + the following `if` each got a spurious *"This statement needs to start in a new line"* error.

**Fix:** return `container.statements` when the container is a `CompoundStatement` (5 lines).

### #379 / #373 — already fixed, now covered by tests

Both were filed on 2026-02-08 and fixed by later work; I verified neither reproduces and added regression tests so they stay fixed:

- **#379** — the current grammar already parses `field … name! = <expr>` initializers and case-insensitive `class`; the old whole-class misparse cascade is gone. New parser test asserts 0 parser/validation errors on the exact reported snippet.
- **#373** — the scope provider (`bbj-scope.ts`) already injects a `java.lang.Class` description named `class` for Java-object receivers, so `hm!.class` resolves. The test module gains a fake `java.lang.Class` (and `HashMap.getClass()`) and a linking test exercises `hm!.class` / `hm!.getClass()`.

See #379 and #373 for close recommendations.

## Testing

- Full suite: **533 passed, 20 skipped, 0 failed**
- `tsc --noEmit` and eslint clean
- Only production change is the 5-line `getSiblings` fix; the rest is tests + one test-infra addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)