### PR TITLE
Add regression tests for already-fixed issues (#374, #380, #77, #32)

### DIFF
--- a/bbj-vscode/test/declare-in-class.test.ts
+++ b/bbj-vscode/test/declare-in-class.test.ts
@@ -1,0 +1,39 @@
+import { EmptyFileSystem, LangiumDocument } from 'langium';
+import { parseHelper } from 'langium/test';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { createBBjServices } from '../src/language/bbj-module';
+import { Model, Program, isBbjClass, isVariableDecl } from '../src/language/generated/ast';
+
+const services = createBBjServices(EmptyFileSystem);
+const parse = parseHelper<Model>(services.BBj);
+
+function expectNoParserLexerErrors(document: LangiumDocument) {
+    expect(document.parseResult.lexerErrors.map(e => e.message).join('\n')).toBe('');
+    expect(document.parseResult.parserErrors.map(e => e.message).join('\n')).toBe('');
+}
+
+describe('DECLARE in class body (#380)', () => {
+    beforeAll(() => services.shared.workspace.WorkspaceManager.initializeWorkspace([]));
+
+    test('DECLARE directly in a class body (outside methods) does not break parsing', async () => {
+        // A `declare` directly in the class body is not valid BBj, but it must NOT break
+        // parsing of the whole file. It is now accepted as a VariableDecl ClassMember and
+        // the class (incl. members after the declare, and trailing statements) still parses
+        // with zero errors — no cascade of misparsed keywords.
+        const result = await parse(`
+                class public Automatization
+                    declare BBjVector scheduledTasks!
+
+                    method public void run()
+                    methodend
+                classend
+
+                x = 1
+        `, { validation: false });
+        expectNoParserLexerErrors(result);
+        const model = result.parseResult.value as Program;
+        const clazz = model.statements.find(isBbjClass);
+        expect(clazz, 'CLASS should parse as a BbjClass').toBeDefined();
+        expect(clazz!.members.some(isVariableDecl), 'declare captured as a class member').toBe(true);
+    });
+});

--- a/bbj-vscode/test/imports.test.ts
+++ b/bbj-vscode/test/imports.test.ts
@@ -57,6 +57,22 @@ describe('Import tests', async () => {
         expectNoValidationErrors(document);
     });
 
+    test('Static method resolves on an instance variable after USE (#374)', async () => {
+        // Regression for #374: a static method called via an instance (`imp!.zero()`),
+        // not just via the class name (`ImportMe.zero()`), must resolve after `use`.
+        // Previously this produced "Could not resolve reference to Class named 'ImportMe'"
+        // on the constructor and an unresolved member on the instance call.
+        const document = await parse(`
+            use ::importMe.bbj::ImportMe
+            imp! = new ImportMe()
+            num = imp!.zero()
+            num2 = imp!.identity(num)
+            val = imp!.field
+        `, { validation: true });
+        expectNoParserLexerErrors(document);
+        expectNoValidationErrors(document);
+    });
+
     test('No import, use full-qualified constructor afterwards', async () => {
         const document = await parse(`
             let imp = new ::./importMe.bbj::ImportMe()

--- a/bbj-vscode/test/lazy-prefix-loading.test.ts
+++ b/bbj-vscode/test/lazy-prefix-loading.test.ts
@@ -1,0 +1,83 @@
+import { CancellationToken, URI } from 'langium';
+import { FileSystemNode, FileSystemProvider } from 'langium';
+import { parseHelper } from 'langium/test';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { createBBjServices } from '../src/language/bbj-module';
+import { BBjWorkspaceManager } from '../src/language/bbj-ws-manager';
+import { Model } from '../src/language/generated/ast';
+
+/**
+ * Regression harness for #32: the language server must NOT eagerly scan/load every
+ * file under a PREFIX directory. It should lazily load only the files that are
+ * actually referenced by a `use ::file.bbj::Class` statement (and their transitive
+ * USE dependencies). A regression to full-directory scanning would load unreferenced
+ * files too, which this test detects.
+ */
+
+const LIB_DIR = '/virtual/lib';
+const usedUri = URI.file(`${LIB_DIR}/Used.bbj`);
+const unusedUri = URI.file(`${LIB_DIR}/Unused.bbj`);
+const transitiveUri = URI.file(`${LIB_DIR}/Transitive.bbj`);
+
+// Minimal in-memory FS holding three PREFIX files. `Used.bbj` pulls in `Transitive.bbj`
+// via USE; `Unused.bbj` is referenced by nobody. readDirectory lists all three, so an
+// eager-scan regression would have everything it needs to (wrongly) load Unused.bbj.
+const files = new Map<string, string>([
+    [usedUri.fsPath, `class public UsedClass\n    use ::Transitive.bbj::TransitiveClass\nclassend`],
+    [unusedUri.fsPath, `class public UnusedClass\nclassend`],
+    [transitiveUri.fsPath, `class public TransitiveClass\nclassend`],
+]);
+
+class InMemoryFileSystemProvider implements FileSystemProvider {
+    private node(uri: URI, isFile: boolean): FileSystemNode {
+        return { isFile, isDirectory: !isFile, uri };
+    }
+    async stat(uri: URI): Promise<FileSystemNode> { return this.statSync(uri); }
+    statSync(uri: URI): FileSystemNode {
+        if (files.has(uri.fsPath)) return this.node(uri, true);
+        if (uri.fsPath === LIB_DIR) return this.node(uri, false);
+        throw new Error(`ENOENT: ${uri.fsPath}`);
+    }
+    async exists(uri: URI): Promise<boolean> { return files.has(uri.fsPath) || uri.fsPath === LIB_DIR; }
+    async readFile(uri: URI): Promise<string> { return this.readFileSync(uri); }
+    readFileSync(uri: URI): string {
+        const content = files.get(uri.fsPath);
+        if (content === undefined) throw new Error(`ENOENT: ${uri.fsPath}`);
+        return content;
+    }
+    async readDirectory(uri: URI): Promise<FileSystemNode[]> { return this.readDirectorySync(uri); }
+    readDirectorySync(uri: URI): FileSystemNode[] {
+        if (uri.fsPath !== LIB_DIR) return [];
+        return [...files.keys()].map(p => this.node(URI.file(p), true));
+    }
+}
+
+const services = createBBjServices({ fileSystemProvider: () => new InMemoryFileSystemProvider() });
+
+describe('Lazy PREFIX loading (#32)', () => {
+    beforeAll(async () => {
+        await services.shared.workspace.WorkspaceManager.initializeWorkspace([]);
+        // Point PREFIX resolution at our in-memory lib dir (initializeWorkspace has no
+        // config.bbx/project.properties to read here, so we set it directly).
+        const wsManager = services.shared.workspace.WorkspaceManager as BBjWorkspaceManager;
+        (wsManager as unknown as { settings: { prefixes: string[]; classpath: string[] } }).settings =
+            { prefixes: [LIB_DIR], classpath: [] };
+    });
+
+    test('only USE-referenced PREFIX files (and their transitive deps) are loaded', async () => {
+        const parse = parseHelper<Model>(services.BBj);
+        // Main workspace program references Used.bbj only.
+        await parse(`use ::Used.bbj::UsedClass\nx! = new UsedClass()`, {
+            documentUri: 'file:///virtual/project/main.bbj',
+            validation: false,
+        });
+
+        const docs = services.shared.workspace.LangiumDocuments;
+        // Referenced file is loaded on demand...
+        expect(docs.hasDocument(usedUri), 'Used.bbj should be lazily loaded').toBe(true);
+        // ...its transitive USE dependency is followed...
+        expect(docs.hasDocument(transitiveUri), 'Transitive.bbj (used by Used.bbj) should be loaded').toBe(true);
+        // ...but the unreferenced file in the same PREFIX dir must NOT be loaded.
+        expect(docs.hasDocument(unusedUri), 'Unused.bbj must NOT be eagerly loaded').toBe(false);
+    });
+});

--- a/bbj-vscode/test/rename.test.ts
+++ b/bbj-vscode/test/rename.test.ts
@@ -1,0 +1,75 @@
+import { EmptyFileSystem } from 'langium';
+import { parseHelper } from 'langium/test';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { createBBjTestServices } from './bbj-test-module.js';
+import { Model } from '../src/language/generated/ast.js';
+import { initializeWorkspace } from './test-helper.js';
+
+const services = createBBjTestServices(EmptyFileSystem);
+
+describe('Rename Provider Tests (#77)', () => {
+
+    beforeAll(async () => {
+        await initializeWorkspace(services.shared);
+    });
+
+    let counter = 0;
+
+    async function renameAt(source: string, symbol: string, occurrence: number, newName: string) {
+        const parse = parseHelper<Model>(services.BBj);
+        const uri = `file:///test/rename${counter++}.bbj`;
+        const doc = await parse(source, { documentUri: uri, validation: false });
+        const provider = services.BBj.lsp.RenameProvider;
+        expect(provider, 'RenameProvider should be registered').toBeDefined();
+        const text = doc.textDocument.getText();
+        // find the Nth occurrence of `symbol`
+        let idx = -1;
+        for (let i = 0; i < occurrence; i++) {
+            idx = text.indexOf(symbol, idx + 1);
+        }
+        expect(idx, `occurrence ${occurrence} of "${symbol}" found`).toBeGreaterThanOrEqual(0);
+        const position = doc.textDocument.positionAt(idx);
+        const edit = await provider!.rename(doc, {
+            textDocument: { uri: doc.textDocument.uri },
+            position,
+            newName
+        });
+        const edits = edit?.changes?.[uri] ?? [];
+        return edits;
+    }
+
+    test('Renaming a field updates its declaration and #-instance-access references', async () => {
+        // Issue #77: field rename previously behaved wrongly. It must now update both the
+        // FieldDecl and every `#field!` instance-access reference.
+        const source = [
+            'class public Test',
+            '    field public BBjString drawer!',
+            '    method public void setUp()',
+            '        #drawer! = "x"',
+            '        y! = #drawer!',
+            '    methodend',
+            'classend'
+        ].join('\n');
+        // position on the declaration occurrence of drawer!
+        const edits = await renameAt(source, 'drawer!', 1, 'cabinet!');
+        // declaration + two #drawer! references = 3 edit sites
+        expect(edits.length).toBeGreaterThanOrEqual(3);
+        expect(edits.every(e => e.newText === 'cabinet!')).toBe(true);
+    });
+
+    test('Renaming a method updates its declaration and call sites', async () => {
+        const source = [
+            'class public Test',
+            '    method public void doWork()',
+            '    methodend',
+            '    method public void run()',
+            '        #doWork()',
+            '    methodend',
+            'classend'
+        ].join('\n');
+        const edits = await renameAt(source, 'doWork', 1, 'process');
+        // declaration + one #doWork() call = 2 edit sites
+        expect(edits.length).toBeGreaterThanOrEqual(2);
+        expect(edits.every(e => e.newText === 'process')).toBe(true);
+    });
+});


### PR DESCRIPTION
## What

During the open-issue triage pass, several issues were verified as **already fixed** on `main` but had **no test locking the behavior**. This PR adds that coverage so they can't silently regress. **Test-only — no production code changed.**

| Issue | What it locks | File |
|------|----------------|------|
| **#374** | A static method called via an **instance variable** after `use ::file.bbj::` (`imp!.zero()`, `imp!.identity()`, `imp!.field`), not just via the class name | `test/imports.test.ts` |
| **#380** | A stray `declare` directly in a **class body** (outside methods) must not break parsing — captured as a `VariableDecl` member, file still parses cleanly, no cascade | `test/declare-in-class.test.ts` (new) |
| **#77** | LSP **rename** returns edits for a field/method declaration **and** every `#`-instance-access reference / call site | `test/rename.test.ts` (new) |
| **#32** | **Lazy PREFIX loading** — only `USE`-referenced files (and their transitive `USE` deps) load; an unreferenced sibling in the same PREFIX dir never loads | `test/lazy-prefix-loading.test.ts` (new) |

The #32 test uses a small in-memory `FileSystemProvider` seeded with three PREFIX files (`Used.bbj` → `use Transitive.bbj`, plus an unreferenced `Unused.bbj`) whose `readDirectory` lists all three — so a regression to eager full-directory scanning would load `Unused.bbj` and fail the test.

### Not added (and why)
- **#367** — the reproducible part (hex / `$$` / `$0A1E$` lexing) is already covered by existing parser tests; the rest was an external-file resolution grab-bag confirmed OBE by the maintainers.
- **#375 / #376 / #377** — already covered by `GRAM-01/02/03` parser tests.
- **#158** (log-noise gating) — asserting a log line is silent at `WARN` is brittle infra-testing.
- **#386** (README doc links) — docs, not code.

## Testing
Full suite on this branch (based on `main`, without PR #421): **532 passed, 19 skipped, 0 failed.** `tsc --noEmit` and eslint clean.

Companion to #421 (the #388 fix + its regression tests). This branch is based on `main` and is independent of #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)