### PR TITLE
Fix #378: resolve relative USE paths against the workspace/project root

### DIFF
--- a/bbj-vscode/src/language/bbj-scope.ts
+++ b/bbj-vscode/src/language/bbj-scope.ts
@@ -270,9 +270,12 @@ export class BbjScopeProvider extends DefaultScopeProvider {
     private getBBjClassesFromFile(container: AstNode, bbjFilePath: string, simpleName: boolean) {
         const currentDocUri = AstUtils.getDocument(container).uri;
         const prefixes = this.workspaceManager.getSettings()?.prefixes ?? [];
-        const adjustedFileUris = [UriUtils.resolvePath(UriUtils.dirname(currentDocUri), bbjFilePath)].concat(
-            prefixes.map(prefixPath => URI.file(resolve(prefixPath, bbjFilePath)))
-        );
+        const workspaceRoots = this.workspaceManager.getWorkspaceFolderUris();
+        const adjustedFileUris = [UriUtils.resolvePath(UriUtils.dirname(currentDocUri), bbjFilePath)]
+            // Resolve relative to each workspace/project root too (#378), so a USE from a
+            // subfolder can reference files by their project-root-relative path.
+            .concat(workspaceRoots.map(root => UriUtils.resolvePath(root, bbjFilePath)))
+            .concat(prefixes.map(prefixPath => URI.file(resolve(prefixPath, bbjFilePath))));
         let bbjClasses = this.indexManager.allElements(BbjClass.$type).filter(bbjClass => {
             return adjustedFileUris.some(adjustedFileUri => normalize(bbjClass.documentUri.fsPath).toLowerCase() === normalize(adjustedFileUri.fsPath).toLowerCase());
         })

--- a/bbj-vscode/src/language/bbj-validator.ts
+++ b/bbj-vscode/src/language/bbj-validator.ts
@@ -274,11 +274,14 @@ export class BBjValidator {
                 const cleanPath = match[1];
                 const currentDocUri = AstUtils.getDocument(use).uri;
                 const prefixes = this.workspaceManager.getSettings()?.prefixes ?? [];
+                const workspaceRoots = this.workspaceManager.getWorkspaceFolderUris();
                 const adjustedFileUris = [
                     UriUtils.resolvePath(UriUtils.dirname(currentDocUri), cleanPath)
-                ].concat(
-                    prefixes.map(prefixPath => URI.file(resolve(prefixPath, cleanPath)))
-                );
+                ]
+                    // Also resolve relative to each workspace/project root (#378), matching
+                    // the scope provider so the diagnostic agrees with actual resolution.
+                    .concat(workspaceRoots.map(root => UriUtils.resolvePath(root, cleanPath)))
+                    .concat(prefixes.map(prefixPath => URI.file(resolve(prefixPath, cleanPath))));
                 // Check if a document exists at any candidate URI. We check document
                 // existence rather than BbjClass index entries because external files
                 // may have parser errors that prevent BbjClass nodes from being created,

--- a/bbj-vscode/src/language/bbj-ws-manager.ts
+++ b/bbj-vscode/src/language/bbj-ws-manager.ts
@@ -211,6 +211,15 @@ export class BBjWorkspaceManager extends DefaultWorkspaceManager {
         return this.settings;
     }
 
+    /**
+     * Root URIs of the open workspace folders. Used as additional base directories when
+     * resolving relative `use ::path::Class` references, so a USE from a subfolder can
+     * address files relative to the project root (#378), not only the current file's dir.
+     */
+    public getWorkspaceFolderUris(): URI[] {
+        return this.folders?.map(folder => this.getRootFolder(folder)) ?? [];
+    }
+
     public getBBjDir() {
         return this.bbjdir;
     }

--- a/bbj-vscode/test/use-project-root.test.ts
+++ b/bbj-vscode/test/use-project-root.test.ts
@@ -1,0 +1,55 @@
+import { EmptyFileSystem, URI, LangiumDocument } from 'langium';
+import { WorkspaceFolder } from 'vscode-languageserver';
+import { parseHelper } from 'langium/test';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { DocumentValidator } from 'langium';
+import { createBBjServices } from '../src/language/bbj-module';
+import { BBjWorkspaceManager } from '../src/language/bbj-ws-manager';
+import { Model } from '../src/language/generated/ast';
+
+/**
+ * Regression for #378: a relative `use ::subdir/file.bbj::Class` from a program in a
+ * subfolder must resolve against the workspace/project root, not only the current file's
+ * directory. Previously it only searched `<current-file-dir>/subdir/file.bbj` (and PREFIXes),
+ * so a project-root-relative USE from a nested file failed to resolve.
+ */
+
+const services = createBBjServices(EmptyFileSystem);
+const parse = parseHelper<Model>(services.BBj);
+
+function linkingErrors(doc: LangiumDocument) {
+    return (doc.diagnostics ?? []).filter(d => d.data?.code === DocumentValidator.LinkingError);
+}
+function fileNotResolvedErrors(doc: LangiumDocument) {
+    return (doc.diagnostics ?? []).filter(d => d.message.includes('could not be resolved'));
+}
+
+describe('USE resolves relative to the project root (#378)', () => {
+    beforeAll(async () => {
+        await services.shared.workspace.WorkspaceManager.initializeWorkspace([]);
+        // Simulate an open workspace rooted at /root (initializeWorkspace([]) leaves folders
+        // empty in this harness, so set it directly).
+        const wsManager = services.shared.workspace.WorkspaceManager as BBjWorkspaceManager;
+        const folders: WorkspaceFolder[] = [{ uri: URI.file('/root').toString(), name: 'root' }];
+        (wsManager as unknown as { folders: WorkspaceFolder[] }).folders = folders;
+
+        // Target class lives at <root>/lib/MyClass.bbj
+        await parse(`class public MyClass\n    method public void doWork()\n    methodend\nclassend`, {
+            documentUri: URI.file('/root/lib/MyClass.bbj').toString(),
+            validation: false,
+        });
+    });
+
+    test('project-root-relative USE from a nested file resolves the class', async () => {
+        // Consumer sits in a *different* subfolder; the USE path is relative to the project root.
+        const consumer = await parse(`use ::lib/MyClass.bbj::MyClass\n\nx! = new MyClass()\nx!.doWork()`, {
+            documentUri: URI.file('/root/app/main.bbj').toString(),
+            validation: true,
+        });
+        expect(consumer.parseResult.parserErrors).toHaveLength(0);
+        // The USE file-path diagnostic must not fire...
+        expect(fileNotResolvedErrors(consumer).map(d => d.message).join('\n')).toBe('');
+        // ...and the class/constructor/method must all link.
+        expect(linkingErrors(consumer).map(d => d.message).join('\n')).toBe('');
+    });
+});


### PR DESCRIPTION
## What

`use ::subdir/file.bbj::Class` was resolved only against the **current file's directory** (plus PREFIX dirs). A USE written relative to the **project root** from a file in a subfolder therefore failed:

```
File 'lib/MyClass.bbj' could not be resolved.
Searched: /root/app/lib/MyClass.bbj, <prefixes...>
```

(the real file being at `/root/lib/MyClass.bbj`).

## Fix

Add the open workspace folder root(s) as additional resolution bases:
- New `BBjWorkspaceManager.getWorkspaceFolderUris()` exposes the folder roots (from `DefaultWorkspaceManager.folders`).
- Both `getBBjClassesFromFile` (scope provider, `bbj-scope.ts`) and the USE file-path validator (`bbj-validator.ts`) now append `<workspace-root>/<path>` to their candidate URIs — kept in sync so the diagnostic agrees with actual resolution.

## Testing

New `test/use-project-root.test.ts`: a project-root-relative USE from a nested file resolves the class, its constructor, and a method call. **Verified failing without the fix** (temporarily neutralizing the accessor makes the class unresolvable).

Full suite: **544 passed, 20 skipped, 0 failed.** `tsc --noEmit` and eslint clean.

Closes #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)