### PR TITLE
Fix #107: multiline strings lose string highlighting

### DIFF
--- a/bbj-vscode/package-lock.json
+++ b/bbj-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bbj-lang",
-  "version": "0.8.15",
+  "version": "0.8.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bbj-lang",
-      "version": "0.8.15",
+      "version": "0.8.32",
       "license": "MIT",
       "dependencies": {
         "@vscode/vsce": "^3.7.1",
@@ -29,7 +29,9 @@
         "shx": "^0.4.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.64.0",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.10",
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.3.2"
       },
       "engines": {
         "vscode": "^1.101.0"
@@ -7664,6 +7666,20 @@
         "vscode-jsonrpc": "9.0.0",
         "vscode-languageserver-types": "3.18.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
+      "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-textmate": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.3.2.tgz",
+      "integrity": "sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -598,6 +598,8 @@
     "shx": "^0.4.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.64.0",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "vscode-oniguruma": "^2.0.1",
+    "vscode-textmate": "^9.3.2"
   }
 }

--- a/bbj-vscode/syntaxes/bbj.tmLanguage.json
+++ b/bbj-vscode/syntaxes/bbj.tmLanguage.json
@@ -67,8 +67,8 @@
     },
     "string-character-escape": {
       "name": "constant.character.escape.bbj",
-      "comment": "Don't escape \\ as it not an escape char in BBx",
-      "match": "(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u\\{[0-9A-Fa-f]+\\}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)"
+      "comment": "Don't escape \\ as it not an escape char in BBx. Note: no `|$` end-of-line alternative here — a zero-width EOL match pops the multi-line string context when the opening quote is the last char on a line, breaking `:`-continued multiline strings (#107).",
+      "match": "(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u\\{[0-9A-Fa-f]+\\}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)"
     }
   }
 }

--- a/bbj-vscode/test/textmate-highlighting.test.ts
+++ b/bbj-vscode/test/textmate-highlighting.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'fs';
+import { beforeAll, describe, expect, test } from 'vitest';
+import * as oniguruma from 'vscode-oniguruma';
+import { INITIAL, IGrammar, Registry, StateStack, parseRawGrammar } from 'vscode-textmate';
+
+/**
+ * Real TextMate tokenization test for the BBj grammar. Regression for #107: a BBj
+ * multiline string (opening quote is the last char on the line, continuation lines
+ * begin with `:`) must stay in the string scope across all physical lines, instead of
+ * dropping the string scope after the opening quote.
+ */
+
+const STRING_SCOPE = 'string.quoted.double.bbj';
+
+let grammar: IGrammar;
+
+beforeAll(async () => {
+    await oniguruma.loadWASM(readFileSync('node_modules/vscode-oniguruma/release/onig.wasm'));
+    const registry = new Registry({
+        onigLib: Promise.resolve({
+            createOnigScanner: (patterns: string[]) => new oniguruma.OnigScanner(patterns),
+            createOnigString: (s: string) => new oniguruma.OnigString(s),
+        }),
+        loadGrammar: async (scopeName: string) => {
+            if (scopeName === 'source.bbj') {
+                const content = readFileSync('syntaxes/bbj.tmLanguage.json', 'utf8');
+                return parseRawGrammar(content, 'bbj.tmLanguage.json');
+            }
+            return null;
+        },
+    });
+    const loaded = await registry.loadGrammar('source.bbj');
+    if (!loaded) throw new Error('failed to load source.bbj grammar');
+    grammar = loaded;
+});
+
+/** Tokenize multiple lines, carrying grammar state across line breaks (as an editor does). */
+function tokenizeLines(lines: string[]): Array<Array<{ text: string; scopes: string[] }>> {
+    let ruleStack: StateStack = INITIAL;
+    return lines.map(line => {
+        const result = grammar.tokenizeLine(line, ruleStack);
+        ruleStack = result.ruleStack;
+        return result.tokens.map(t => ({ text: line.substring(t.startIndex, t.endIndex), scopes: t.scopes }));
+    });
+}
+
+describe('TextMate highlighting (#107)', () => {
+    test('a `:`-continued multiline string stays in string scope across lines', () => {
+        // From the issue. Inner quotes are single quotes: inside a BBj "double" string a
+        // bare " would close it (""" escapes), so the real example uses '...'.
+        const lines = [
+            'pos! = inputD!.executeScript("',
+            ': (async () => {',
+            ":  await customElements.whenDefined('bbj-inputd');",
+            ':  return (await component.getPart(\'input\')).selectionStart',
+            ':", BBjAPI.TRUE)',
+        ];
+        const perLine = tokenizeLines(lines);
+
+        // Opening line: the trailing `"` opens the string.
+        expect(perLine[0].some(t => t.scopes.includes(STRING_SCOPE)), 'opening quote starts a string').toBe(true);
+
+        // Continuation lines (1..3) must be entirely inside the string scope.
+        for (let i = 1; i <= 3; i++) {
+            const allString = perLine[i].every(t => t.scopes.includes(STRING_SCOPE));
+            expect(allString, `line ${i} ("${lines[i]}") should be fully inside the string`).toBe(true);
+        }
+
+        // Final line: the closing `"` ends the string; the code after it (BBjAPI, TRUE)
+        // must NOT be string-scoped.
+        const lastLine = perLine[4];
+        const apiToken = lastLine.find(t => t.text.includes('BBjAPI'));
+        expect(apiToken, 'BBjAPI token present on the closing line').toBeDefined();
+        expect(apiToken!.scopes.includes(STRING_SCOPE), 'code after the closing quote is not string-scoped').toBe(false);
+    });
+
+    test('a normal single-line string still terminates at its closing quote', () => {
+        const [tokens] = tokenizeLines(['x$ = "hello" + y$']);
+        const yToken = tokens.find(t => t.text.includes('y$'));
+        expect(yToken, 'y$ token present').toBeDefined();
+        expect(yToken!.scopes.includes(STRING_SCOPE), 'text after the closed string is not string-scoped').toBe(false);
+    });
+});


### PR DESCRIPTION
## What

A BBj string can span multiple physical lines (continuation lines begin with `:`):

```bbj
pos! = inputD!.executeScript("
: (async () => {
:  await customElements.whenDefined('bbj-inputd');
:  return (await component.getPart('input')).selectionStart
:", BBjAPI.TRUE)
```

When the opening `"` is the **last character on the line**, the string lost its scope: the continuation lines were highlighted as code, and the trailing real code (`, BBjAPI.TRUE)`) was highlighted as string.

## Root cause & fix

The string rule is a multi-line `begin:"` / `end:"` span, but the shared `string-character-escape` pattern ended with a `|$` alternative (`syntaxes/bbj.tmLanguage.json`). That zero-width end-of-line match popped the string context at EOL when the quote was the last char on the line. Removing `|$` lets the string span lines until the closing quote — which is what BBj requires. (Diagnosis and fix per @StephanWald's triage on the issue.)

## Testing

Adds a **real TextMate tokenization test** (`test/textmate-highlighting.test.ts`) — new dev-only deps `vscode-textmate` + `vscode-oniguruma` — that loads the actual grammar and asserts:
- a `:`-continued multiline string stays `string.quoted.double.bbj` across all lines,
- code after the closing quote is **not** string-scoped,
- a normal single-line string still terminates at its closing quote.

**Verified failing with `|$` present.** Full suite: **545 passed, 20 skipped, 0 failed.** `tsc --noEmit` and eslint clean; grammar JSON validated.

This repo previously had no tests for its TextMate grammar; this adds the harness for future highlighting regressions.

Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)