### PR TITLE
Fix "clazz.comments is not iterable" crash in comment provider

### DIFF
--- a/bbj-vscode/src/language/bbj-comment-provider.ts
+++ b/bbj-vscode/src/language/bbj-comment-provider.ts
@@ -1,6 +1,6 @@
 import { AstNode, GenericAstNode } from "langium";
 import { CommentProvider } from "langium";
-import { BbjClass, CommentStatement, isBBjClassMember, isBbjClass, isCommentStatement } from "./generated/ast.js";
+import { CommentStatement, isBBjClassMember, isBbjClass, isCommentStatement } from "./generated/ast.js";
 
 export class BBjCommentProvider implements CommentProvider {
 
@@ -24,12 +24,16 @@ export class BBjCommentProvider implements CommentProvider {
                     }
                 }
             }
-        } else if (isBBjClassMember(node)) {
+        } else if (isBBjClassMember(node) && isBbjClass(node.$container)) {
+            // Note: BBjClassMember includes VariableDecl, which is also a plain DECLARE
+            // statement that can live outside a class (in a Program or method body). Only
+            // treat it as a class member when its container really is a BbjClass — otherwise
+            // clazz.comments / clazz.members are undefined and iterating them throws (#comment-crash).
             const untilOffset = node.$cstNode?.offset;
-            const clazz = (node.$container as BbjClass);
+            const clazz = node.$container;
             const fromOffset = node.$containerIndex === 0 ? clazz.$cstNode?.offset : clazz.members[node.$containerIndex! - 1].$cstNode?.end;
             const comments = []
-            for (const comment of clazz.comments) {
+            for (const comment of clazz.comments ?? []) {
                 if (comment.$cstNode?.offset! < untilOffset! && comment.$cstNode?.end! > fromOffset!) {
                     const commentText = cutRemKeyword(comment);
                     if (commentText?.startsWith('/**')) {

--- a/bbj-vscode/test/comment-provider.test.ts
+++ b/bbj-vscode/test/comment-provider.test.ts
@@ -1,8 +1,8 @@
-import { EmptyFileSystem } from 'langium';
+import { AstUtils, EmptyFileSystem } from 'langium';
 import { parseHelper } from 'langium/test';
 import { describe, expect, test } from 'vitest';
 import { createBBjServices } from '../src/language/bbj-module.js';
-import { Model, Program, isBbjClass } from '../src/language/generated/ast.js';
+import { Model, Program, isBbjClass, isVariableDecl } from '../src/language/generated/ast.js';
 
 
 const services = createBBjServices(EmptyFileSystem);
@@ -41,5 +41,27 @@ classend
         expect(commentProvider.getComment(clazz)).toBe('/**\n* Javadoc for TestClass\n*/')
         expect(commentProvider.getComment(clazz.members[0])).toBe('/**\n* Javadoc for Method TEST\n*/')
         expect(commentProvider.getComment(clazz.members[1])).toBe('/**\n* Javadoc for Field TEST\n*/')
+    })
+
+    test('getComment on a DECLARE outside a class does not throw', async () => {
+        // Regression: a VariableDecl (DECLARE) is a BBjClassMember by type but can live in a
+        // Program or method body, whose container has no `comments`/`members`. getComment must
+        // not throw "clazz.comments is not iterable" (crashed completion documentation).
+        const doc = await parse(`
+            declare BBjString foo!
+            foo! = "x"
+
+            class public C
+                method public void m()
+                    declare BBjString bar!
+                    declare BBjString baz!
+                methodend
+            classend
+        `, { validation: false });
+        const decls = [...AstUtils.streamAst(doc.parseResult.value)].filter(isVariableDecl);
+        expect(decls.length).toBe(3);
+        for (const decl of decls) {
+            expect(() => commentProvider.getComment(decl)).not.toThrow();
+        }
     })
 })


### PR DESCRIPTION
## What

The LS error log was being spammed with:

```
TypeError: clazz.comments is not iterable
  at BBjCommentProvider.getComment
  at JSDocDocumentationProvider.getDocumentation
  at _BBjCompletionProvider.getReferenceDocumentation
  at _BBjCompletionProvider.createReferenceCompletionItem
  ...
```

## Root cause

`getComment` treats any `BBjClassMember` as a class member and iterates `node.$container` as a `BbjClass`:

```ts
} else if (isBBjClassMember(node)) {
    const clazz = node.$container as BbjClass;
    ... clazz.members[...] ...
    for (const comment of clazz.comments) { ... }
```

But `BBjClassMember = FieldDecl | MethodDecl | VariableDecl`, and a **`VariableDecl` is also a plain `DECLARE` statement** that can live outside a class — at the top level (container = `Program`) or in a method body (container = `MethodDecl`). Those containers have no `comments` array → `for..of` throws. `clazz.members[...]` is a second latent crash on the same path (for a non-first `DECLARE` in a method body).

It surfaces through completion: building the documentation for a completion candidate that resolves to a top-level `DECLARE`d variable.

## Reproduction

A file containing a top-level `declare` and a reference to it; trigger completion on the reference (its candidate documentation calls `getComment`):

```bbj
declare BBjString foo!
foo! = "x"
```

## Fix

Only take the class-member branch when the container is actually a `BbjClass`; guard `clazz.comments` defensively. Non-class `DECLARE`s now return no doc instead of crashing.

## Testing

New regression test in `comment-provider.test.ts` covering a top-level `DECLARE` and (first + non-first) `DECLARE`s in a method body. Full suite: **544 passed, 20 skipped, 0 failed.** `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)