### PR TITLE
Visual MSGBOX composer: webview panel with live preview (#426)

### DIFF
--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -152,6 +152,11 @@
         "category": "BBj",
         "command": "bbj.composeMsgbox",
         "title": "Compose MSGBOX…"
+      },
+      {
+        "category": "BBj",
+        "command": "bbj.composeMsgboxVisual",
+        "title": "Compose MSGBOX (visual)…"
       }
     ],
     "keybindings": [
@@ -205,6 +210,11 @@
         },
         {
           "command": "bbj.composeMsgbox",
+          "when": "editorLangId == bbj",
+          "group": "1_modification"
+        },
+        {
+          "command": "bbj.composeMsgboxVisual",
           "when": "editorLangId == bbj",
           "group": "1_modification"
         }

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -577,7 +577,9 @@
     "onCommand:bbj.configureCompileOptions",
     "onCommand:bbj.denumber",
     "onCommand:bbj.decompile",
-    "onCommand:bbj.decompileReadonly"
+    "onCommand:bbj.decompileReadonly",
+    "onCommand:bbj.composeMsgbox",
+    "onCommand:bbj.composeMsgboxVisual"
   ],
   "main": "./out/extension.cjs",
   "scripts": {

--- a/bbj-vscode/src/msgbox-composer-ui.ts
+++ b/bbj-vscode/src/msgbox-composer-ui.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import {
     BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS, CatalogItem,
     MsgboxState, DEFAULT_STATE, encode, decode, describe, composeStatement, findMsgboxCallAt, flagsFromState,
+    splitButtonsAndTrailing,
 } from './msgbox-composer.js';
 import { openMsgboxComposerPanel, MsgboxPanelArg } from './msgbox-composer-webview.js';
 
@@ -42,25 +43,21 @@ class MsgboxCodeActionProvider implements vscode.CodeActionProvider {
         if (!info) {
             return [];
         }
-        // The span of the whole MSGBOX(...) call and any args past the title we preserve verbatim.
-        const target = {
-            uri: document.uri.toString(),
-            line: lineNo,
-            callStart: info.callStart,
-            callEnd: info.callEnd,
-            trailingArgs: info.args.slice(3),
-        };
+        const callSpan = { uri: document.uri.toString(), line: lineNo, callStart: info.callStart, callEnd: info.callEnd };
 
         // Existing numeric options -> open the visual editor prefilled from the current call.
         if (info.exprRange && info.exprValue !== undefined) {
             const st = decode(info.exprValue);
+            // Split args past the title into custom button labels vs. args to preserve verbatim.
+            const { buttons, trailing } = splitButtonsAndTrailing(info.args.slice(3), st.buttonSet === 7);
             const arg: MsgboxPanelArg = {
-                target,
+                target: { ...callSpan, trailingArgs: trailing },
                 initial: {
                     message: info.args[0] ?? '""',
                     title: info.args[2] ?? '',
                     buttonSet: st.buttonSet, icon: st.icon, defaultButton: st.defaultButton,
                     flags: flagsFromState(st),
+                    customButtons: buttons,
                 },
             };
             return [visualAction(`Configure MSGBOX options (${describe(info.exprValue)})`, arg)];
@@ -68,11 +65,11 @@ class MsgboxCodeActionProvider implements vscode.CodeActionProvider {
         // Bare MSGBOX("...") with no options yet -> open the visual editor to add them.
         if (info.optionInsertOffset !== undefined) {
             const arg: MsgboxPanelArg = {
-                target: { ...target, trailingArgs: [] },
+                target: { ...callSpan, trailingArgs: [] },
                 initial: {
                     message: info.args[0] ?? '""',
                     title: '',
-                    buttonSet: 0, icon: 0, defaultButton: 0, flags: [],
+                    buttonSet: 0, icon: 0, defaultButton: 0, flags: [], customButtons: [],
                 },
             };
             return [visualAction('Add MSGBOX options…', arg)];

--- a/bbj-vscode/src/msgbox-composer-ui.ts
+++ b/bbj-vscode/src/msgbox-composer-ui.ts
@@ -10,9 +10,9 @@
 import * as vscode from 'vscode';
 import {
     BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS, CatalogItem,
-    MsgboxState, DEFAULT_STATE, encode, decode, describe, composeStatement, findMsgboxCallAt,
+    MsgboxState, DEFAULT_STATE, encode, decode, describe, composeStatement, findMsgboxCallAt, flagsFromState,
 } from './msgbox-composer.js';
-import { openMsgboxComposerPanel } from './msgbox-composer-webview.js';
+import { openMsgboxComposerPanel, MsgboxPanelArg } from './msgbox-composer-webview.js';
 
 interface ComposeArg {
     /** Reconfigure an existing numeric `expr` in place (call already has options). */
@@ -24,7 +24,7 @@ interface ComposeArg {
 export function registerMsgboxComposer(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         vscode.commands.registerCommand('bbj.composeMsgbox', (arg?: ComposeArg) => runComposer(arg)),
-        vscode.commands.registerCommand('bbj.composeMsgboxVisual', () => openMsgboxComposerPanel(context)),
+        vscode.commands.registerCommand('bbj.composeMsgboxVisual', (arg?: MsgboxPanelArg) => openMsgboxComposerPanel(context, arg)),
         vscode.languages.registerCodeActionsProvider(
             { language: 'bbj' },
             new MsgboxCodeActionProvider(),
@@ -42,31 +42,49 @@ class MsgboxCodeActionProvider implements vscode.CodeActionProvider {
         if (!info) {
             return [];
         }
-        // Existing numeric options -> reconfigure in place.
+        // The span of the whole MSGBOX(...) call and any args past the title we preserve verbatim.
+        const target = {
+            uri: document.uri.toString(),
+            line: lineNo,
+            callStart: info.callStart,
+            callEnd: info.callEnd,
+            trailingArgs: info.args.slice(3),
+        };
+
+        // Existing numeric options -> open the visual editor prefilled from the current call.
         if (info.exprRange && info.exprValue !== undefined) {
-            const action = new vscode.CodeAction(
-                `Configure MSGBOX options (${describe(info.exprValue)})`,
-                vscode.CodeActionKind.RefactorRewrite,
-            );
-            action.command = {
-                command: 'bbj.composeMsgbox',
-                title: 'Configure MSGBOX options',
-                arguments: [{ edit: { line: lineNo, exprRange: info.exprRange, current: info.exprValue } } satisfies ComposeArg],
+            const st = decode(info.exprValue);
+            const arg: MsgboxPanelArg = {
+                target,
+                initial: {
+                    message: info.args[0] ?? '""',
+                    title: info.args[2] ?? '',
+                    buttonSet: st.buttonSet, icon: st.icon, defaultButton: st.defaultButton,
+                    flags: flagsFromState(st),
+                },
             };
-            return [action];
+            return [visualAction(`Configure MSGBOX options (${describe(info.exprValue)})`, arg)];
         }
-        // Bare MSGBOX("...") with no options yet -> add options.
+        // Bare MSGBOX("...") with no options yet -> open the visual editor to add them.
         if (info.optionInsertOffset !== undefined) {
-            const action = new vscode.CodeAction('Add MSGBOX options…', vscode.CodeActionKind.RefactorRewrite);
-            action.command = {
-                command: 'bbj.composeMsgbox',
-                title: 'Add MSGBOX options',
-                arguments: [{ insert: { line: lineNo, character: info.optionInsertOffset } } satisfies ComposeArg],
+            const arg: MsgboxPanelArg = {
+                target: { ...target, trailingArgs: [] },
+                initial: {
+                    message: info.args[0] ?? '""',
+                    title: '',
+                    buttonSet: 0, icon: 0, defaultButton: 0, flags: [],
+                },
             };
-            return [action];
+            return [visualAction('Add MSGBOX options…', arg)];
         }
         return [];
     }
+}
+
+function visualAction(title: string, arg: MsgboxPanelArg): vscode.CodeAction {
+    const action = new vscode.CodeAction(title, vscode.CodeActionKind.RefactorRewrite);
+    action.command = { command: 'bbj.composeMsgboxVisual', title, arguments: [arg] };
+    return action;
 }
 
 async function runComposer(arg?: ComposeArg): Promise<void> {

--- a/bbj-vscode/src/msgbox-composer-ui.ts
+++ b/bbj-vscode/src/msgbox-composer-ui.ts
@@ -12,6 +12,7 @@ import {
     BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS, CatalogItem,
     MsgboxState, DEFAULT_STATE, encode, decode, describe, composeStatement, findMsgboxCallAt,
 } from './msgbox-composer.js';
+import { openMsgboxComposerPanel } from './msgbox-composer-webview.js';
 
 interface ComposeArg {
     /** Reconfigure an existing numeric `expr` in place (call already has options). */
@@ -23,6 +24,7 @@ interface ComposeArg {
 export function registerMsgboxComposer(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         vscode.commands.registerCommand('bbj.composeMsgbox', (arg?: ComposeArg) => runComposer(arg)),
+        vscode.commands.registerCommand('bbj.composeMsgboxVisual', () => openMsgboxComposerPanel(context)),
         vscode.languages.registerCodeActionsProvider(
             { language: 'bbj' },
             new MsgboxCodeActionProvider(),

--- a/bbj-vscode/src/msgbox-composer-webview.ts
+++ b/bbj-vscode/src/msgbox-composer-webview.ts
@@ -132,16 +132,17 @@ export function openMsgboxComposerPanel(context: vscode.ExtensionContext, arg?: 
                 if (!msg.payload) break;
                 const r = build(msg.payload);
                 if (!r.valid) break; // guard; the webview also disables the button
+                // Apply via a WorkspaceEdit so the change lands in the existing editor tab
+                // without opening the document again in the webview's (Beside) column.
+                const edit = new vscode.WorkspaceEdit();
                 if (editMode && arg?.target) {
-                    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(arg.target.uri));
-                    const ed = await vscode.window.showTextDocument(doc, { preserveFocus: false });
+                    const uri = vscode.Uri.parse(arg.target.uri);
                     const range = new vscode.Range(arg.target.line, arg.target.callStart, arg.target.line, arg.target.callEnd);
-                    await ed.edit(b => b.replace(range, r.statement));
+                    edit.replace(uri, range, r.statement);
                 } else if (insertUri && insertPosition) {
-                    const doc = await vscode.workspace.openTextDocument(insertUri);
-                    const ed = await vscode.window.showTextDocument(doc, { preserveFocus: false });
-                    await ed.edit(b => b.insert(insertPosition!, r.statement));
+                    edit.insert(insertUri, insertPosition, r.statement);
                 }
+                await vscode.workspace.applyEdit(edit);
                 panel.dispose();
                 break;
             }

--- a/bbj-vscode/src/msgbox-composer-webview.ts
+++ b/bbj-vscode/src/msgbox-composer-webview.ts
@@ -1,0 +1,238 @@
+/**
+ * Visual MSGBOX composer — a webview panel with a live preview of the generated statement (#426).
+ *
+ * The panel is pure presentation: it renders a form from the option catalog and sends the raw
+ * selection back to the extension, which computes `expr`/statement text with the shared
+ * ./msgbox-composer logic (no flag math is duplicated in the webview). On "Insert" the composed
+ * statement is written into the editor that was active when the panel opened.
+ */
+import * as vscode from 'vscode';
+import {
+    BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS,
+    encode, describe, composeStatement, stateFromSelection,
+} from './msgbox-composer.js';
+
+interface Selection {
+    buttonSet: number;
+    icon: number;
+    defaultButton: number;
+    flags: number[];
+    message: string;
+    title: string;
+    assignTo: string;
+}
+
+export function openMsgboxComposerPanel(context: vscode.ExtensionContext): void {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        vscode.window.showInformationMessage('Open a BBj file first, then run the MSGBOX composer.');
+        return;
+    }
+    const targetUri = editor.document.uri;
+    const insertPosition = editor.selection.active;
+
+    const panel = vscode.window.createWebviewPanel(
+        'bbjMsgboxComposer',
+        'MSGBOX Composer',
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        { enableScripts: true, retainContextWhenHidden: true },
+    );
+    panel.webview.html = getHtml(panel.webview);
+
+    function build(sel: Selection): { expr: number; statement: string; summary: string } {
+        const expr = encode(stateFromSelection(sel));
+        const statement = composeStatement({
+            message: sel.message || '""',
+            expr,
+            title: sel.title || undefined,
+            assignTo: sel.assignTo || undefined,
+        });
+        return { expr, statement, summary: describe(expr) };
+    }
+
+    panel.webview.onDidReceiveMessage(async (msg: { type: string; payload?: Selection }) => {
+        switch (msg.type) {
+            case 'ready':
+                panel.webview.postMessage({
+                    type: 'init',
+                    catalogs: { buttonSets: BUTTON_SETS, icons: ICONS, defaultButtons: DEFAULT_BUTTONS, flags: FLAGS },
+                });
+                break;
+            case 'change':
+                if (msg.payload) {
+                    panel.webview.postMessage({ type: 'preview', ...build(msg.payload) });
+                }
+                break;
+            case 'insert':
+                if (msg.payload) {
+                    const { statement } = build(msg.payload);
+                    const doc = await vscode.workspace.openTextDocument(targetUri);
+                    const target = await vscode.window.showTextDocument(doc, { preserveFocus: false });
+                    await target.edit(b => b.insert(insertPosition, statement));
+                    panel.dispose();
+                }
+                break;
+            case 'cancel':
+                panel.dispose();
+                break;
+        }
+    }, undefined, context.subscriptions);
+}
+
+function getHtml(webview: vscode.Webview): string {
+    const nonce = getNonce();
+    const csp = [
+        `default-src 'none'`,
+        `style-src ${webview.cspSource} 'unsafe-inline'`,
+        `script-src 'nonce-${nonce}'`,
+    ].join('; ');
+    return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MSGBOX Composer</title>
+<style>
+  body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 12px 16px; }
+  h2 { margin: 0 0 12px; font-size: 1.1em; }
+  .row { display: flex; flex-direction: column; gap: 4px; margin-bottom: 12px; }
+  label { font-size: 0.85em; opacity: 0.85; }
+  select, input[type="text"] {
+    background: var(--vscode-input-background); color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent); padding: 4px 6px; border-radius: 2px;
+    font-family: var(--vscode-font-family); font-size: 0.95em;
+  }
+  fieldset { border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 3px; margin: 0 0 12px; padding: 8px 10px; }
+  legend { font-size: 0.82em; opacity: 0.85; padding: 0 4px; }
+  .check { display: flex; align-items: center; gap: 6px; font-size: 0.9em; margin: 3px 0; }
+  .preview { margin: 8px 0 4px; }
+  pre {
+    background: var(--vscode-textCodeBlock-background); border: 1px solid var(--vscode-panel-border);
+    padding: 8px 10px; border-radius: 3px; white-space: pre-wrap; word-break: break-all; margin: 4px 0;
+  }
+  .summary { font-size: 0.82em; opacity: 0.75; min-height: 1.1em; }
+  .buttons { display: flex; gap: 8px; margin-top: 14px; }
+  button {
+    background: var(--vscode-button-background); color: var(--vscode-button-foreground);
+    border: none; padding: 6px 14px; border-radius: 2px; cursor: pointer; font-size: 0.95em;
+  }
+  button:hover { background: var(--vscode-button-hoverBackground); }
+  button.secondary { background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); }
+</style>
+</head>
+<body>
+  <h2>MSGBOX Composer</h2>
+
+  <div class="row">
+    <label for="message">Message expression</label>
+    <input type="text" id="message" value='"Message"'>
+  </div>
+  <div class="row">
+    <label for="title">Title expression (optional)</label>
+    <input type="text" id="title" value="">
+  </div>
+  <div class="row">
+    <label for="assignTo">Assign result to (optional)</label>
+    <input type="text" id="assignTo" value="ret!">
+  </div>
+
+  <div class="row">
+    <label for="icon">Icon</label>
+    <select id="icon"></select>
+  </div>
+  <div class="row">
+    <label for="buttonSet">Buttons</label>
+    <select id="buttonSet"></select>
+  </div>
+  <div class="row">
+    <label for="defaultButton">Default button</label>
+    <select id="defaultButton"></select>
+  </div>
+
+  <fieldset id="flags"><legend>Extra options</legend></fieldset>
+
+  <div class="preview">
+    <label>Preview</label>
+    <pre id="preview">—</pre>
+    <div class="summary" id="summary"></div>
+  </div>
+
+  <div class="buttons">
+    <button id="insert">Insert</button>
+    <button id="cancel" class="secondary">Cancel</button>
+  </div>
+
+<script nonce="${nonce}">
+  const vscode = acquireVsCodeApi();
+  const $ = (id) => document.getElementById(id);
+
+  function fillSelect(sel, items) {
+    sel.innerHTML = '';
+    for (const it of items) {
+      const opt = document.createElement('option');
+      opt.value = String(it.value);
+      opt.textContent = it.label + '  (' + it.value + ')';
+      sel.appendChild(opt);
+    }
+  }
+
+  function readForm() {
+    const flags = Array.from(document.querySelectorAll('#flags input:checked')).map(c => Number(c.value));
+    return {
+      buttonSet: Number($('buttonSet').value || 0),
+      icon: Number($('icon').value || 0),
+      defaultButton: Number($('defaultButton').value || 0),
+      flags,
+      message: $('message').value,
+      title: $('title').value,
+      assignTo: $('assignTo').value,
+    };
+  }
+
+  function change() { vscode.postMessage({ type: 'change', payload: readForm() }); }
+
+  window.addEventListener('message', (e) => {
+    const m = e.data;
+    if (m.type === 'init') {
+      fillSelect($('icon'), m.catalogs.icons);
+      fillSelect($('buttonSet'), m.catalogs.buttonSets);
+      fillSelect($('defaultButton'), m.catalogs.defaultButtons);
+      const fs = $('flags');
+      for (const f of m.catalogs.flags) {
+        const wrap = document.createElement('label');
+        wrap.className = 'check';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox'; cb.value = String(f.value); cb.addEventListener('change', change);
+        const span = document.createElement('span');
+        span.textContent = f.label;
+        wrap.appendChild(cb); wrap.appendChild(span); fs.appendChild(wrap);
+      }
+      change();
+    } else if (m.type === 'preview') {
+      $('preview').textContent = m.statement;
+      $('summary').textContent = 'expr = ' + m.expr + '  ·  ' + m.summary;
+    }
+  });
+
+  for (const id of ['message', 'title', 'assignTo', 'icon', 'buttonSet', 'defaultButton']) {
+    $(id).addEventListener('input', change);
+    $(id).addEventListener('change', change);
+  }
+  $('insert').addEventListener('click', () => vscode.postMessage({ type: 'insert', payload: readForm() }));
+  $('cancel').addEventListener('click', () => vscode.postMessage({ type: 'cancel' }));
+
+  vscode.postMessage({ type: 'ready' });
+</script>
+</body>
+</html>`;
+}
+
+function getNonce(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let text = '';
+    for (let i = 0; i < 32; i++) {
+        text += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return text;
+}

--- a/bbj-vscode/src/msgbox-composer-webview.ts
+++ b/bbj-vscode/src/msgbox-composer-webview.ts
@@ -1,9 +1,10 @@
 /**
- * Visual MSGBOX composer — a webview panel with a live preview of the generated statement (#426).
+ * Visual MSGBOX composer — a webview panel with a schematic dialog preview + generated statement (#426).
  *
  * The panel is pure presentation: it renders a form from the option catalog and sends the raw
- * selection back to the extension, which computes `expr`/statement text and validates the
- * message/title with the shared ./msgbox-composer logic (no flag math is duplicated here).
+ * selection back to the extension, which computes `expr`/statement text, validates the
+ * message/title, and produces the schematic render with the shared ./msgbox-composer logic
+ * (no flag math / button labels are duplicated here).
  *
  * Two modes:
  *   - NEW (no arg): compose a fresh `ret! = MSGBOX(...)` and insert it at the cursor.
@@ -14,6 +15,7 @@ import * as vscode from 'vscode';
 import {
     BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS,
     encode, describe, composeStatement, stateFromSelection, validateBbjExpression,
+    buttonLabels, expressionDisplayText,
 } from './msgbox-composer.js';
 
 export interface MsgboxPanelArg {
@@ -28,6 +30,7 @@ export interface MsgboxPanelArg {
         icon: number;
         defaultButton: number;
         flags: number[];
+        customButtons: string[];
     };
 }
 
@@ -36,6 +39,7 @@ interface Selection {
     icon: number;
     defaultButton: number;
     flags: number[];
+    customButtons: string[];
     message: string;
     title: string;
     assignTo: string;
@@ -59,7 +63,7 @@ export function openMsgboxComposerPanel(context: vscode.ExtensionContext, arg?: 
 
     const initial = arg?.initial ?? {
         message: '"Message"', title: '', assignTo: 'ret!',
-        buttonSet: 0, icon: 0, defaultButton: 0, flags: [],
+        buttonSet: 0, icon: 0, defaultButton: 0, flags: [], customButtons: [],
     };
     const trailingArgs = arg?.target?.trailingArgs ?? [];
 
@@ -72,21 +76,40 @@ export function openMsgboxComposerPanel(context: vscode.ExtensionContext, arg?: 
     panel.webview.html = getHtml(panel.webview);
 
     function build(sel: Selection) {
-        const expr = encode(stateFromSelection(sel));
+        const state = stateFromSelection(sel);
+        const isCustom = state.buttonSet === 7;
+        const cleanCustom = (sel.customButtons ?? []).map(s => s.trim()).filter(s => s !== '');
+        const expr = encode(state);
+
         const msgV = validateBbjExpression(sel.message, { required: true });
         const titleV = validateBbjExpression(sel.title, { required: false });
+        const customValid = cleanCustom.every(b => validateBbjExpression(b).ok);
+        const customOk = !isCustom || (cleanCustom.length > 0 && customValid);
+
         const statement = composeStatement({
             message: sel.message || '""',
             expr,
             title: sel.title || undefined,
+            buttons: isCustom ? cleanCustom : undefined,
             trailingArgs,
             assignTo: editMode ? undefined : (sel.assignTo || undefined),
         });
+
+        const labels = buttonLabels(state.buttonSet, sel.customButtons);
+        const defaultIndex = state.defaultButton === 256 ? 1 : state.defaultButton === 512 ? 2 : 0;
         return {
             expr, statement, summary: describe(expr),
             messageError: msgV.ok ? undefined : msgV.message,
             titleError: titleV.ok ? undefined : titleV.message,
-            valid: msgV.ok && titleV.ok,
+            customError: customOk ? undefined : (cleanCustom.length === 0 ? 'Add at least one button label' : 'Invalid button expression'),
+            valid: msgV.ok && titleV.ok && customOk,
+            render: {
+                title: expressionDisplayText(sel.title),
+                message: expressionDisplayText(sel.message),
+                icon: state.icon,
+                buttons: labels,
+                defaultIndex: Math.max(0, Math.min(defaultIndex, labels.length - 1)),
+            },
         };
     }
 
@@ -158,6 +181,34 @@ function getHtml(webview: vscode.Webview): string {
   fieldset { border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 3px; margin: 0 0 12px; padding: 8px 10px; }
   legend { font-size: 0.82em; opacity: 0.85; padding: 0 4px; }
   .check { display: flex; align-items: center; gap: 6px; font-size: 0.9em; margin: 3px 0; }
+  #customButtons input { margin-bottom: 6px; width: 100%; box-sizing: border-box; }
+
+  .mock-wrap { margin: 6px 0 12px; }
+  .mock {
+    border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+    border-radius: 4px; overflow: hidden; max-width: 340px;
+    background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+    box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+  }
+  .mock-title {
+    background: var(--vscode-titleBar-activeBackground, var(--vscode-editorGroupHeader-tabsBackground));
+    color: var(--vscode-titleBar-activeForeground, var(--vscode-foreground));
+    padding: 5px 10px; font-size: 0.85em; font-weight: 600;
+  }
+  .mock-body { display: flex; align-items: flex-start; gap: 10px; padding: 14px 12px; }
+  .mock-icon { font-size: 1.6em; line-height: 1; }
+  .mock-msg { font-size: 0.92em; white-space: pre-wrap; word-break: break-word; }
+  .mock-buttons { display: flex; justify-content: flex-end; gap: 6px; padding: 8px 12px; }
+  .mock-btn {
+    border: 1px solid var(--vscode-button-border, var(--vscode-contrastBorder, transparent));
+    background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground);
+    padding: 3px 12px; border-radius: 2px; font-size: 0.85em; min-width: 54px; text-align: center;
+  }
+  .mock-btn.default {
+    background: var(--vscode-button-background); color: var(--vscode-button-foreground);
+    outline: 2px solid var(--vscode-focusBorder); outline-offset: 1px; font-weight: 600;
+  }
+
   .preview { margin: 8px 0 4px; }
   pre {
     background: var(--vscode-textCodeBlock-background); border: 1px solid var(--vscode-panel-border);
@@ -177,6 +228,14 @@ function getHtml(webview: vscode.Webview): string {
 </head>
 <body>
   <h2 id="heading">MSGBOX Composer</h2>
+
+  <div class="mock-wrap">
+    <div class="mock">
+      <div class="mock-title" id="mock-title"></div>
+      <div class="mock-body"><span class="mock-icon" id="mock-icon"></span><span class="mock-msg" id="mock-msg"></span></div>
+      <div class="mock-buttons" id="mock-buttons"></div>
+    </div>
+  </div>
 
   <div class="row">
     <label for="message">Message expression</label>
@@ -201,6 +260,15 @@ function getHtml(webview: vscode.Webview): string {
     <label for="buttonSet">Buttons</label>
     <select id="buttonSet"></select>
   </div>
+
+  <fieldset id="customButtons" class="hidden">
+    <legend>Custom button labels</legend>
+    <input type="text" id="customBtn0" placeholder='e.g. "Left"'>
+    <input type="text" id="customBtn1" placeholder='e.g. "Right"'>
+    <input type="text" id="customBtn2" placeholder="(optional)">
+    <div class="error" id="custom-error"></div>
+  </fieldset>
+
   <div class="row">
     <label for="defaultButton">Default button</label>
     <select id="defaultButton"></select>
@@ -209,7 +277,7 @@ function getHtml(webview: vscode.Webview): string {
   <fieldset id="flags"><legend>Extra options</legend></fieldset>
 
   <div class="preview">
-    <label>Preview</label>
+    <label>Generated statement</label>
     <pre id="preview">—</pre>
     <div class="summary" id="summary"></div>
   </div>
@@ -222,6 +290,7 @@ function getHtml(webview: vscode.Webview): string {
 <script nonce="${nonce}">
   const vscode = acquireVsCodeApi();
   const $ = (id) => document.getElementById(id);
+  const ICON_GLYPH = { 16: '🛑', 32: '❓', 48: '⚠️', 64: 'ℹ️' };
 
   function fillSelect(sel, items, value) {
     sel.innerHTML = '';
@@ -234,6 +303,10 @@ function getHtml(webview: vscode.Webview): string {
     }
   }
 
+  function toggleCustom() {
+    $('customButtons').classList.toggle('hidden', Number($('buttonSet').value) !== 7);
+  }
+
   function readForm() {
     const flags = Array.from(document.querySelectorAll('#flags input:checked')).map(c => Number(c.value));
     return {
@@ -241,13 +314,14 @@ function getHtml(webview: vscode.Webview): string {
       icon: Number($('icon').value || 0),
       defaultButton: Number($('defaultButton').value || 0),
       flags,
+      customButtons: [$('customBtn0').value, $('customBtn1').value, $('customBtn2').value],
       message: $('message').value,
       title: $('title').value,
       assignTo: $('assignTo').value,
     };
   }
 
-  function change() { vscode.postMessage({ type: 'change', payload: readForm() }); }
+  function change() { toggleCustom(); vscode.postMessage({ type: 'change', payload: readForm() }); }
 
   window.addEventListener('message', (e) => {
     const m = e.data;
@@ -258,6 +332,9 @@ function getHtml(webview: vscode.Webview): string {
       $('title').value = init.title;
       $('assignTo').value = init.assignTo || '';
       if (m.editMode) $('assignTo-row').classList.add('hidden');
+      $('customBtn0').value = init.customButtons[0] || '';
+      $('customBtn1').value = init.customButtons[1] || '';
+      $('customBtn2').value = init.customButtons[2] || '';
       fillSelect($('icon'), m.catalogs.icons, init.icon);
       fillSelect($('buttonSet'), m.catalogs.buttonSets, init.buttonSet);
       fillSelect($('defaultButton'), m.catalogs.defaultButtons, init.defaultButton);
@@ -273,19 +350,33 @@ function getHtml(webview: vscode.Webview): string {
         span.textContent = f.label;
         wrap.appendChild(cb); wrap.appendChild(span); fs.appendChild(wrap);
       }
+      toggleCustom();
       change();
     } else if (m.type === 'preview') {
       $('preview').textContent = m.statement;
       $('summary').textContent = 'expr = ' + m.expr + '  ·  ' + m.summary;
       $('message-error').textContent = m.messageError || '';
       $('title-error').textContent = m.titleError || '';
+      $('custom-error').textContent = m.customError || '';
       $('message').classList.toggle('invalid', !!m.messageError);
       $('title').classList.toggle('invalid', !!m.titleError);
       $('insert').disabled = !m.valid;
+      // schematic dialog
+      const r = m.render;
+      $('mock-title').textContent = r.title || '(no title)';
+      $('mock-icon').textContent = ICON_GLYPH[r.icon] || '';
+      $('mock-msg').textContent = r.message || '';
+      const mb = $('mock-buttons'); mb.innerHTML = '';
+      r.buttons.forEach((b, i) => {
+        const el = document.createElement('span');
+        el.className = 'mock-btn' + (i === r.defaultIndex ? ' default' : '');
+        el.textContent = b;
+        mb.appendChild(el);
+      });
     }
   });
 
-  for (const id of ['message', 'title', 'assignTo', 'icon', 'buttonSet', 'defaultButton']) {
+  for (const id of ['message', 'title', 'assignTo', 'icon', 'buttonSet', 'defaultButton', 'customBtn0', 'customBtn1', 'customBtn2']) {
     $(id).addEventListener('input', change);
     $(id).addEventListener('change', change);
   }

--- a/bbj-vscode/src/msgbox-composer-webview.ts
+++ b/bbj-vscode/src/msgbox-composer-webview.ts
@@ -2,15 +2,34 @@
  * Visual MSGBOX composer — a webview panel with a live preview of the generated statement (#426).
  *
  * The panel is pure presentation: it renders a form from the option catalog and sends the raw
- * selection back to the extension, which computes `expr`/statement text with the shared
- * ./msgbox-composer logic (no flag math is duplicated in the webview). On "Insert" the composed
- * statement is written into the editor that was active when the panel opened.
+ * selection back to the extension, which computes `expr`/statement text and validates the
+ * message/title with the shared ./msgbox-composer logic (no flag math is duplicated here).
+ *
+ * Two modes:
+ *   - NEW (no arg): compose a fresh `ret! = MSGBOX(...)` and insert it at the cursor.
+ *   - EDIT (arg from the Code Action): prefill from an existing call and replace that call span
+ *     in place, preserving the assignment prefix and any trailing args we don't model.
  */
 import * as vscode from 'vscode';
 import {
     BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS,
-    encode, describe, composeStatement, stateFromSelection,
+    encode, describe, composeStatement, stateFromSelection, validateBbjExpression,
 } from './msgbox-composer.js';
+
+export interface MsgboxPanelArg {
+    /** Replace an existing call span in place (from the Code Action). Absent = insert new at cursor. */
+    target?: { uri: string; line: number; callStart: number; callEnd: number; trailingArgs: string[] };
+    /** Prefill values for the form. */
+    initial?: {
+        message: string;
+        title: string;
+        assignTo?: string;
+        buttonSet: number;
+        icon: number;
+        defaultButton: number;
+        flags: number[];
+    };
+}
 
 interface Selection {
     buttonSet: number;
@@ -22,32 +41,53 @@ interface Selection {
     assignTo: string;
 }
 
-export function openMsgboxComposerPanel(context: vscode.ExtensionContext): void {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-        vscode.window.showInformationMessage('Open a BBj file first, then run the MSGBOX composer.');
-        return;
+export function openMsgboxComposerPanel(context: vscode.ExtensionContext, arg?: MsgboxPanelArg): void {
+    const editMode = !!arg?.target;
+
+    // For a NEW statement, capture the target editor + position now (the webview steals focus).
+    let insertUri: vscode.Uri | undefined;
+    let insertPosition: vscode.Position | undefined;
+    if (!editMode) {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showInformationMessage('Open a BBj file first, then run the MSGBOX composer.');
+            return;
+        }
+        insertUri = editor.document.uri;
+        insertPosition = editor.selection.active;
     }
-    const targetUri = editor.document.uri;
-    const insertPosition = editor.selection.active;
+
+    const initial = arg?.initial ?? {
+        message: '"Message"', title: '', assignTo: 'ret!',
+        buttonSet: 0, icon: 0, defaultButton: 0, flags: [],
+    };
+    const trailingArgs = arg?.target?.trailingArgs ?? [];
 
     const panel = vscode.window.createWebviewPanel(
         'bbjMsgboxComposer',
-        'MSGBOX Composer',
+        editMode ? 'Edit MSGBOX' : 'MSGBOX Composer',
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
         { enableScripts: true, retainContextWhenHidden: true },
     );
     panel.webview.html = getHtml(panel.webview);
 
-    function build(sel: Selection): { expr: number; statement: string; summary: string } {
+    function build(sel: Selection) {
         const expr = encode(stateFromSelection(sel));
+        const msgV = validateBbjExpression(sel.message, { required: true });
+        const titleV = validateBbjExpression(sel.title, { required: false });
         const statement = composeStatement({
             message: sel.message || '""',
             expr,
             title: sel.title || undefined,
-            assignTo: sel.assignTo || undefined,
+            trailingArgs,
+            assignTo: editMode ? undefined : (sel.assignTo || undefined),
         });
-        return { expr, statement, summary: describe(expr) };
+        return {
+            expr, statement, summary: describe(expr),
+            messageError: msgV.ok ? undefined : msgV.message,
+            titleError: titleV.ok ? undefined : titleV.message,
+            valid: msgV.ok && titleV.ok,
+        };
     }
 
     panel.webview.onDidReceiveMessage(async (msg: { type: string; payload?: Selection }) => {
@@ -55,7 +95,9 @@ export function openMsgboxComposerPanel(context: vscode.ExtensionContext): void 
             case 'ready':
                 panel.webview.postMessage({
                     type: 'init',
+                    editMode,
                     catalogs: { buttonSets: BUTTON_SETS, icons: ICONS, defaultButtons: DEFAULT_BUTTONS, flags: FLAGS },
+                    initial,
                 });
                 break;
             case 'change':
@@ -63,15 +105,23 @@ export function openMsgboxComposerPanel(context: vscode.ExtensionContext): void 
                     panel.webview.postMessage({ type: 'preview', ...build(msg.payload) });
                 }
                 break;
-            case 'insert':
-                if (msg.payload) {
-                    const { statement } = build(msg.payload);
-                    const doc = await vscode.workspace.openTextDocument(targetUri);
-                    const target = await vscode.window.showTextDocument(doc, { preserveFocus: false });
-                    await target.edit(b => b.insert(insertPosition, statement));
-                    panel.dispose();
+            case 'insert': {
+                if (!msg.payload) break;
+                const r = build(msg.payload);
+                if (!r.valid) break; // guard; the webview also disables the button
+                if (editMode && arg?.target) {
+                    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(arg.target.uri));
+                    const ed = await vscode.window.showTextDocument(doc, { preserveFocus: false });
+                    const range = new vscode.Range(arg.target.line, arg.target.callStart, arg.target.line, arg.target.callEnd);
+                    await ed.edit(b => b.replace(range, r.statement));
+                } else if (insertUri && insertPosition) {
+                    const doc = await vscode.workspace.openTextDocument(insertUri);
+                    const ed = await vscode.window.showTextDocument(doc, { preserveFocus: false });
+                    await ed.edit(b => b.insert(insertPosition!, r.statement));
                 }
+                panel.dispose();
                 break;
+            }
             case 'cancel':
                 panel.dispose();
                 break;
@@ -96,13 +146,15 @@ function getHtml(webview: vscode.Webview): string {
 <style>
   body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 12px 16px; }
   h2 { margin: 0 0 12px; font-size: 1.1em; }
-  .row { display: flex; flex-direction: column; gap: 4px; margin-bottom: 12px; }
+  .row { display: flex; flex-direction: column; gap: 4px; margin-bottom: 10px; }
   label { font-size: 0.85em; opacity: 0.85; }
   select, input[type="text"] {
     background: var(--vscode-input-background); color: var(--vscode-input-foreground);
     border: 1px solid var(--vscode-input-border, transparent); padding: 4px 6px; border-radius: 2px;
     font-family: var(--vscode-font-family); font-size: 0.95em;
   }
+  input.invalid { border-color: var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground)); }
+  .error { color: var(--vscode-errorForeground); font-size: 0.8em; min-height: 1em; }
   fieldset { border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 3px; margin: 0 0 12px; padding: 8px 10px; }
   legend { font-size: 0.82em; opacity: 0.85; padding: 0 4px; }
   .check { display: flex; align-items: center; gap: 6px; font-size: 0.9em; margin: 3px 0; }
@@ -118,23 +170,27 @@ function getHtml(webview: vscode.Webview): string {
     border: none; padding: 6px 14px; border-radius: 2px; cursor: pointer; font-size: 0.95em;
   }
   button:hover { background: var(--vscode-button-hoverBackground); }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
   button.secondary { background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); }
+  .hidden { display: none; }
 </style>
 </head>
 <body>
-  <h2>MSGBOX Composer</h2>
+  <h2 id="heading">MSGBOX Composer</h2>
 
   <div class="row">
     <label for="message">Message expression</label>
-    <input type="text" id="message" value='"Message"'>
+    <input type="text" id="message">
+    <div class="error" id="message-error"></div>
   </div>
   <div class="row">
     <label for="title">Title expression (optional)</label>
-    <input type="text" id="title" value="">
+    <input type="text" id="title">
+    <div class="error" id="title-error"></div>
   </div>
-  <div class="row">
+  <div class="row" id="assignTo-row">
     <label for="assignTo">Assign result to (optional)</label>
-    <input type="text" id="assignTo" value="ret!">
+    <input type="text" id="assignTo">
   </div>
 
   <div class="row">
@@ -167,12 +223,13 @@ function getHtml(webview: vscode.Webview): string {
   const vscode = acquireVsCodeApi();
   const $ = (id) => document.getElementById(id);
 
-  function fillSelect(sel, items) {
+  function fillSelect(sel, items, value) {
     sel.innerHTML = '';
     for (const it of items) {
       const opt = document.createElement('option');
       opt.value = String(it.value);
       opt.textContent = it.label + '  (' + it.value + ')';
+      if (it.value === value) opt.selected = true;
       sel.appendChild(opt);
     }
   }
@@ -195,15 +252,23 @@ function getHtml(webview: vscode.Webview): string {
   window.addEventListener('message', (e) => {
     const m = e.data;
     if (m.type === 'init') {
-      fillSelect($('icon'), m.catalogs.icons);
-      fillSelect($('buttonSet'), m.catalogs.buttonSets);
-      fillSelect($('defaultButton'), m.catalogs.defaultButtons);
+      $('heading').textContent = m.editMode ? 'Edit MSGBOX' : 'MSGBOX Composer';
+      const init = m.initial;
+      $('message').value = init.message;
+      $('title').value = init.title;
+      $('assignTo').value = init.assignTo || '';
+      if (m.editMode) $('assignTo-row').classList.add('hidden');
+      fillSelect($('icon'), m.catalogs.icons, init.icon);
+      fillSelect($('buttonSet'), m.catalogs.buttonSets, init.buttonSet);
+      fillSelect($('defaultButton'), m.catalogs.defaultButtons, init.defaultButton);
       const fs = $('flags');
       for (const f of m.catalogs.flags) {
         const wrap = document.createElement('label');
         wrap.className = 'check';
         const cb = document.createElement('input');
-        cb.type = 'checkbox'; cb.value = String(f.value); cb.addEventListener('change', change);
+        cb.type = 'checkbox'; cb.value = String(f.value);
+        if (init.flags.includes(f.value)) cb.checked = true;
+        cb.addEventListener('change', change);
         const span = document.createElement('span');
         span.textContent = f.label;
         wrap.appendChild(cb); wrap.appendChild(span); fs.appendChild(wrap);
@@ -212,6 +277,11 @@ function getHtml(webview: vscode.Webview): string {
     } else if (m.type === 'preview') {
       $('preview').textContent = m.statement;
       $('summary').textContent = 'expr = ' + m.expr + '  ·  ' + m.summary;
+      $('message-error').textContent = m.messageError || '';
+      $('title-error').textContent = m.titleError || '';
+      $('message').classList.toggle('invalid', !!m.messageError);
+      $('title').classList.toggle('invalid', !!m.titleError);
+      $('insert').disabled = !m.valid;
     }
   });
 

--- a/bbj-vscode/src/msgbox-composer.ts
+++ b/bbj-vscode/src/msgbox-composer.ts
@@ -69,6 +69,23 @@ export const DEFAULT_STATE: MsgboxState = {
     buttonSet: 0, icon: 0, defaultButton: 0, noEnter: false, disableHtml: false, mdi: false,
 };
 
+/**
+ * Build a MsgboxState from a flat UI selection (button/icon/default values + a list of flag
+ * values). Keeps the flag-value -> boolean mapping in one place so UIs (QuickPick, webview,
+ * a future IntelliJ dialog) only pass raw selections.
+ */
+export function stateFromSelection(sel: { buttonSet?: number; icon?: number; defaultButton?: number; flags?: number[] }): MsgboxState {
+    const flags = new Set(sel.flags ?? []);
+    return {
+        buttonSet: sel.buttonSet ?? 0,
+        icon: sel.icon ?? 0,
+        defaultButton: sel.defaultButton ?? 0,
+        noEnter: flags.has(65536),
+        disableHtml: flags.has(32768),
+        mdi: flags.has(131072),
+    };
+}
+
 /** Compose the additive `expr` number from a selection. */
 export function encode(s: MsgboxState): number {
     return (s.buttonSet & BUTTON_MASK)

--- a/bbj-vscode/src/msgbox-composer.ts
+++ b/bbj-vscode/src/msgbox-composer.ts
@@ -198,6 +198,50 @@ export function validateBbjExpression(text: string, opts: { required?: boolean }
     return { ok: true };
 }
 
+/** Human display text for an expression: a `"..."` literal becomes its content, anything else is shown as-is. */
+export function expressionDisplayText(expr: string): string {
+    const t = (expr ?? '').trim();
+    if (/^"([^"]|"")*"$/.test(t)) {
+        return t.slice(1, -1).replace(/""/g, '"');
+    }
+    return t;
+}
+
+const STANDARD_BUTTON_LABELS: Record<number, string[]> = {
+    0: ['OK'],
+    1: ['OK', 'Cancel'],
+    2: ['Abort', 'Retry', 'Ignore'],
+    3: ['Yes', 'No', 'Cancel'],
+    4: ['Yes', 'No'],
+    5: ['Retry', 'Cancel'],
+};
+
+/** Display labels for the schematic preview: standard set labels, or the custom button expressions. */
+export function buttonLabels(buttonSet: number, customButtons: string[] = []): string[] {
+    if (buttonSet === 7) {
+        const labels = customButtons.map(expressionDisplayText).filter(s => s.trim() !== '');
+        return labels.length ? labels : ['Button 1'];
+    }
+    return STANDARD_BUTTON_LABELS[buttonSet] ?? ['OK'];
+}
+
+/**
+ * Split the args past the title (args[3..]) into custom button labels and the remaining trailing
+ * args to preserve verbatim. Positional buttons only apply to the "Custom" set (7) and stop at the
+ * first `MODE=`/`TIM=`/`ERR=` keyword arg.
+ */
+export function splitButtonsAndTrailing(rest: string[], isCustom: boolean): { buttons: string[]; trailing: string[] } {
+    if (!isCustom) return { buttons: [], trailing: rest };
+    const keyword = /^(MODE|TIM|ERR)\b\s*=/i;
+    const buttons: string[] = [];
+    let i = 0;
+    while (i < rest.length && buttons.length < 3 && !keyword.test(rest[i])) {
+        buttons.push(rest[i]);
+        i++;
+    }
+    return { buttons, trailing: rest.slice(i) };
+}
+
 export interface MsgboxCallInfo {
     /** Index of `MSGBOX` within the line. */
     callStart: number;

--- a/bbj-vscode/src/msgbox-composer.ts
+++ b/bbj-vscode/src/msgbox-composer.ts
@@ -132,23 +132,70 @@ export interface ComposeInput {
     title?: string;
     /** Custom button label expressions (only meaningful with the "Custom" button set). */
     buttons?: string[];
+    /**
+     * Verbatim args appended after the title — used when rewriting an existing call to preserve
+     * anything past the title we don't model (custom buttons, `MODE=`/`TIM=`/`ERR=`).
+     */
+    trailingArgs?: string[];
     /** Optional assignment target, e.g. `ret!` -> `ret! = MSGBOX(...)`. */
     assignTo?: string;
 }
 
 /** Build a `MSGBOX(...)` statement, including only the positional args that are needed. */
 export function composeStatement(input: ComposeInput): string {
-    const hasButtons = !!input.buttons && input.buttons.length > 0;
-    const needTitle = (input.title !== undefined && input.title !== '') || hasButtons;
+    const extras = [...(input.buttons ?? []), ...(input.trailingArgs ?? [])];
+    const hasExtras = extras.length > 0;
+    const needTitle = (input.title !== undefined && input.title !== '') || hasExtras;
     const needExpr = input.expr !== 0 || needTitle;
 
     const args: string[] = [input.message];
     if (needExpr) args.push(String(input.expr));
-    if (needTitle) args.push(input.title ?? '""');
-    if (hasButtons) args.push(...input.buttons!);
+    if (needTitle) args.push(input.title || '""');
+    if (hasExtras) args.push(...extras);
 
     const call = `MSGBOX(${args.join(', ')})`;
     return input.assignTo ? `${input.assignTo} = ${call}` : call;
+}
+
+/** The flag values (65536/32768/131072) set on a state — inverse of the flag part of stateFromSelection. */
+export function flagsFromState(s: MsgboxState): number[] {
+    const flags: number[] = [];
+    if (s.noEnter) flags.push(65536);
+    if (s.disableHtml) flags.push(32768);
+    if (s.mdi) flags.push(131072);
+    return flags;
+}
+
+/**
+ * Lightweight lexical check that a message/title entry is a well-formed BBj expression: not
+ * empty (when required), with balanced `"` string literals (`""` escapes) and parentheses.
+ * It intentionally does NOT require a string *literal* — `msg$`, `a$+b$`, `getText()` are all
+ * valid string expressions — it only flags obvious errors like `"TEST` (no closing quote).
+ * Deeper "resolves to a String" checking would need the language server's type inference.
+ */
+export function validateBbjExpression(text: string, opts: { required?: boolean } = {}): { ok: boolean; message?: string } {
+    const t = text.trim();
+    if (t === '') {
+        return opts.required ? { ok: false, message: 'Required' } : { ok: true };
+    }
+    let inStr = false;
+    let depth = 0;
+    for (let i = 0; i < t.length; i++) {
+        const c = t[i];
+        if (inStr) {
+            if (c === '"') {
+                if (t[i + 1] === '"') { i++; continue; } // "" escape
+                inStr = false;
+            }
+            continue;
+        }
+        if (c === '"') { inStr = true; }
+        else if (c === '(') { depth++; }
+        else if (c === ')') { if (--depth < 0) return { ok: false, message: 'Unbalanced parentheses' }; }
+    }
+    if (inStr) return { ok: false, message: 'Unterminated string literal' };
+    if (depth !== 0) return { ok: false, message: 'Unbalanced parentheses' };
+    return { ok: true };
 }
 
 export interface MsgboxCallInfo {

--- a/bbj-vscode/test/msgbox-composer.test.ts
+++ b/bbj-vscode/test/msgbox-composer.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'vitest';
 import {
     encode, decode, describe as describeExpr, composeStatement, parseMsgboxCallOnLine, findMsgboxCallAt,
-    stateFromSelection, flagsFromState, validateBbjExpression, DEFAULT_STATE,
+    stateFromSelection, flagsFromState, validateBbjExpression, expressionDisplayText, buttonLabels,
+    splitButtonsAndTrailing, DEFAULT_STATE,
 } from '../src/msgbox-composer';
 
 describe('MSGBOX composer logic (#426)', () => {
@@ -71,6 +72,26 @@ describe('MSGBOX composer logic (#426)', () => {
         expect(validateBbjExpression('getText(1').ok).toBe(false);            // unbalanced paren
         expect(validateBbjExpression('', { required: true }).ok).toBe(false); // required + empty
         expect(validateBbjExpression('', {}).ok).toBe(true);                   // optional + empty
+    });
+
+    test('expressionDisplayText unquotes string literals, passes expressions through', () => {
+        expect(expressionDisplayText('"Hello World!"')).toBe('Hello World!');
+        expect(expressionDisplayText('"say ""hi"""')).toBe('say "hi"');
+        expect(expressionDisplayText('msg$')).toBe('msg$');
+        expect(expressionDisplayText('a$ + "!"')).toBe('a$ + "!"'); // not a single literal -> as-is
+    });
+
+    test('buttonLabels returns standard labels or custom expressions', () => {
+        expect(buttonLabels(4)).toEqual(['Yes', 'No']);
+        expect(buttonLabels(0)).toEqual(['OK']);
+        expect(buttonLabels(7, ['"Left"', '"Right"'])).toEqual(['Left', 'Right']);
+        expect(buttonLabels(7, [])).toEqual(['Button 1']); // fallback when custom set has no labels
+    });
+
+    test('splitButtonsAndTrailing separates custom buttons from MODE/TIM/ERR', () => {
+        expect(splitButtonsAndTrailing(['"Left"', '"Right"'], true)).toEqual({ buttons: ['"Left"', '"Right"'], trailing: [] });
+        expect(splitButtonsAndTrailing(['"Left"', 'MODE="x"'], true)).toEqual({ buttons: ['"Left"'], trailing: ['MODE="x"'] });
+        expect(splitButtonsAndTrailing(['MODE="x"'], false)).toEqual({ buttons: [], trailing: ['MODE="x"'] });
     });
 
     test('parseMsgboxCallOnLine finds a numeric expr and its range', () => {

--- a/bbj-vscode/test/msgbox-composer.test.ts
+++ b/bbj-vscode/test/msgbox-composer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
-    encode, decode, describe as describeExpr, composeStatement, parseMsgboxCallOnLine, findMsgboxCallAt, DEFAULT_STATE,
+    encode, decode, describe as describeExpr, composeStatement, parseMsgboxCallOnLine, findMsgboxCallAt,
+    stateFromSelection, DEFAULT_STATE,
 } from '../src/msgbox-composer';
 
 describe('MSGBOX composer logic (#426)', () => {
@@ -9,6 +10,13 @@ describe('MSGBOX composer logic (#426)', () => {
         expect(encode({ ...DEFAULT_STATE, buttonSet: 4, icon: 48 })).toBe(52); // Yes/No + Exclamation
         expect(encode({ ...DEFAULT_STATE, buttonSet: 1, icon: 64, defaultButton: 256 })).toBe(1 + 64 + 256);
         expect(encode({ ...DEFAULT_STATE, buttonSet: 3, icon: 32, noEnter: true })).toBe(3 + 32 + 65536);
+    });
+
+    test('stateFromSelection maps flat UI selection (flags list) to state', () => {
+        expect(encode(stateFromSelection({ buttonSet: 4, icon: 32, flags: [65536] }))).toBe(4 + 32 + 65536);
+        expect(encode(stateFromSelection({ buttonSet: 3, icon: 48, defaultButton: 256, flags: [32768, 131072] })))
+            .toBe(3 + 48 + 256 + 32768 + 131072);
+        expect(encode(stateFromSelection({}))).toBe(0);
     });
 
     test('decode is the inverse of encode', () => {

--- a/bbj-vscode/test/msgbox-composer.test.ts
+++ b/bbj-vscode/test/msgbox-composer.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
     encode, decode, describe as describeExpr, composeStatement, parseMsgboxCallOnLine, findMsgboxCallAt,
-    stateFromSelection, DEFAULT_STATE,
+    stateFromSelection, flagsFromState, validateBbjExpression, DEFAULT_STATE,
 } from '../src/msgbox-composer';
 
 describe('MSGBOX composer logic (#426)', () => {
@@ -47,6 +47,30 @@ describe('MSGBOX composer logic (#426)', () => {
             .toBe('ret! = MSGBOX("Hi", 36, "C")');
         expect(composeStatement({ message: '"Q"', expr: 7, buttons: ['"Left"', '"Right"'] }))
             .toBe('MSGBOX("Q", 7, "", "Left", "Right")');
+    });
+
+    test('composeStatement preserves trailing args (buttons / MODE / ERR) when rewriting', () => {
+        expect(composeStatement({ message: '"m"', expr: 36, title: '"t"', trailingArgs: ['MODE="theme=primary"', 'ERR=*NEXT'] }))
+            .toBe('MSGBOX("m", 36, "t", MODE="theme=primary", ERR=*NEXT)');
+        // trailing args force a (possibly empty) title slot to keep positions valid
+        expect(composeStatement({ message: '"m"', expr: 0, title: '', trailingArgs: ['TIM=5'] }))
+            .toBe('MSGBOX("m", 0, "", TIM=5)');
+    });
+
+    test('flagsFromState is the inverse of the flag part of stateFromSelection', () => {
+        expect(flagsFromState(stateFromSelection({ flags: [65536, 131072] })).sort()).toEqual([65536, 131072].sort());
+        expect(flagsFromState(stateFromSelection({}))).toEqual([]);
+    });
+
+    test('validateBbjExpression flags unterminated strings / unbalanced parens, allows real expressions', () => {
+        expect(validateBbjExpression('"TEST').ok).toBe(false);                 // no closing quote
+        expect(validateBbjExpression('"TEST"').ok).toBe(true);
+        expect(validateBbjExpression('"say ""hi"""').ok).toBe(true);           // "" escapes
+        expect(validateBbjExpression('msg$').ok).toBe(true);                   // a variable is fine
+        expect(validateBbjExpression('a$ + "!"').ok).toBe(true);              // concatenation
+        expect(validateBbjExpression('getText(1').ok).toBe(false);            // unbalanced paren
+        expect(validateBbjExpression('', { required: true }).ok).toBe(false); // required + empty
+        expect(validateBbjExpression('', {}).ok).toBe(true);                   // optional + empty
     });
 
     test('parseMsgboxCallOnLine finds a numeric expr and its range', () => {


### PR DESCRIPTION
Builds on #427 (QuickPick composer). **Stacked on `spike/msgbox-composer`** so the diff is webview-only — GitHub will auto-retarget this to `main` once #427 merges.

## What

Adds **BBj: Compose MSGBOX (visual)…** (Command Palette / editor context menu) → a themed webview panel:

- Form: message / title / assign-to expressions, icon, buttons, default button, extra flags.
- **Live preview** of the generated statement + the `expr` value and a human summary, updating as you change anything.
- **Insert** writes the statement into the editor that was active when the panel opened.

## Design

- `src/msgbox-composer-webview.ts` is **pure presentation**: it renders the form from the option **catalog** and posts the raw selection back; the extension computes `expr`/statement with the shared `./msgbox-composer` logic. No flag arithmetic is duplicated in the webview.
- New `stateFromSelection()` helper in the pure module (flat UI selection → `MsgboxState`), unit-tested — reused by the webview (and available to a future IntelliJ dialog).
- Strict CSP with a per-load nonce; styled entirely with `var(--vscode-*)` theme variables (light/dark aware). No external resources.
- The QuickPick wizard + Code Action from #427 stay as the fast/keyboard path; this is the richer visual entry.

## Testing

- 14 unit tests over the pure logic (incl. the new `stateFromSelection`). Full suite **556 passed**; `tsc`, esbuild bundle, eslint clean; webview verified in the bundle.
- The panel/webview interaction itself is exercised in a VS Code host (not unit-testable here); all logic under it is tested.

## Follow-ups
- Open the panel **prefilled** from the Code Action to visually edit/add options on an existing call (currently the panel composes new; the QuickPick Code Action handles edit/add).
- Custom button labels (button set 7) and `MODE=` / `TIM=` / `ERR=`.
- Consider a shared HTML panel rendered via JCEF for IntelliJ parity.

Refs #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)