### PR TITLE
MSGBOX composer: require string fields to resolve to a String (#426)

### DIFF
--- a/bbj-vscode/src/msgbox-composer-ui.ts
+++ b/bbj-vscode/src/msgbox-composer-ui.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode';
 import {
     BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS, CatalogItem,
     MsgboxState, DEFAULT_STATE, encode, decode, describe, composeStatement, findMsgboxCallAt, flagsFromState,
-    splitButtonsAndTrailing,
+    splitButtonsAndTrailing, validateStringField,
 } from './msgbox-composer.js';
 import { openMsgboxComposerPanel, MsgboxPanelArg } from './msgbox-composer-webview.js';
 
@@ -111,11 +111,13 @@ async function runComposer(arg?: ComposeArg): Promise<void> {
         const message = await vscode.window.showInputBox({
             title: 'MSGBOX — message', prompt: 'BBj expression for the message',
             value: '"Message"', ignoreFocusOut: true,
+            validateInput: v => validateStringField(v, { required: true }).message,
         });
         if (message === undefined) return;
         const title = await vscode.window.showInputBox({
             title: 'MSGBOX — title (optional)', prompt: 'BBj expression for the title, or leave empty',
             value: '', ignoreFocusOut: true,
+            validateInput: v => validateStringField(v, { required: false }).message,
         });
         if (title === undefined) return;
 

--- a/bbj-vscode/src/msgbox-composer-webview.ts
+++ b/bbj-vscode/src/msgbox-composer-webview.ts
@@ -14,7 +14,7 @@
 import * as vscode from 'vscode';
 import {
     BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS,
-    encode, describe, composeStatement, stateFromSelection, validateBbjExpression,
+    encode, describe, composeStatement, stateFromSelection, validateStringField,
     buttonLabels, expressionDisplayText,
 } from './msgbox-composer.js';
 
@@ -81,10 +81,10 @@ export function openMsgboxComposerPanel(context: vscode.ExtensionContext, arg?: 
         const cleanCustom = (sel.customButtons ?? []).map(s => s.trim()).filter(s => s !== '');
         const expr = encode(state);
 
-        const msgV = validateBbjExpression(sel.message, { required: true });
-        const titleV = validateBbjExpression(sel.title, { required: false });
-        const customValid = cleanCustom.every(b => validateBbjExpression(b).ok);
-        const customOk = !isCustom || (cleanCustom.length > 0 && customValid);
+        const msgV = validateStringField(sel.message, { required: true });
+        const titleV = validateStringField(sel.title, { required: false });
+        const firstBadButton = cleanCustom.map(b => validateStringField(b)).find(v => !v.ok);
+        const customOk = !isCustom || (cleanCustom.length > 0 && !firstBadButton);
 
         const statement = composeStatement({
             message: sel.message || '""',
@@ -101,7 +101,7 @@ export function openMsgboxComposerPanel(context: vscode.ExtensionContext, arg?: 
             expr, statement, summary: describe(expr),
             messageError: msgV.ok ? undefined : msgV.message,
             titleError: titleV.ok ? undefined : titleV.message,
-            customError: customOk ? undefined : (cleanCustom.length === 0 ? 'Add at least one button label' : 'Invalid button expression'),
+            customError: customOk ? undefined : (cleanCustom.length === 0 ? 'Add at least one button label' : (firstBadButton?.message ?? 'Invalid button expression')),
             valid: msgV.ok && titleV.ok && customOk,
             render: {
                 title: expressionDisplayText(sel.title),

--- a/bbj-vscode/src/msgbox-composer.ts
+++ b/bbj-vscode/src/msgbox-composer.ts
@@ -169,9 +169,9 @@ export function flagsFromState(s: MsgboxState): number[] {
 /**
  * Lightweight lexical check that a message/title entry is a well-formed BBj expression: not
  * empty (when required), with balanced `"` string literals (`""` escapes) and parentheses.
- * It intentionally does NOT require a string *literal* — `msg$`, `a$+b$`, `getText()` are all
- * valid string expressions — it only flags obvious errors like `"TEST` (no closing quote).
- * Deeper "resolves to a String" checking would need the language server's type inference.
+ * It only flags structural errors like `"TEST` (no closing quote) — it does NOT check the
+ * expression's *type*. Use {@link validateStringField} for the message/title/button inputs,
+ * which additionally requires the expression to resolve to a String.
  */
 export function validateBbjExpression(text: string, opts: { required?: boolean } = {}): { ok: boolean; message?: string } {
     const t = text.trim();
@@ -195,6 +195,112 @@ export function validateBbjExpression(text: string, opts: { required?: boolean }
     }
     if (inStr) return { ok: false, message: 'Unterminated string literal' };
     if (depth !== 0) return { ok: false, message: 'Unbalanced parentheses' };
+    return { ok: true };
+}
+
+/** Wrap arbitrary text as a BBj string literal, doubling any embedded `"` (the BBj `""` escape). */
+export function quoteAsStringLiteral(text: string): string {
+    return `"${text.replace(/"/g, '""')}"`;
+}
+
+/** True when `t` is a single, whole-length `"..."` string literal (with `""` escapes). */
+function isStringLiteral(t: string): boolean {
+    return /^"([^"]|"")*"$/.test(t);
+}
+
+/** True when `t` starts with `(` and its matching `)` is the final character. */
+function wrappedInParens(t: string): boolean {
+    if (!t.startsWith('(') || !t.endsWith(')')) return false;
+    let depth = 0, inStr = false;
+    for (let i = 0; i < t.length; i++) {
+        const c = t[i];
+        if (inStr) {
+            if (c === '"') { if (t[i + 1] === '"') { i++; continue; } inStr = false; }
+            continue;
+        }
+        if (c === '"') inStr = true;
+        else if (c === '(') depth++;
+        else if (c === ')') { depth--; if (depth === 0 && i !== t.length - 1) return false; }
+    }
+    return depth === 0;
+}
+
+/**
+ * Split a BBj expression on its top-level `+` (concatenation) operators, ignoring `+` inside
+ * string literals, parentheses, or `[...]` subscripts. Returns `null` when the top level uses a
+ * numeric operator (`-`, `*`, `/`) — such an expression is arithmetic, i.e. NOT a String.
+ */
+function splitTopLevelPlus(t: string): string[] | null {
+    const parts: string[] = [];
+    let depth = 0, inStr = false, start = 0;
+    for (let i = 0; i < t.length; i++) {
+        const c = t[i];
+        if (inStr) {
+            if (c === '"') { if (t[i + 1] === '"') { i++; continue; } inStr = false; }
+            continue;
+        }
+        if (c === '"') inStr = true;
+        else if (c === '(' || c === '[') depth++;
+        else if (c === ')' || c === ']') depth--;
+        else if (depth === 0) {
+            if (c === '+') { parts.push(t.slice(start, i)); start = i + 1; }
+            else if (c === '-' || c === '*' || c === '/') return null; // arithmetic ⇒ numeric
+        }
+    }
+    parts.push(t.slice(start));
+    return parts;
+}
+
+/** Whether a single `+`-free operand is String-typed by its lexical form. */
+function operandIsString(op: string): boolean {
+    const t = op.trim();
+    if (t === '') return false;
+    if (wrappedInParens(t)) return resolvesToString(t.slice(1, -1));
+    if (isStringLiteral(t)) return true;
+    // A function/method call may return a String (STR(), CVS(), obj!.getText(), a$(...)); accept it.
+    if (t.endsWith(')')) return true;
+    // A reference whose name ends in `$` (string) or `!` (object), allowing a trailing subscript.
+    const bare = t.replace(/(\[[^\]]*\])+$/, '');
+    return /[$!]$/.test(bare);
+}
+
+/**
+ * Best-effort lexical check that a BBj expression resolves to a String — the constraint for the
+ * MSGBOX message/title/button arguments. Without the language server's type inference this cannot
+ * be exact, but it reliably distinguishes the forms that matter here:
+ *   - String literals (`"Caption"`), string vars (`caption$`), object vars (`caption!`),
+ *     function/method calls, and `+`-concatenations of those  → String (accepted).
+ *   - A bare numeric variable (`caption`), an integer var (`n%`), or a number → NOT a String.
+ * The last case is the reported bug: `caption` lands verbatim as a numeric reference and breaks
+ * the generated statement; the caller should quote it (`"caption"`) or add a `$`/`!` suffix.
+ */
+export function resolvesToString(text: string): boolean {
+    const t = text.trim();
+    if (t === '') return false;
+    const operands = splitTopLevelPlus(t);
+    if (operands === null) return false; // top-level arithmetic ⇒ numeric
+    return operands.every(operandIsString);
+}
+
+/**
+ * Validate a string-typed field (message / title / custom button). Layers three checks: presence
+ * (when `required`), structural well-formedness ({@link validateBbjExpression}), and String typing
+ * ({@link resolvesToString}). The typing message tells the user how to fix a bare value.
+ */
+export function validateStringField(text: string, opts: { required?: boolean } = {}): { ok: boolean; message?: string } {
+    const t = text.trim();
+    if (t === '') {
+        return opts.required ? { ok: false, message: 'Required' } : { ok: true };
+    }
+    const structural = validateBbjExpression(t);
+    if (!structural.ok) return structural;
+    if (!resolvesToString(t)) {
+        // Suggest a `$`/`!` suffix only when the value is a plain identifier (a valid var name);
+        // for anything else (prose, numbers) the only sensible fix is to quote it.
+        const isIdentifier = /^[A-Za-z_][A-Za-z0-9_]*$/.test(t);
+        const suffixHint = isIdentifier ? `, or a string variable (${t}$ / ${t}!)` : '';
+        return { ok: false, message: `Not a string — quote it as ${quoteAsStringLiteral(t)}${suffixHint}` };
+    }
     return { ok: true };
 }
 

--- a/bbj-vscode/test/msgbox-composer.test.ts
+++ b/bbj-vscode/test/msgbox-composer.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import {
     encode, decode, describe as describeExpr, composeStatement, parseMsgboxCallOnLine, findMsgboxCallAt,
     stateFromSelection, flagsFromState, validateBbjExpression, expressionDisplayText, buttonLabels,
-    splitButtonsAndTrailing, DEFAULT_STATE,
+    splitButtonsAndTrailing, DEFAULT_STATE, resolvesToString, validateStringField, quoteAsStringLiteral,
 } from '../src/msgbox-composer';
 
 describe('MSGBOX composer logic (#426)', () => {
@@ -72,6 +72,54 @@ describe('MSGBOX composer logic (#426)', () => {
         expect(validateBbjExpression('getText(1').ok).toBe(false);            // unbalanced paren
         expect(validateBbjExpression('', { required: true }).ok).toBe(false); // required + empty
         expect(validateBbjExpression('', {}).ok).toBe(true);                   // optional + empty
+    });
+
+    test('quoteAsStringLiteral wraps text and doubles embedded quotes', () => {
+        expect(quoteAsStringLiteral('Caption')).toBe('"Caption"');
+        expect(quoteAsStringLiteral('Are you sure?')).toBe('"Are you sure?"');
+        expect(quoteAsStringLiteral('say "hi"')).toBe('"say ""hi"""');
+    });
+
+    test('resolvesToString accepts literals / $ / ! vars, function calls, and string concatenations', () => {
+        expect(resolvesToString('"Caption"')).toBe(true);
+        expect(resolvesToString('caption$')).toBe(true);          // string variable
+        expect(resolvesToString('caption!')).toBe(true);          // object variable
+        expect(resolvesToString('arr$[1]')).toBe(true);           // string array element
+        expect(resolvesToString('obj!.getText()')).toBe(true);    // method call
+        expect(resolvesToString('STR(n)')).toBe(true);            // string function
+        expect(resolvesToString('a$ + "!"')).toBe(true);          // concatenation
+        expect(resolvesToString('"n=" + STR(n)')).toBe(true);
+        expect(resolvesToString('("wrapped" + a$)')).toBe(true);  // parenthesised
+    });
+
+    test('resolvesToString rejects bare numeric refs, numbers, %-vars, and arithmetic', () => {
+        expect(resolvesToString('Caption')).toBe(false);          // the reported bug: numeric variable
+        expect(resolvesToString('Are you sure?')).toBe(false);    // unquoted prose
+        expect(resolvesToString('42')).toBe(false);
+        expect(resolvesToString('count%')).toBe(false);           // integer variable
+        expect(resolvesToString('"x" + count')).toBe(false);      // numeric operand in concat
+        expect(resolvesToString('a$ - b$')).toBe(false);          // arithmetic operator ⇒ numeric
+        expect(resolvesToString('')).toBe(false);
+    });
+
+    test('validateStringField requires a String and suggests how to fix a bare value', () => {
+        expect(validateStringField('"Caption"', { required: true }).ok).toBe(true);
+        expect(validateStringField('caption$').ok).toBe(true);
+        expect(validateStringField('', { required: false }).ok).toBe(true);   // optional + empty
+        expect(validateStringField('', { required: true }).ok).toBe(false);   // required + empty
+
+        const bareId = validateStringField('Caption', { required: true });
+        expect(bareId.ok).toBe(false);
+        expect(bareId.message).toContain('"Caption"');       // suggests quoting
+        expect(bareId.message).toContain('Caption$');        // and the $/! variable form
+
+        const prose = validateStringField('Are you sure?', { required: true });
+        expect(prose.ok).toBe(false);
+        expect(prose.message).toContain('"Are you sure?"');  // quote suggestion
+        expect(prose.message).not.toContain('$');            // no nonsensical `prose$` hint
+
+        // structural errors still win over the typing check
+        expect(validateStringField('"TEST').ok).toBe(false); // unterminated literal
     });
 
     test('expressionDisplayText unquotes string literals, passes expressions through', () => {


### PR DESCRIPTION
## Problem

In the MSGBOX composer, the **message**, **title**, and **custom button** fields accepted any well-formed BBj expression — including a bare identifier like `Caption`. In BBj a bare identifier is a **numeric** variable reference, so it landed verbatim in the generated `MSGBOX(...)` call and produced a syntax/type error. Only a quoted literal (`"Caption"`), a string variable (`Caption$`), or an object variable (`Caption!`) is a valid string argument.

The existing `validateBbjExpression` only checked *structure* (balanced quotes/parens), never *type* — so these values slipped through.

## Fix

Add two functions to the editor-agnostic `msgbox-composer.ts` (kept there so the logic stays unit-testable and reusable by the IntelliJ client later):

- **`resolvesToString(text)`** — best-effort lexical string-type check. Splits on top-level `+` and accepts only when every operand is string-typed: a `"..."` literal, a `$`/`!` reference (with optional `[subscript]`), a function/method call, or a parenthesised string. Rejects bare numeric refs (`Caption`), numbers, integer vars (`n%`), and top-level arithmetic (`-`/`*`/`/`, or a numeric operand in a concat).
- **`validateStringField(text, {required})`** — layers presence → structural (`validateBbjExpression`) → string typing, and on rejection tells the user how to fix it (quote it, or add a `$`/`!` suffix for a plain identifier).
- **`quoteAsStringLiteral(text)`** — helper that wraps text and doubles embedded quotes.

Wired into **both** entry points:
- Webview form — message, title, and each custom button (now surfacing the specific per-button reason instead of a generic "Invalid button expression").
- QuickPick create flow — input-box `validateInput` on message/title.

## Testing

- Added a test block covering the reported bug and the valid/invalid forms.
- `npx vitest run test/msgbox-composer.test.ts` → 24/24 pass.
- `tsc --noEmit` clean · ESLint clean on the changed files.

Refs #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)