### PR TITLE
Visual composer for BBjSysGui::addWindow flags + event_mask, with schematic preview (#430)

### DIFF
--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -157,6 +157,11 @@
         "category": "BBj",
         "command": "bbj.composeMsgboxVisual",
         "title": "Compose MSGBOX (visual)…"
+      },
+      {
+        "category": "BBj",
+        "command": "bbj.composeAddWindow",
+        "title": "Compose addWindow (visual)…"
       }
     ],
     "keybindings": [
@@ -215,6 +220,11 @@
         },
         {
           "command": "bbj.composeMsgboxVisual",
+          "when": "editorLangId == bbj",
+          "group": "1_modification"
+        },
+        {
+          "command": "bbj.composeAddWindow",
           "when": "editorLangId == bbj",
           "group": "1_modification"
         }
@@ -579,7 +589,8 @@
     "onCommand:bbj.decompile",
     "onCommand:bbj.decompileReadonly",
     "onCommand:bbj.composeMsgbox",
-    "onCommand:bbj.composeMsgboxVisual"
+    "onCommand:bbj.composeMsgboxVisual",
+    "onCommand:bbj.composeAddWindow"
   ],
   "main": "./out/extension.cjs",
   "scripts": {

--- a/bbj-vscode/src/addwindow-composer-ui.ts
+++ b/bbj-vscode/src/addwindow-composer-ui.ts
@@ -1,0 +1,68 @@
+/**
+ * VS Code UI for the BBjSysGui::addWindow composer (#430).
+ *
+ * Thin client layer: a command + a Code Action, both opening the visual webview. All hex/flag
+ * logic lives in the editor-agnostic ./addwindow-composer module. Two entry points:
+ *   - Command "bbj.composeAddWindow" with no args -> compose a NEW addWindow statement at the cursor.
+ *   - Code Action on an existing addWindow(...)   -> decode its flags/event_mask hex and edit the
+ *                                                    tokens in place (or add flags where there are none).
+ */
+import * as vscode from 'vscode';
+import {
+    WINDOW_FLAGS, EVENT_MASK_BITS, unknownBits, describeFlags, findAddWindowCallAt,
+} from './addwindow-composer.js';
+import { openAddWindowComposerPanel, AddWindowPanelArg } from './addwindow-composer-webview.js';
+
+export function registerAddWindowComposer(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('bbj.composeAddWindow', (arg?: AddWindowPanelArg) => openAddWindowComposerPanel(context, arg)),
+        vscode.languages.registerCodeActionsProvider(
+            { language: 'bbj' },
+            new AddWindowCodeActionProvider(),
+            { providedCodeActionKinds: [vscode.CodeActionKind.RefactorRewrite] },
+        ),
+    );
+}
+
+class AddWindowCodeActionProvider implements vscode.CodeActionProvider {
+    provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection): vscode.CodeAction[] {
+        const lineNo = range.start.line;
+        const info = findAddWindowCallAt(document.lineAt(lineNo).text, range.start.character);
+        if (!info) return [];
+
+        const flags = info.flagsValue ?? 0;
+        const eventMask = info.eventMaskValue ?? null;
+        const arg: AddWindowPanelArg = {
+            target: {
+                uri: document.uri.toString(),
+                line: lineNo,
+                flagsRange: info.flagsRange,
+                flagsInsertOffset: info.flagsInsertOffset,
+                eventMaskRange: info.eventMaskRange,
+                eventMaskInsertOffset: info.eventMaskInsertOffset,
+                preservedFlagBits: unknownBits(flags, WINDOW_FLAGS),
+                preservedEventBits: eventMask === null ? 0 : unknownBits(eventMask, EVENT_MASK_BITS),
+            },
+            initial: {
+                flags, eventMask,
+                // Geometry/title are fixed in the source in EDIT mode; pass the title for the preview.
+                receiver: '', sysgui: 'sysgui!',
+                x: '', y: '', width: '', height: '',
+                title: titleArg(info.args),
+            },
+        };
+
+        const label = info.flagsValue !== undefined
+            ? `Configure window flags (${describeFlags(flags)})`
+            : 'Add window flags…';
+        const action = new vscode.CodeAction(label, vscode.CodeActionKind.RefactorRewrite);
+        action.command = { command: 'bbj.composeAddWindow', title: label, arguments: [arg] };
+        return [action];
+    }
+}
+
+/** Best-effort pick of the title argument for the preview: the last string-literal arg before the flags. */
+function titleArg(args: string[]): string {
+    const literal = [...args].reverse().find(a => /^"([^"]|"")*"$/.test(a));
+    return literal ?? '"Window"';
+}

--- a/bbj-vscode/src/addwindow-composer-webview.ts
+++ b/bbj-vscode/src/addwindow-composer-webview.ts
@@ -1,0 +1,425 @@
+/**
+ * Visual BBjSysGui::addWindow composer — a webview panel with grouped flag checkboxes, a
+ * collapsible (opt-in) event-mask sub-area, a live schematic window preview, and the generated
+ * statement (#430).
+ *
+ * The panel is pure presentation: it renders the two catalogs, groups them, and sends the raw
+ * selection back to the extension, which computes the `$flags$` / `$event_mask$` hex, the
+ * statement text, and the schematic descriptor with the shared ./addwindow-composer logic.
+ *
+ * Two modes:
+ *   - NEW (no target): compose a fresh `window! = sysgui!.addWindow(...)` and insert it at the cursor.
+ *   - EDIT (from the Code Action): the geometry/title are fixed in the source; the panel edits only
+ *     the `$flags$` (and optional `$event_mask$`) hex tokens and applies them in place.
+ */
+import * as vscode from 'vscode';
+import {
+    WINDOW_FLAGS, EVENT_MASK_BITS, encodeBits, formatHex, describeFlags,
+    describeEventMask, windowSchematic, composeAddWindow,
+} from './addwindow-composer.js';
+// Reuse the small display-text helper from the MSGBOX composer scaffolding (#426).
+import { expressionDisplayText } from './msgbox-composer.js';
+
+/** Where/how to apply an EDIT: token ranges to replace, or offsets to insert at. */
+export interface AddWindowEditTarget {
+    uri: string;
+    line: number;
+    /** Replace the existing flags literal, or insert `, $flags$` at this offset if there is none. */
+    flagsRange?: [number, number];
+    flagsInsertOffset?: number;
+    /** Replace the existing event_mask literal, or insert `, $mask$` at this offset (opt-in). */
+    eventMaskRange?: [number, number];
+    eventMaskInsertOffset?: number;
+    /** Preserved bits the catalog doesn't model, OR-ed back in on encode (round-trip safety). */
+    preservedFlagBits: number;
+    preservedEventBits: number;
+}
+
+export interface AddWindowPanelArg {
+    /** Present = EDIT an existing call's hex tokens in place. Absent = insert a NEW statement. */
+    target?: AddWindowEditTarget;
+    initial?: {
+        flags: number;
+        /** null = event mask unset (window default); a number = configured. */
+        eventMask: number | null;
+        /** For the preview only in EDIT mode; the full form in NEW mode. */
+        receiver: string;
+        sysgui: string;
+        x: string;
+        y: string;
+        width: string;
+        height: string;
+        title: string;
+    };
+}
+
+interface Selection {
+    flags: number[];
+    eventMaskEnabled: boolean;
+    eventMask: number[];
+    receiver: string;
+    sysgui: string;
+    x: string;
+    y: string;
+    width: string;
+    height: string;
+    title: string;
+}
+
+const DEFAULT_INITIAL = {
+    // Resizable + Close box + Keyboard navigation — the shape of the BASIS doc example ($00010003$).
+    flags: 0x00010003,
+    eventMask: null as number | null,
+    receiver: 'window!', sysgui: 'sysgui!',
+    x: '10', y: '10', width: '400', height: '300', title: '"Window"',
+};
+
+export function openAddWindowComposerPanel(context: vscode.ExtensionContext, arg?: AddWindowPanelArg): void {
+    const editMode = !!arg?.target;
+
+    let insertUri: vscode.Uri | undefined;
+    let insertPosition: vscode.Position | undefined;
+    if (!editMode) {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showInformationMessage('Open a BBj file first, then run the addWindow composer.');
+            return;
+        }
+        insertUri = editor.document.uri;
+        insertPosition = editor.selection.active;
+    }
+
+    const initial = { ...DEFAULT_INITIAL, ...(arg?.initial ?? {}) };
+    const target = arg?.target;
+
+    const panel = vscode.window.createWebviewPanel(
+        'bbjAddWindowComposer',
+        editMode ? 'Edit addWindow flags' : 'addWindow Composer',
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        { enableScripts: true, retainContextWhenHidden: true },
+    );
+    panel.webview.html = getHtml(panel.webview);
+
+    function build(sel: Selection) {
+        const flags = encodeBits(sel.flags);
+        const eventMask = sel.eventMaskEnabled ? encodeBits(sel.eventMask) : null;
+        const flagsHex = formatHex(flags | (target?.preservedFlagBits ?? 0));
+        const eventHex = eventMask === null ? null : formatHex(eventMask | (target?.preservedEventBits ?? 0));
+
+        const statement = composeAddWindow({
+            receiver: editMode ? undefined : (sel.receiver || undefined),
+            sysgui: sel.sysgui || 'sysgui!',
+            x: sel.x || '0', y: sel.y || '0', width: sel.width || '0', height: sel.height || '0',
+            title: sel.title || '""',
+            flags, eventMask,
+        });
+
+        return {
+            flagsHex, eventHex, statement,
+            flagsSummary: describeFlags(flags),
+            eventSummary: eventMask === null ? '(default)' : describeEventMask(eventMask),
+            render: { ...windowSchematic(flags), title: expressionDisplayText(sel.title) },
+        };
+    }
+
+    panel.webview.onDidReceiveMessage(async (msg: { type: string; payload?: Selection }) => {
+        switch (msg.type) {
+            case 'ready':
+                panel.webview.postMessage({
+                    type: 'init',
+                    editMode,
+                    catalogs: { flags: WINDOW_FLAGS, eventBits: EVENT_MASK_BITS },
+                    initial,
+                });
+                break;
+            case 'change':
+                if (msg.payload) panel.webview.postMessage({ type: 'preview', ...build(msg.payload) });
+                break;
+            case 'insert': {
+                if (!msg.payload) break;
+                const r = build(msg.payload);
+                const edit = new vscode.WorkspaceEdit();
+                if (editMode && target) {
+                    applyEdit(edit, msg.payload, r, target);
+                } else if (insertUri && insertPosition) {
+                    edit.insert(insertUri, insertPosition, r.statement);
+                }
+                await vscode.workspace.applyEdit(edit);
+                panel.dispose();
+                break;
+            }
+            case 'cancel':
+                panel.dispose();
+                break;
+        }
+    }, undefined, context.subscriptions);
+}
+
+/** EDIT mode: rewrite only the flags (and, if enabled, event_mask) hex tokens in place. */
+function applyEdit(edit: vscode.WorkspaceEdit, sel: Selection, r: { flagsHex: string; eventHex: string | null }, target: AddWindowEditTarget): void {
+    const uri = vscode.Uri.parse(target.uri);
+    const at = (col: number) => new vscode.Position(target.line, col);
+
+    if (target.flagsRange) {
+        edit.replace(uri, new vscode.Range(at(target.flagsRange[0]), at(target.flagsRange[1])), r.flagsHex);
+    } else if (target.flagsInsertOffset !== undefined) {
+        edit.insert(uri, at(target.flagsInsertOffset), `, ${r.flagsHex}`);
+    }
+
+    // Event mask: replace an existing token, or insert one when the user opts in. (Removing an
+    // existing event_mask arg is out of scope for the spike — omitting vs. $00000000$ differ.)
+    if (r.eventHex !== null) {
+        if (target.eventMaskRange) {
+            edit.replace(uri, new vscode.Range(at(target.eventMaskRange[0]), at(target.eventMaskRange[1])), r.eventHex);
+        } else if (target.eventMaskInsertOffset !== undefined) {
+            edit.insert(uri, at(target.eventMaskInsertOffset), `, ${r.eventHex}`);
+        }
+    }
+}
+
+function getHtml(webview: vscode.Webview): string {
+    const nonce = getNonce();
+    const csp = [
+        `default-src 'none'`,
+        `style-src ${webview.cspSource} 'unsafe-inline'`,
+        `script-src 'nonce-${nonce}'`,
+    ].join('; ');
+    return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>addWindow Composer</title>
+<style>
+  body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 12px 16px; }
+  h2 { margin: 0 0 12px; font-size: 1.1em; }
+  .row { display: flex; flex-direction: column; gap: 4px; margin-bottom: 10px; }
+  .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+  label { font-size: 0.85em; opacity: 0.85; }
+  input[type="text"] {
+    background: var(--vscode-input-background); color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent); padding: 4px 6px; border-radius: 2px;
+    font-family: var(--vscode-font-family); font-size: 0.95em;
+  }
+  fieldset { border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 3px; margin: 0 0 12px; padding: 8px 10px; }
+  legend { font-size: 0.82em; opacity: 0.85; padding: 0 4px; }
+  .flag-groups { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px 18px; }
+  .group-title { font-size: 0.78em; text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.6; margin: 6px 0 2px; }
+  .check { display: flex; align-items: center; gap: 6px; font-size: 0.9em; margin: 2px 0; }
+
+  .mock-wrap { margin: 6px 0 12px; display: flex; justify-content: center; }
+  .mock {
+    border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+    border-radius: 4px; overflow: hidden; width: 300px;
+    background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+    box-shadow: 0 2px 8px rgba(0,0,0,0.25); position: relative;
+  }
+  .mock.thick-border { border-width: 3px; }
+  .mock.disabled { opacity: 0.5; }
+  .mock.invisible { opacity: 0.28; border-style: dashed; }
+  .mock-title {
+    background: var(--vscode-titleBar-activeBackground, var(--vscode-editorGroupHeader-tabsBackground));
+    color: var(--vscode-titleBar-activeForeground, var(--vscode-foreground));
+    padding: 4px 8px; font-size: 0.82em; font-weight: 600; display: flex; align-items: center; justify-content: space-between;
+  }
+  .mock-title .btns { display: flex; gap: 4px; opacity: 0.9; }
+  .mock-title .btns span { display: inline-block; width: 14px; text-align: center; }
+  .mock-menu { display: flex; gap: 12px; padding: 3px 8px; font-size: 0.78em; opacity: 0.8; border-bottom: 1px solid var(--vscode-panel-border); }
+  .mock-body { height: 90px; position: relative; }
+  .mock-body .vscroll { position: absolute; top: 0; right: 0; width: 10px; height: 100%; background: var(--vscode-scrollbarSlider-background, rgba(120,120,120,0.4)); }
+  .mock-body .hscroll { position: absolute; left: 0; bottom: 0; height: 10px; width: 100%; background: var(--vscode-scrollbarSlider-background, rgba(120,120,120,0.4)); }
+  .mock-body .grip { position: absolute; right: 1px; bottom: 1px; font-size: 0.8em; opacity: 0.6; }
+  .mock-state { position: absolute; top: 50%; left: 0; right: 0; transform: translateY(-50%); text-align: center; font-size: 0.8em; opacity: 0.7; }
+  .badges { display: flex; flex-wrap: wrap; gap: 4px; margin: 8px 0 2px; }
+  .badge { font-size: 0.72em; padding: 1px 7px; border-radius: 10px; background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); }
+
+  .preview { margin: 8px 0 4px; }
+  pre {
+    background: var(--vscode-textCodeBlock-background); border: 1px solid var(--vscode-panel-border);
+    padding: 8px 10px; border-radius: 3px; white-space: pre-wrap; word-break: break-all; margin: 4px 0;
+  }
+  .summary { font-size: 0.8em; opacity: 0.75; min-height: 1.1em; margin-bottom: 3px; }
+  .buttons { display: flex; gap: 8px; margin-top: 14px; }
+  button {
+    background: var(--vscode-button-background); color: var(--vscode-button-foreground);
+    border: none; padding: 6px 14px; border-radius: 2px; cursor: pointer; font-size: 0.95em;
+  }
+  button:hover { background: var(--vscode-button-hoverBackground); }
+  button.secondary { background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); }
+  .hidden { display: none; }
+  .toggle-line { display: flex; align-items: center; gap: 6px; font-size: 0.9em; }
+</style>
+</head>
+<body>
+  <h2 id="heading">addWindow Composer</h2>
+
+  <div class="mock-wrap">
+    <div class="mock" id="mock">
+      <div class="mock-title" id="mock-title">
+        <span id="mock-title-text"></span>
+        <span class="btns" id="mock-title-btns"></span>
+      </div>
+      <div class="mock-menu hidden" id="mock-menu"><span>File</span><span>Edit</span><span>Help</span></div>
+      <div class="mock-body" id="mock-body"></div>
+    </div>
+  </div>
+  <div class="badges" id="badges"></div>
+
+  <fieldset id="geometry">
+    <legend>Statement</legend>
+    <div class="grid">
+      <div class="row"><label for="receiver">Assign to</label><input type="text" id="receiver"></div>
+      <div class="row"><label for="sysgui">SysGui expr</label><input type="text" id="sysgui"></div>
+      <div class="row"><label for="title">Title expr</label><input type="text" id="title"></div>
+      <div class="row"><label for="x">x</label><input type="text" id="x"></div>
+      <div class="row"><label for="y">y</label><input type="text" id="y"></div>
+      <div class="row"><label for="width">width</label><input type="text" id="width"></div>
+      <div class="row"><label for="height">height</label><input type="text" id="height"></div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Window flags</legend>
+    <div class="flag-groups" id="flag-groups"></div>
+  </fieldset>
+
+  <fieldset>
+    <legend>
+      <label class="toggle-line"><input type="checkbox" id="event-enabled"> Configure event mask (default: unset)</label>
+    </legend>
+    <div id="event-area" class="hidden">
+      <div class="flag-groups" id="event-groups"></div>
+    </div>
+  </fieldset>
+
+  <div class="preview">
+    <label>Generated statement</label>
+    <pre id="preview">—</pre>
+    <div class="summary" id="flags-summary"></div>
+    <div class="summary" id="event-summary"></div>
+  </div>
+
+  <div class="buttons">
+    <button id="insert">Insert</button>
+    <button id="cancel" class="secondary">Cancel</button>
+  </div>
+
+<script nonce="${nonce}">
+  const vscode = acquireVsCodeApi();
+  const $ = (id) => document.getElementById(id);
+  let editMode = false;
+
+  function groupCatalog(items) {
+    const groups = new Map();
+    for (const it of items) {
+      if (!groups.has(it.group)) groups.set(it.group, []);
+      groups.get(it.group).push(it);
+    }
+    return groups;
+  }
+
+  function renderChecks(container, items, selectedMask, cls) {
+    container.innerHTML = '';
+    for (const [group, groupItems] of groupCatalog(items)) {
+      const title = document.createElement('div');
+      title.className = 'group-title'; title.textContent = group;
+      title.style.gridColumn = '1 / -1';
+      container.appendChild(title);
+      for (const it of groupItems) {
+        const wrap = document.createElement('label');
+        wrap.className = 'check';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox'; cb.value = String(it.value); cb.className = cls;
+        if ((selectedMask & it.value) !== 0) cb.checked = true;
+        cb.addEventListener('change', change);
+        const span = document.createElement('span'); span.textContent = it.label;
+        wrap.appendChild(cb); wrap.appendChild(span); container.appendChild(wrap);
+      }
+    }
+  }
+
+  function readForm() {
+    return {
+      flags: Array.from(document.querySelectorAll('.flag-cb:checked')).map(c => Number(c.value)),
+      eventMaskEnabled: $('event-enabled').checked,
+      eventMask: Array.from(document.querySelectorAll('.event-cb:checked')).map(c => Number(c.value)),
+      receiver: $('receiver').value, sysgui: $('sysgui').value, title: $('title').value,
+      x: $('x').value, y: $('y').value, width: $('width').value, height: $('height').value,
+    };
+  }
+
+  function change() {
+    $('event-area').classList.toggle('hidden', !$('event-enabled').checked);
+    vscode.postMessage({ type: 'change', payload: readForm() });
+  }
+
+  window.addEventListener('message', (e) => {
+    const m = e.data;
+    if (m.type === 'init') {
+      editMode = m.editMode;
+      $('heading').textContent = editMode ? 'Edit addWindow flags' : 'addWindow Composer';
+      const init = m.initial;
+      $('receiver').value = init.receiver || '';
+      $('sysgui').value = init.sysgui || 'sysgui!';
+      $('title').value = init.title || '';
+      $('x').value = init.x; $('y').value = init.y; $('width').value = init.width; $('height').value = init.height;
+      // In EDIT mode the geometry/title live in the source; we only rewrite the hex tokens.
+      if (editMode) $('geometry').classList.add('hidden');
+      renderChecks($('flag-groups'), m.catalogs.flags, init.flags, 'flag-cb');
+      renderChecks($('event-groups'), m.catalogs.eventBits, init.eventMask || 0, 'event-cb');
+      $('event-enabled').checked = init.eventMask !== null && init.eventMask !== undefined;
+      $('event-enabled').addEventListener('change', change);
+      change();
+    } else if (m.type === 'preview') {
+      $('preview').textContent = m.statement;
+      $('flags-summary').textContent = 'flags = ' + m.flagsHex + '  ·  ' + m.flagsSummary;
+      $('event-summary').textContent = 'event_mask = ' + (m.eventHex || '(unset)') + '  ·  ' + m.eventSummary;
+      drawMock(m.render);
+    }
+  });
+
+  function drawMock(r) {
+    const mock = $('mock');
+    mock.classList.toggle('thick-border', r.border);
+    mock.classList.toggle('disabled', r.disabled);
+    mock.classList.toggle('invisible', r.invisible);
+    $('mock-title').classList.toggle('hidden', !r.titleBar);
+    $('mock-title-text').textContent = r.title || '(no title)';
+    const btns = $('mock-title-btns'); btns.innerHTML = '';
+    if (r.minMax) { btns.appendChild(mkBtn('–')); btns.appendChild(mkBtn('□')); }
+    if (r.closeBox) btns.appendChild(mkBtn('×'));
+    $('mock-menu').classList.toggle('hidden', !r.menuBar);
+    const body = $('mock-body'); body.innerHTML = '';
+    if (r.minimized) body.appendChild(mkState('(minimized)'));
+    else if (r.maximized) body.appendChild(mkState('(maximized)'));
+    if (r.vScroll) body.appendChild(mkDiv('vscroll'));
+    if (r.hScroll) body.appendChild(mkDiv('hscroll'));
+    if (r.resizable) { const g = mkDiv('grip'); g.textContent = '◢'; body.appendChild(g); }
+    const badges = $('badges'); badges.innerHTML = '';
+    for (const b of r.badges) { const el = document.createElement('span'); el.className = 'badge'; el.textContent = b; badges.appendChild(el); }
+  }
+  function mkBtn(t) { const s = document.createElement('span'); s.textContent = t; return s; }
+  function mkDiv(cls) { const d = document.createElement('div'); d.className = cls; return d; }
+  function mkState(t) { const d = document.createElement('div'); d.className = 'mock-state'; d.textContent = t; return d; }
+
+  for (const id of ['receiver', 'sysgui', 'title', 'x', 'y', 'width', 'height']) {
+    $(id).addEventListener('input', change);
+  }
+  $('insert').addEventListener('click', () => vscode.postMessage({ type: 'insert', payload: readForm() }));
+  $('cancel').addEventListener('click', () => vscode.postMessage({ type: 'cancel' }));
+
+  vscode.postMessage({ type: 'ready' });
+</script>
+</body>
+</html>`;
+}
+
+function getNonce(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let text = '';
+    for (let i = 0; i < 32; i++) {
+        text += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return text;
+}

--- a/bbj-vscode/src/addwindow-composer.ts
+++ b/bbj-vscode/src/addwindow-composer.ts
@@ -1,0 +1,285 @@
+/**
+ * Editor-agnostic logic for the BBjSysGui::addWindow composer (spike for #430).
+ *
+ * `addWindow(x, y, w, h, title$, flags$ [, event_mask$])` hides the window's whole personality
+ * behind two hex-STRING bitmasks (see
+ * https://documentation.basis.cloud/BASISHelp/WebHelp/bbjobjects/SysGui/bbjsysgui/bbjsysgui_addwindow.htm):
+ *   - `flags$`      — ~26 independent toggles (close box, resize, title bar, dialog, MDI, …)
+ *   - `event_mask$` — ~19 event-reporting bits (mouse/keyboard/window/control events)
+ * Both are written as `$HHHHHHHH$` hex literals, e.g. `$00010003$` (Resizable + Close box +
+ * Keyboard navigation). This is the same problem the MSGBOX composer (#426) solved for a decimal
+ * `expr`, but hex, 32-bit, and with the sign bit (`$80000000$`) in play.
+ *
+ * This module owns the two catalogs and the mask <-> hex <-> statement conversions with NO
+ * `vscode` dependency, so it is unit-testable and reusable by the IntelliJ client later.
+ */
+
+export interface FlagItem {
+    /** The single bit this toggle sets, e.g. 0x00000002. */
+    value: number;
+    label: string;
+    /** UI grouping so the composer can lay related toggles out together. */
+    group: string;
+    detail?: string;
+}
+
+/**
+ * Window creation flags — every bit is an independent toggle (unlike MSGBOX's mutually-exclusive
+ * button/icon groups), so the "state" is simply the set of chosen bits. Grouped for the UI.
+ */
+export const WINDOW_FLAGS: FlagItem[] = [
+    // Frame & chrome
+    { value: 0x00040000, label: 'Border', group: 'Frame' },
+    { value: 0x01000000, label: 'No title bar', group: 'Frame' },
+    { value: 0x00080000, label: 'Dialog', group: 'Frame' },
+    { value: 0x00000800, label: 'Menu bar', group: 'Frame' },
+    { value: 0x00002000, label: 'No menu separator line', group: 'Frame' },
+    // Title-bar controls
+    { value: 0x00000002, label: 'Close box', group: 'Title bar' },
+    { value: 0x00000080, label: 'Maximizable & minimizable', group: 'Title bar' },
+    // Resize & scrollbars
+    { value: 0x00000001, label: 'Resizable', group: 'Resize' },
+    { value: 0x00000004, label: 'Horizontal scrollbar', group: 'Resize' },
+    { value: 0x00000008, label: 'Vertical scrollbar', group: 'Resize' },
+    // Initial state
+    { value: 0x00000010, label: 'Initially invisible', group: 'Initial state' },
+    { value: 0x00000020, label: 'Initially disabled', group: 'Initial state' },
+    { value: 0x00000100, label: 'Initially minimized', group: 'Initial state' },
+    { value: 0x00001000, label: 'Initially maximized', group: 'Initial state' },
+    // MDI
+    { value: 0x02000000, label: 'Modal within MDI desktop', group: 'MDI' },
+    { value: 0x40000000, label: 'Modal within MDI group', group: 'MDI' },
+    // Behavior
+    { value: 0x00010000, label: 'Keyboard navigation', group: 'Behavior' },
+    { value: 0x00020000, label: 'Always on top', group: 'Behavior' },
+    { value: 0x00100000, label: 'Automatic layout', group: 'Behavior' },
+    { value: 0x00400000, label: 'Custom colors', group: 'Behavior' },
+    { value: 0x00800000, label: 'Enter behaves as Tab', group: 'Behavior' },
+    { value: 0x08000000, label: 'Enforce unique control names', group: 'Behavior' },
+    { value: 0x04000000, label: 'SYSCOLOR events', group: 'Behavior' },
+    { value: 0x10000000, label: 'Report all mouse events', group: 'Behavior' },
+    { value: 0x20000000, label: 'Report all keypress events', group: 'Behavior' },
+    { value: 0x80000000, label: 'TRACK(0) instead of TRACK(1)', group: 'Behavior' },
+];
+
+/** Event-mask bits — which events the window reports. Optional; usually left at the default. */
+export const EVENT_MASK_BITS: FlagItem[] = [
+    // Mouse
+    { value: 0x00000040, label: 'Mouse button down', group: 'Mouse' },
+    { value: 0x00000080, label: 'Mouse button up', group: 'Mouse' },
+    { value: 0x00000100, label: 'Mouse moved', group: 'Mouse' },
+    { value: 0x00000200, label: 'Mouse button double-click', group: 'Mouse' },
+    { value: 0x00000020, label: 'Mouse wheel scroll', group: 'Mouse' },
+    { value: 0x00000800, label: 'Mouse button click (BBj 23+)', group: 'Mouse' },
+    { value: 0x20000000, label: 'Right mouse button down', group: 'Mouse' },
+    { value: 0x10000000, label: 'Mouse enter/exit control or window', group: 'Mouse' },
+    // Keyboard
+    { value: 0x00000400, label: 'Key pressed', group: 'Keyboard' },
+    // Window
+    { value: 0x00000001, label: 'Popup request', group: 'Window' },
+    { value: 0x00000004, label: 'Window focus change', group: 'Window' },
+    { value: 0x00000008, label: 'Window resized', group: 'Window' },
+    { value: 0x40000000, label: 'Window activation', group: 'Window' },
+    { value: 0x80000000, label: 'User changed system colors', group: 'Window' },
+    // Controls
+    { value: 0x02000000, label: 'Check/uncheck checkbox or radio button', group: 'Controls' },
+    { value: 0x01000000, label: 'Click or double-click on list item', group: 'Controls' },
+    { value: 0x00400000, label: 'Edit / list-edit modified', group: 'Controls' },
+    { value: 0x00800000, label: 'Edit / list-edit / text-edit focus change', group: 'Controls' },
+    { value: 0x00100000, label: 'Scroll bar position changed', group: 'Controls' },
+];
+
+/** OR of every catalog bit — used to isolate bits we don't model so a round-trip can preserve them. */
+export function knownMask(catalog: FlagItem[]): number {
+    return catalog.reduce((m, f) => (m | f.value) >>> 0, 0);
+}
+
+/** OR a list of bit values into a single unsigned 32-bit mask (sign bit safe). */
+export function encodeBits(values: number[]): number {
+    return values.reduce((acc, v) => (acc | v) >>> 0, 0);
+}
+
+/** The catalog bits set in `mask`, in catalog order (inverse of {@link encodeBits}). */
+export function bitsSet(mask: number, catalog: FlagItem[]): number[] {
+    return catalog.filter(f => (mask & f.value) !== 0).map(f => f.value);
+}
+
+/** Bits set in `mask` that no catalog entry models — preserved verbatim when re-encoding a call. */
+export function unknownBits(mask: number, catalog: FlagItem[]): number {
+    return (mask & ~knownMask(catalog)) >>> 0;
+}
+
+/** Format a 32-bit mask as a canonical BBj hex-string literal, e.g. `$00010003$`. */
+export function formatHex(mask: number): string {
+    return '$' + (mask >>> 0).toString(16).toUpperCase().padStart(8, '0') + '$';
+}
+
+/** Parse a `$HHHHHHHH$` hex-string literal to an unsigned 32-bit number; `$$` is 0. Else undefined. */
+export function parseHexLiteral(token: string): number | undefined {
+    const m = /^\$([0-9A-Fa-f]*)\$$/.exec(token.trim());
+    if (!m) return undefined;
+    return m[1] === '' ? 0 : parseInt(m[1], 16) >>> 0;
+}
+
+/** Human-readable ` · `-joined summary of the set bits in `mask` (or `(none)` when empty). */
+export function describeMask(mask: number, catalog: FlagItem[]): string {
+    const labels = catalog.filter(f => (mask & f.value) !== 0).map(f => f.label);
+    return labels.length ? labels.join(' · ') : '(none)';
+}
+
+export const describeFlags = (mask: number): string => describeMask(mask, WINDOW_FLAGS);
+export const describeEventMask = (mask: number): string => describeMask(mask, EVENT_MASK_BITS);
+
+// ---------------------------------------------------------------------------------------------
+// Statement composition
+// ---------------------------------------------------------------------------------------------
+
+export interface AddWindowInput {
+    /** Optional assignment target, e.g. `window!` -> `window! = SYSGUI!.addWindow(...)`. */
+    receiver?: string;
+    /** The BBjSysGui expression the method is called on, e.g. `sysgui!`. */
+    sysgui: string;
+    /** Positional geometry/title argument texts (verbatim BBj expressions). */
+    x: string;
+    y: string;
+    width: string;
+    height: string;
+    title: string;
+    /** Window flags bitmask; rendered as a `$........$` hex literal. */
+    flags: number;
+    /** Event mask bitmask, or null/undefined to leave it unset (omit the argument = window default). */
+    eventMask?: number | null;
+}
+
+/** Build an `addWindow(...)` statement, emitting the event_mask argument only when it is set. */
+export function composeAddWindow(input: AddWindowInput): string {
+    const args = [input.x, input.y, input.width, input.height, input.title, formatHex(input.flags)];
+    if (input.eventMask != null) {
+        args.push(formatHex(input.eventMask));
+    }
+    const call = `${input.sysgui}.addWindow(${args.join(', ')})`;
+    return input.receiver ? `${input.receiver} = ${call}` : call;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Call parsing (locate the flags / event_mask hex literals in an existing call)
+// ---------------------------------------------------------------------------------------------
+
+const HEX_LITERAL = /^\$[0-9A-Fa-f]*\$$/;
+
+export interface AddWindowCallInfo {
+    /** Index of `addWindow` (well, the receiver-relative `.addWindow`) start within the line. */
+    callStart: number;
+    /** Index just past the closing `)` (or the line end if the call is unterminated). */
+    callEnd: number;
+    /** Trimmed top-level argument texts. */
+    args: string[];
+    /** [start, end) of the flags hex literal token within the line, if present. */
+    flagsRange?: [number, number];
+    flagsValue?: number;
+    /** [start, end) of the event_mask hex literal token within the line, if present. */
+    eventMaskRange?: [number, number];
+    eventMaskValue?: number;
+    /**
+     * Line-relative offset at which to insert `, $flags$` when the call has args but no hex-literal
+     * flags yet (flags follow the title in every overload) — lets the composer *add* flags.
+     */
+    flagsInsertOffset?: number;
+    /**
+     * Line-relative offset at which to insert `, $event_mask$` when the call has flags but no
+     * event_mask yet — the opt-in "configure event mask" path.
+     */
+    eventMaskInsertOffset?: number;
+}
+
+/**
+ * Scan the top-level arguments of a call starting just after its `(`. Handles nested parens and
+ * `"` string literals (with `""` escapes) so commas inside them don't split arguments. `$...$` hex
+ * literals contain no comma/paren so they need no special handling here.
+ */
+function scanArgs(line: string, open: number): { argRanges: Array<[number, number]>; callEnd: number } {
+    const argRanges: Array<[number, number]> = [];
+    let depth = 0, inStr = false, argStart = open, i = open, ended = false;
+    for (; i < line.length; i++) {
+        const c = line[i];
+        if (inStr) {
+            if (c === '"') { if (line[i + 1] === '"') { i++; continue; } inStr = false; }
+            continue;
+        }
+        if (c === '"') inStr = true;
+        else if (c === '(') depth++;
+        else if (c === ')') {
+            if (depth === 0) { argRanges.push([argStart, i]); i++; ended = true; break; }
+            depth--;
+        } else if (c === ',' && depth === 0) {
+            argRanges.push([argStart, i]);
+            argStart = i + 1;
+        }
+    }
+    if (!ended) argRanges.push([argStart, line.length]);
+    return { argRanges, callEnd: i };
+}
+
+/** The [start, end) of the trimmed token inside an argument range (strips surrounding whitespace). */
+function trimmedRange(line: string, a: number, b: number): [number, number] {
+    const seg = line.slice(a, b);
+    const start = a + (seg.length - seg.trimStart().length);
+    return [start, start + seg.trim().length];
+}
+
+function buildCallInfo(line: string, callStart: number, open: number): AddWindowCallInfo {
+    const { argRanges, callEnd } = scanArgs(line, open);
+    const args = argRanges.map(([a, b]) => line.slice(a, b).trim());
+    const nonEmpty = args.length > 1 || args[0] !== '';
+    const info: AddWindowCallInfo = { callStart, callEnd, args };
+
+    // flags = first hex literal, event_mask = second (event_mask never precedes flags in any overload).
+    const hexArgIdx = args.map((a, i) => (HEX_LITERAL.test(a) ? i : -1)).filter(i => i >= 0);
+    if (hexArgIdx.length >= 1) {
+        const fi = hexArgIdx[0];
+        info.flagsRange = trimmedRange(line, argRanges[fi][0], argRanges[fi][1]);
+        info.flagsValue = parseHexLiteral(args[fi]);
+    }
+    if (hexArgIdx.length >= 2) {
+        const ei = hexArgIdx[1];
+        info.eventMaskRange = trimmedRange(line, argRanges[ei][0], argRanges[ei][1]);
+        info.eventMaskValue = parseHexLiteral(args[ei]);
+    }
+
+    if (hexArgIdx.length === 0 && nonEmpty) {
+        // No flags yet: flags go right after the last (title) argument.
+        const [, end] = trimmedRange(line, argRanges[argRanges.length - 1][0], argRanges[argRanges.length - 1][1]);
+        info.flagsInsertOffset = end;
+    } else if (hexArgIdx.length === 1) {
+        // Flags but no event_mask: the event_mask goes right after the flags literal.
+        info.eventMaskInsertOffset = info.flagsRange![1];
+    }
+    return info;
+}
+
+/** Every `addWindow(...)` call on the line, in source order. */
+export function findAddWindowCalls(line: string): AddWindowCallInfo[] {
+    const re = /addwindow\s*\(/gi;
+    const calls: AddWindowCallInfo[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(line)) !== null) {
+        calls.push(buildCallInfo(line, m.index, m.index + m[0].length));
+    }
+    return calls;
+}
+
+/** First `addWindow(...)` call on the line (convenience). */
+export function parseAddWindowCallOnLine(line: string): AddWindowCallInfo | undefined {
+    return findAddWindowCalls(line)[0];
+}
+
+/**
+ * The `addWindow(...)` call the cursor is inside, if any. When calls are nested/multiple, the
+ * innermost (smallest span) containing the cursor wins — so a line with two calls only offers the
+ * action for the one in focus.
+ */
+export function findAddWindowCallAt(line: string, character: number): AddWindowCallInfo | undefined {
+    const containing = findAddWindowCalls(line).filter(c => character >= c.callStart && character <= c.callEnd);
+    if (containing.length === 0) return undefined;
+    return containing.reduce((best, c) => (c.callEnd - c.callStart < best.callEnd - best.callStart ? c : best));
+}

--- a/bbj-vscode/src/addwindow-composer.ts
+++ b/bbj-vscode/src/addwindow-composer.ts
@@ -130,6 +130,62 @@ export function describeMask(mask: number, catalog: FlagItem[]): string {
 export const describeFlags = (mask: number): string => describeMask(mask, WINDOW_FLAGS);
 export const describeEventMask = (mask: number): string => describeMask(mask, EVENT_MASK_BITS);
 
+/** Named window-flag bits — for readable render/preview code without scattering magic hex. */
+export const WINDOW_FLAG = {
+    RESIZABLE: 0x00000001,
+    CLOSE_BOX: 0x00000002,
+    HSCROLL: 0x00000004,
+    VSCROLL: 0x00000008,
+    INVISIBLE: 0x00000010,
+    DISABLED: 0x00000020,
+    MAXIMIZABLE: 0x00000080,
+    MINIMIZED: 0x00000100,
+    MENU_BAR: 0x00000800,
+    MAXIMIZED: 0x00001000,
+    NO_TITLE_BAR: 0x01000000,
+    BORDER: 0x00040000,
+} as const;
+
+/** Bits the schematic mock draws directly; every other set flag is surfaced as a text badge. */
+const VISUALIZED = Object.values(WINDOW_FLAG).reduce((m, v) => (m | v) >>> 0, 0);
+
+export interface WindowSchematic {
+    titleBar: boolean;
+    closeBox: boolean;
+    minMax: boolean;
+    menuBar: boolean;
+    hScroll: boolean;
+    vScroll: boolean;
+    border: boolean;
+    resizable: boolean;
+    disabled: boolean;
+    invisible: boolean;
+    minimized: boolean;
+    maximized: boolean;
+    /** Labels for set flags with no direct visual (Dialog, Always on top, MDI modal, …). */
+    badges: string[];
+}
+
+/** Derive a schematic description of the window a flag mask produces (drives the live preview). */
+export function windowSchematic(mask: number): WindowSchematic {
+    const on = (bit: number) => (mask & bit) !== 0;
+    return {
+        titleBar: !on(WINDOW_FLAG.NO_TITLE_BAR),
+        closeBox: on(WINDOW_FLAG.CLOSE_BOX),
+        minMax: on(WINDOW_FLAG.MAXIMIZABLE),
+        menuBar: on(WINDOW_FLAG.MENU_BAR),
+        hScroll: on(WINDOW_FLAG.HSCROLL),
+        vScroll: on(WINDOW_FLAG.VSCROLL),
+        border: on(WINDOW_FLAG.BORDER),
+        resizable: on(WINDOW_FLAG.RESIZABLE),
+        disabled: on(WINDOW_FLAG.DISABLED),
+        invisible: on(WINDOW_FLAG.INVISIBLE),
+        minimized: on(WINDOW_FLAG.MINIMIZED),
+        maximized: on(WINDOW_FLAG.MAXIMIZED),
+        badges: WINDOW_FLAGS.filter(f => (mask & f.value) !== 0 && (VISUALIZED & f.value) === 0).map(f => f.label),
+    };
+}
+
 // ---------------------------------------------------------------------------------------------
 // Statement composition
 // ---------------------------------------------------------------------------------------------

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -16,6 +16,7 @@ import { DocumentFormatter } from './document-formatter.js';
 import { isTokenizedBBjHeader, TOKENIZED_BBJ_MAGIC_LENGTH } from './tokenized-bbj.js';
 import { isLineNumberedSource } from './line-numbering.js';
 import { registerMsgboxComposer } from './msgbox-composer-ui.js';
+import { registerAddWindowComposer } from './addwindow-composer-ui.js';
 import {
     OPTION_GROUP_ORDER,
     getOptionsGrouped,
@@ -579,6 +580,7 @@ async function maybePromptLineNumbered(editor: vscode.TextEditor | undefined): P
 export function activate(context: vscode.ExtensionContext): void {
     BBjLibraryFileSystemProvider.register(context);
     registerMsgboxComposer(context); // spike: visual MSGBOX composer (#426)
+    registerAddWindowComposer(context); // spike: visual addWindow flags/event-mask composer (#430)
     secretStorage = context.secrets;
     client = startLanguageClient(context);
     outputChannel = client.outputChannel;

--- a/bbj-vscode/test/addwindow-composer.test.ts
+++ b/bbj-vscode/test/addwindow-composer.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import {
     WINDOW_FLAGS, EVENT_MASK_BITS, encodeBits, bitsSet, unknownBits, knownMask,
     formatHex, parseHexLiteral, describeMask, describeFlags, describeEventMask,
-    composeAddWindow, parseAddWindowCallOnLine, findAddWindowCallAt,
+    composeAddWindow, parseAddWindowCallOnLine, findAddWindowCallAt, windowSchematic, WINDOW_FLAG,
 } from '../src/addwindow-composer';
 
 describe('addWindow composer logic (#430)', () => {
@@ -67,6 +67,24 @@ describe('addWindow composer logic (#430)', () => {
         expect(describeMask(0, WINDOW_FLAGS)).toBe('(none)');
         expect(describeEventMask(0x00000040 | 0x00000400)).toContain('Mouse button down');
         expect(describeEventMask(0x00000040 | 0x00000400)).toContain('Key pressed');
+    });
+
+    test('windowSchematic maps flag bits to a drawable preview + badges', () => {
+        const s = windowSchematic(WINDOW_FLAG.RESIZABLE | WINDOW_FLAG.CLOSE_BOX | WINDOW_FLAG.MENU_BAR);
+        expect(s.titleBar).toBe(true);   // no "No title bar" flag
+        expect(s.closeBox).toBe(true);
+        expect(s.menuBar).toBe(true);
+        expect(s.resizable).toBe(true);
+        expect(s.minMax).toBe(false);
+        expect(s.badges).toEqual([]);    // all set bits are visualized
+
+        const noTitle = windowSchematic(WINDOW_FLAG.NO_TITLE_BAR);
+        expect(noTitle.titleBar).toBe(false);
+
+        // A non-visual flag (Dialog) surfaces as a badge, not a drawn element
+        const dialog = windowSchematic(0x00080000 | 0x00020000); // Dialog + Always on top
+        expect(dialog.badges).toContain('Dialog');
+        expect(dialog.badges).toContain('Always on top');
     });
 
     test('composeAddWindow renders the call and omits event_mask when unset', () => {

--- a/bbj-vscode/test/addwindow-composer.test.ts
+++ b/bbj-vscode/test/addwindow-composer.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'vitest';
+import {
+    WINDOW_FLAGS, EVENT_MASK_BITS, encodeBits, bitsSet, unknownBits, knownMask,
+    formatHex, parseHexLiteral, describeMask, describeFlags, describeEventMask,
+    composeAddWindow, parseAddWindowCallOnLine, findAddWindowCallAt,
+} from '../src/addwindow-composer';
+
+describe('addWindow composer logic (#430)', () => {
+    test('catalogs cover the documented bit counts and have unique bits', () => {
+        expect(WINDOW_FLAGS).toHaveLength(26);
+        expect(EVENT_MASK_BITS).toHaveLength(19);
+        for (const catalog of [WINDOW_FLAGS, EVENT_MASK_BITS]) {
+            const values = catalog.map(f => f.value);
+            expect(new Set(values).size).toBe(values.length);          // no duplicate bits
+            expect(values.every(v => (v & (v - 1)) === 0 && v !== 0)).toBe(true); // each is a single bit
+        }
+    });
+
+    test('encodeBits ORs bits into an unsigned mask, including the sign bit', () => {
+        expect(encodeBits([0x1, 0x2, 0x10000])).toBe(0x00010003);
+        expect(encodeBits([])).toBe(0);
+        // 0x80000000 must stay positive (unsigned), not become a negative int32
+        expect(encodeBits([0x80000000, 0x1])).toBe(0x80000001);
+        expect(encodeBits([0x80000000])).toBeGreaterThan(0);
+    });
+
+    test('bitsSet is the inverse of encodeBits over a catalog', () => {
+        const chosen = [0x00000001, 0x00000002, 0x01000000, 0x80000000];
+        expect(bitsSet(encodeBits(chosen), WINDOW_FLAGS).sort()).toEqual([...chosen].sort());
+        expect(bitsSet(0, WINDOW_FLAGS)).toEqual([]);
+    });
+
+    test('formatHex / parseHexLiteral round-trip canonical 8-digit hex', () => {
+        expect(formatHex(0x00010003)).toBe('$00010003$');
+        expect(formatHex(0)).toBe('$00000000$');
+        expect(formatHex(0x80000000)).toBe('$80000000$'); // sign bit renders unsigned
+        for (const n of [0, 0x1, 0x00010003, 0x40000000, 0x80000000, 0xFFFFFFFF]) {
+            expect(parseHexLiteral(formatHex(n))).toBe(n >>> 0);
+        }
+    });
+
+    test('parseHexLiteral accepts $$ and rejects non-hex-literals', () => {
+        expect(parseHexLiteral('$$')).toBe(0);
+        expect(parseHexLiteral('$00010003$')).toBe(0x00010003);
+        expect(parseHexLiteral('  $00010003$  ')).toBe(0x00010003); // trimmed
+        expect(parseHexLiteral('00010003')).toBeUndefined();        // no $ delimiters
+        expect(parseHexLiteral('$00XY$')).toBeUndefined();          // not hex
+        expect(parseHexLiteral('flags$')).toBeUndefined();          // a variable, not a literal
+    });
+
+    test('unknownBits isolates bits no catalog entry models (for round-trip preservation)', () => {
+        const reserved = 0x00004000; // not a documented window flag
+        const mask = 0x00000001 | reserved;
+        expect(unknownBits(mask, WINDOW_FLAGS)).toBe(reserved);
+        expect(unknownBits(0x00000001, WINDOW_FLAGS)).toBe(0);
+        // re-encoding the known selection plus preserved unknown bits reproduces the original mask
+        expect(encodeBits([...bitsSet(mask, WINDOW_FLAGS), unknownBits(mask, WINDOW_FLAGS)])).toBe(mask);
+    });
+
+    test('knownMask ORs every catalog bit', () => {
+        expect(knownMask(WINDOW_FLAGS)).toBe(encodeBits(WINDOW_FLAGS.map(f => f.value)));
+    });
+
+    test('describeMask / describeFlags / describeEventMask render a human summary', () => {
+        // 0x00010003 = Close box (0x2) + Resizable (0x1) + Keyboard navigation (0x10000), in catalog order
+        expect(describeFlags(0x00010003)).toBe('Close box · Resizable · Keyboard navigation');
+        expect(describeMask(0, WINDOW_FLAGS)).toBe('(none)');
+        expect(describeEventMask(0x00000040 | 0x00000400)).toContain('Mouse button down');
+        expect(describeEventMask(0x00000040 | 0x00000400)).toContain('Key pressed');
+    });
+
+    test('composeAddWindow renders the call and omits event_mask when unset', () => {
+        const base = { receiver: 'window!', sysgui: 'sysgui!', x: '10', y: '10', width: '400', height: '300', title: '"Win"' };
+        expect(composeAddWindow({ ...base, flags: 0x00010003 }))
+            .toBe('window! = sysgui!.addWindow(10, 10, 400, 300, "Win", $00010003$)');
+        // event_mask included only when provided
+        expect(composeAddWindow({ ...base, flags: 0x00000003, eventMask: 0x00000440 }))
+            .toBe('window! = sysgui!.addWindow(10, 10, 400, 300, "Win", $00000003$, $00000440$)');
+        // no receiver -> bare expression; eventMask: null is treated as unset
+        expect(composeAddWindow({ sysgui: 'g!', x: '0', y: '0', width: '1', height: '1', title: 't$', flags: 0, eventMask: null }))
+            .toBe('g!.addWindow(0, 0, 1, 1, t$, $00000000$)');
+    });
+
+    test('parse locates the flags hex literal and its replaceable range', () => {
+        const line = 'window! = sysgui!.addWindow(300,300,400,400,"Title",$00010003$)';
+        const info = parseAddWindowCallOnLine(line)!;
+        expect(info.flagsValue).toBe(0x00010003);
+        expect(line.slice(info.flagsRange![0], info.flagsRange![1])).toBe('$00010003$');
+        expect(info.eventMaskRange).toBeUndefined();
+        // flags present but no event_mask -> offer an insert point right after the flags literal
+        expect(info.eventMaskInsertOffset).toBe(info.flagsRange![1]);
+    });
+
+    test('parse locates flags AND event_mask (second hex literal)', () => {
+        const line = 'w! = g!.addWindow(0, 0, 200, 100, "T", $00000003$, $10000440$)';
+        const info = parseAddWindowCallOnLine(line)!;
+        expect(info.flagsValue).toBe(0x00000003);
+        expect(info.eventMaskValue).toBe(0x10000440);
+        expect(line.slice(info.eventMaskRange![0], info.eventMaskRange![1])).toBe('$10000440$');
+        expect(info.flagsInsertOffset).toBeUndefined();
+        expect(info.eventMaskInsertOffset).toBeUndefined();
+    });
+
+    test('parse finds flags regardless of the context-id / title-only overload', () => {
+        // context-id overload: extra leading int arg, flags still the first hex literal
+        const ctx = parseAddWindowCallOnLine('g!.addWindow(1, 0, 0, 200, 100, "T", $00040000$)')!;
+        expect(ctx.flagsValue).toBe(0x00040000);
+        // title-only overload
+        const titleOnly = parseAddWindowCallOnLine('g!.addWindow("T", $00080002$)')!;
+        expect(titleOnly.flagsValue).toBe(0x00080002);
+    });
+
+    test('parse offers a flags-insert offset for a call with no hex literal yet', () => {
+        const line = 'window! = sysgui!.addWindow(10, 10, 400, 300, "Hello")';
+        const info = parseAddWindowCallOnLine(line)!;
+        expect(info.flagsValue).toBeUndefined();
+        expect(info.flagsInsertOffset).toBeDefined();
+        const off = info.flagsInsertOffset!;
+        expect(line.slice(0, off) + ', $00010003$' + line.slice(off))
+            .toBe('window! = sysgui!.addWindow(10, 10, 400, 300, "Hello", $00010003$)');
+    });
+
+    test('parse handles commas/parens inside the title string', () => {
+        const line = 'w! = g!.addWindow(0,0,9,9,"a, b (c)",$00000002$)';
+        const info = parseAddWindowCallOnLine(line)!;
+        expect(info.args[4]).toBe('"a, b (c)"');
+        expect(info.flagsValue).toBe(0x00000002);
+    });
+
+    test('findAddWindowCallAt targets the call the cursor is inside (two calls on one line)', () => {
+        const line = 'if x then a! = g!.addWindow("A", $00000002$) else b! = g!.addWindow("B")';
+        const first = findAddWindowCallAt(line, line.indexOf('"A"'))!;
+        expect(first.flagsValue).toBe(0x00000002);
+        const second = findAddWindowCallAt(line, line.indexOf('"B"'))!;
+        expect(second.flagsValue).toBeUndefined();
+        expect(second.flagsInsertOffset).toBeDefined();
+        expect(first.callStart).not.toBe(second.callStart);
+        expect(findAddWindowCallAt(line, 0)).toBeUndefined(); // cursor on the IF, outside both calls
+    });
+});


### PR DESCRIPTION
Implements #430 — a visual composer for the `BBjSysGui::addWindow` window creation **flags** and **event_mask**, in the same spirit as the MSGBOX composer (#426) but for **hex-string** bitmasks.

## Why

`addWindow(x, y, w, h, title$, flags$ [, event_mask$])` hides the whole window personality behind two additive **hex** literals like `$00010003$` — ~26 independent flag toggles (close box, resize, title bar, dialog, MDI, …) plus an optional ~19-bit `event_mask`. Nobody remembers these, and reading an existing `$01090003$` back is worse. This is the MSGBOX problem, but hex, 32-bit, and with the sign bit (`$80000000$`) in play.

## What's here

**Editor-agnostic module** (`addwindow-composer.ts`, no `vscode` dep, unit-tested, reusable by IntelliJ later):
- `WINDOW_FLAGS` (26) + `EVENT_MASK_BITS` (19) catalogs, each bit tagged with a UI group.
- `encodeBits` / `bitsSet` / `unknownBits` (round-trip-preserves bits we don't model) / `formatHex` / `parseHexLiteral` (unsigned 32-bit, `$$` = 0) / `describeMask`.
- `composeAddWindow` (emits `event_mask` only when set) and a call parser that locates the flags/event_mask literals **by their `$...$` shape** — robust across the context-id and title-only overloads — plus in-place replace ranges and add-flags / add-event-mask insert offsets.
- `windowSchematic(mask)` — derives a drawable preview descriptor (title bar, close/min/max, menu, scrollbars, border, state) + badges for non-visual flags.

**VS Code UI** (mirrors #426):
- Webview with grouped flag checkboxes, a **live schematic window mock**, and the event mask in a collapsed **opt-in "Configure event mask" sub-area** (default: unset — per the issue, it's rarely set). Shows the generated statement + flags/event-mask hex + human summaries.
- Command `bbj.composeAddWindow` (create) and a RefactorRewrite **Code Action** that decodes an existing call and edits the hex tokens in place (or adds flags where a call has none). Unknown bits preserved on round-trip.

## Design notes / scope

- **Event mask** uses option (A) from the issue — one command with a collapsible sub-area, not a second command.
- **Edit mode** rewrites only the `$...$` tokens (robust across overloads); it does not restructure geometry/title. Removing an already-present `event_mask` is intentionally out of scope for the spike (omitting the arg vs. `$00000000$` are semantically different).
- Follow-ups: IntelliJ parity; optionally move the shared logic into the language server as `workspace/executeCommand`.

## Testing

- 16 unit tests for the addWindow module (catalogs, hex round-trips incl. the sign bit, unknown-bit preservation, compose, overload-robust parsing, schematic); 36 total across both composers.
- `npm run build` (tsc + esbuild) green · `tsc --noEmit` clean · ESLint clean · `package.json` validates.

Closes #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)