### PR TITLE
Composer LS command layer: bbj/composer/* requests for cross-client reuse (#433)

### DIFF
--- a/bbj-vscode/src/language/composer-commands.ts
+++ b/bbj-vscode/src/language/composer-commands.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared composer command layer for the MSGBOX (#426) and addWindow (#430) visual composers,
+ * exposed over LSP `workspace`-style custom requests so BOTH clients — the VS Code webview and the
+ * IntelliJ plugin (LSP4IJ) — drive one implementation of the flag/hex arithmetic (#433).
+ *
+ * The domain logic itself lives in the editor-agnostic `../msgbox-composer` and `../addwindow-composer`
+ * modules (no `vscode` dependency, fully unit-tested); this file only re-exposes their pure API as
+ * request handlers. It adds NO new flag/hex logic — every handler is a thin pass-through — so the
+ * language server and the VS Code UI stay a single source of truth.
+ *
+ * Requests use the `bbj/composer/*` namespace, matching the existing custom-request convention in
+ * `main.ts` (e.g. `bbj/refreshJavaClasses`). Params/results are plain JSON.
+ */
+import type { Connection } from 'vscode-languageserver';
+import {
+    BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS,
+    encode, decode, describe as describeMsgbox, composeStatement, stateFromSelection, flagsFromState,
+    validateStringField, findMsgboxCallAt, parseMsgboxCallOnLine,
+    type ComposeInput,
+} from '../msgbox-composer.js';
+import {
+    WINDOW_FLAGS, EVENT_MASK_BITS,
+    encodeBits, bitsSet, unknownBits, formatHex, parseHexLiteral,
+    describeFlags, describeEventMask, windowSchematic, composeAddWindow,
+    findAddWindowCallAt, parseAddWindowCallOnLine,
+    type AddWindowInput,
+} from '../addwindow-composer.js';
+
+/** A line + optional cursor column; when `character` is set, only the call at the cursor is returned. */
+interface LineQuery { line: string; character?: number }
+
+/**
+ * The composer request handlers, keyed by LSP method. Exported (not just wired) so they can be
+ * unit-tested directly without a live LSP connection. Each takes the JSON params and returns JSON.
+ */
+export const composerHandlers = {
+    /** Static option catalogs — a client fetches these once and renders its own UI. */
+    'bbj/composer/catalogs': () => ({
+        msgbox: { buttonSets: BUTTON_SETS, icons: ICONS, defaultButtons: DEFAULT_BUTTONS, flags: FLAGS },
+        addwindow: { flags: WINDOW_FLAGS, eventBits: EVENT_MASK_BITS },
+    }),
+
+    // ---- MSGBOX ----------------------------------------------------------------------------------
+    /** Flat UI selection -> additive numeric `expr`. */
+    'bbj/composer/msgbox/encode': (p: { selection: Parameters<typeof stateFromSelection>[0] }) =>
+        ({ expr: encode(stateFromSelection(p.selection)) }),
+    /** `expr` -> flat selection (button set / icon / default button / flag values). */
+    'bbj/composer/msgbox/decode': (p: { expr: number }) => {
+        const s = decode(p.expr);
+        return { buttonSet: s.buttonSet, icon: s.icon, defaultButton: s.defaultButton, flags: flagsFromState(s) };
+    },
+    'bbj/composer/msgbox/compose': (p: { input: ComposeInput }) => ({ statement: composeStatement(p.input) }),
+    'bbj/composer/msgbox/describe': (p: { expr: number }) => ({ text: describeMsgbox(p.expr) }),
+    /** Validate a string-typed field (message/title/button) — resolves-to-String + structural. */
+    'bbj/composer/msgbox/validateString': (p: { text: string; required?: boolean }) =>
+        validateStringField(p.text, { required: p.required }),
+    /** Locate a MSGBOX call on a line (the one at `character`, or the first). */
+    'bbj/composer/msgbox/parseLine': (p: LineQuery) =>
+        ({ call: p.character === undefined ? parseMsgboxCallOnLine(p.line) : findMsgboxCallAt(p.line, p.character) }),
+
+    // ---- addWindow -------------------------------------------------------------------------------
+    /** Chosen flag bits -> mask + `$........$` hex (unknown bits OR-ed back for round-trip safety). */
+    'bbj/composer/addwindow/encodeFlags': (p: { bits: number[]; preserved?: number }) => {
+        const mask = encodeBits(p.bits) | (p.preserved ?? 0);
+        return { mask: mask >>> 0, hex: formatHex(mask) };
+    },
+    'bbj/composer/addwindow/encodeEventMask': (p: { bits: number[]; preserved?: number }) => {
+        const mask = encodeBits(p.bits) | (p.preserved ?? 0);
+        return { mask: mask >>> 0, hex: formatHex(mask) };
+    },
+    /** A flags mask -> the set flag bits, the bits we don't model, and a drawable schematic. */
+    'bbj/composer/addwindow/decodeFlags': (p: { mask: number }) => ({
+        bits: bitsSet(p.mask, WINDOW_FLAGS),
+        unknownBits: unknownBits(p.mask, WINDOW_FLAGS),
+        schematic: windowSchematic(p.mask),
+        text: describeFlags(p.mask),
+    }),
+    'bbj/composer/addwindow/decodeEventMask': (p: { mask: number }) => ({
+        bits: bitsSet(p.mask, EVENT_MASK_BITS),
+        unknownBits: unknownBits(p.mask, EVENT_MASK_BITS),
+        text: describeEventMask(p.mask),
+    }),
+    'bbj/composer/addwindow/compose': (p: { input: AddWindowInput }) => ({ statement: composeAddWindow(p.input) }),
+    'bbj/composer/addwindow/schematic': (p: { mask: number }) => windowSchematic(p.mask),
+    /** Parse a `$HHHHHHHH$` hex literal to an unsigned number (or undefined). */
+    'bbj/composer/addwindow/parseHex': (p: { token: string }) => ({ value: parseHexLiteral(p.token) }),
+    /** Locate an addWindow call on a line (the one at `character`, or the first). */
+    'bbj/composer/addwindow/parseLine': (p: LineQuery) =>
+        ({ call: p.character === undefined ? parseAddWindowCallOnLine(p.line) : findAddWindowCallAt(p.line, p.character) }),
+} as const;
+
+/** Register every composer request on the LSP connection. Call once during server startup. */
+export function registerComposerRequests(connection: Pick<Connection, 'onRequest'>): void {
+    for (const [method, handler] of Object.entries(composerHandlers)) {
+        connection.onRequest(method, handler as (params: unknown) => unknown);
+    }
+}

--- a/bbj-vscode/src/language/main.ts
+++ b/bbj-vscode/src/language/main.ts
@@ -13,12 +13,17 @@ import { BBjWorkspaceManager } from './bbj-ws-manager.js';
 import { logger, LogLevel } from './logger.js';
 import { setSuppressCascading, setMaxErrors, setCompilerTrigger } from './bbj-document-validator.js';
 import { initNotifications } from './bbj-notifications.js';
+import { registerComposerRequests } from './composer-commands.js';
 
 // Create a connection to the client
 const connection = createConnection(ProposedFeatures.all);
 
 // Wire the notification module with the LSP connection (before any notifications can fire)
 initNotifications(connection);
+
+// Expose the visual-composer domain logic (#426/#430) as bbj/composer/* requests so both the
+// VS Code and IntelliJ clients drive one implementation (#433).
+registerComposerRequests(connection);
 
 // Inject the shared services and language-specific services
 const { shared, BBj } = createBBjServices({ connection, ...NodeFileSystem });

--- a/bbj-vscode/test/composer-commands.test.ts
+++ b/bbj-vscode/test/composer-commands.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test, vi } from 'vitest';
+import { composerHandlers, registerComposerRequests } from '../src/language/composer-commands';
+
+// Thin pass-through handlers: these tests assert the request layer faithfully re-exposes the pure
+// composer API (the arithmetic itself is covered by msgbox-composer / addwindow-composer tests).
+const call = <M extends keyof typeof composerHandlers>(method: M, params?: unknown) =>
+    (composerHandlers[method] as (p: unknown) => unknown)(params);
+
+describe('composer LS command layer (#433)', () => {
+    test('catalogs returns both composers option sets', () => {
+        const c = call('bbj/composer/catalogs') as any;
+        expect(c.msgbox.buttonSets.length).toBeGreaterThan(0);
+        expect(c.msgbox.icons.length).toBeGreaterThan(0);
+        expect(c.addwindow.flags).toHaveLength(26);
+        expect(c.addwindow.eventBits).toHaveLength(19);
+    });
+
+    test('msgbox encode/decode round-trips a selection through expr', () => {
+        const { expr } = call('bbj/composer/msgbox/encode', { selection: { buttonSet: 4, icon: 32, flags: [65536] } }) as any;
+        expect(expr).toBe(4 + 32 + 65536);
+        const decoded = call('bbj/composer/msgbox/decode', { expr }) as any;
+        expect(decoded).toEqual({ buttonSet: 4, icon: 32, defaultButton: 0, flags: [65536] });
+    });
+
+    test('msgbox compose / describe / validateString pass through', () => {
+        expect((call('bbj/composer/msgbox/compose', { input: { message: '"Hi"', expr: 36 } }) as any).statement)
+            .toBe('MSGBOX("Hi", 36)');
+        expect((call('bbj/composer/msgbox/describe', { expr: 36 }) as any).text).toBe('Yes, No · Question icon');
+        expect((call('bbj/composer/msgbox/validateString', { text: 'Caption', required: true }) as any).ok).toBe(false);
+        expect((call('bbj/composer/msgbox/validateString', { text: '"Caption"' }) as any).ok).toBe(true);
+    });
+
+    test('msgbox parseLine finds the call (first, or the one at the cursor)', () => {
+        const first = call('bbj/composer/msgbox/parseLine', { line: 'x = MSGBOX("a", 36)' }) as any;
+        expect(first.call.exprValue).toBe(36);
+        const line = 'if c then MSGBOX("A", 16) else MSGBOX("B")';
+        const at = call('bbj/composer/msgbox/parseLine', { line, character: line.indexOf('"B"') }) as any;
+        expect(at.call.exprValue).toBeUndefined(); // the bare second call
+    });
+
+    test('addwindow encodeFlags -> mask + canonical hex, preserving unknown bits', () => {
+        const r = call('bbj/composer/addwindow/encodeFlags', { bits: [0x1, 0x2, 0x10000] }) as any;
+        expect(r.mask).toBe(0x00010003);
+        expect(r.hex).toBe('$00010003$');
+        // sign bit stays unsigned; a preserved (undocumented) bit is OR-ed back
+        const s = call('bbj/composer/addwindow/encodeFlags', { bits: [0x80000000], preserved: 0x00004000 }) as any;
+        expect(s.mask).toBe((0x80000000 | 0x00004000) >>> 0);
+        expect(s.hex).toBe('$80004000$');
+    });
+
+    test('addwindow decodeFlags returns bits + schematic + unknown bits', () => {
+        const r = call('bbj/composer/addwindow/decodeFlags', { mask: 0x01000002 | 0x00004000 }) as any;
+        expect(r.bits).toContain(0x00000002);      // Close box
+        expect(r.bits).toContain(0x01000000);      // No title bar
+        expect(r.unknownBits).toBe(0x00004000);    // reserved bit preserved
+        expect(r.schematic.titleBar).toBe(false);  // No title bar flag set
+        expect(r.schematic.closeBox).toBe(true);
+        expect(r.text).toContain('No title bar');
+    });
+
+    test('addwindow compose / schematic / parseHex / parseLine pass through', () => {
+        const statement = (call('bbj/composer/addwindow/compose', {
+            input: { receiver: 'w!', sysgui: 'g!', x: '0', y: '0', width: '9', height: '9', title: '"T"', flags: 0x2 },
+        }) as any).statement;
+        expect(statement).toBe('w! = g!.addWindow(0, 0, 9, 9, "T", $00000002$)');
+        expect((call('bbj/composer/addwindow/schematic', { mask: 0x01000000 }) as any).titleBar).toBe(false);
+        expect((call('bbj/composer/addwindow/parseHex', { token: '$00010003$' }) as any).value).toBe(0x00010003);
+        const parsed = call('bbj/composer/addwindow/parseLine', { line: 'w! = g!.addWindow("T", $00080002$)' }) as any;
+        expect(parsed.call.flagsValue).toBe(0x00080002);
+    });
+
+    test('registerComposerRequests wires every handler onto the connection', () => {
+        const onRequest = vi.fn();
+        registerComposerRequests({ onRequest } as any);
+        const methods = onRequest.mock.calls.map(c => c[0]);
+        expect(methods).toEqual(Object.keys(composerHandlers));
+        expect(methods).toContain('bbj/composer/catalogs');
+        expect(methods).toContain('bbj/composer/addwindow/compose');
+    });
+});


### PR DESCRIPTION
First step of #433 (IntelliJ parity) — the **shared substrate** both clients need. No IntelliJ code yet; this is the language-server foundation that the IntelliJ composer UI will consume.

## Why

The MSGBOX (#426) and addWindow (#430) composers keep their domain logic — option catalogs and the `state ↔ number/hex ↔ statement-text` conversions — in editor-agnostic modules (`msgbox-composer.ts`, `addwindow-composer.ts`, no `vscode` import, fully unit-tested). But those are compiled into the **VS Code extension** bundle, which the JVM-based IntelliJ plugin can't import. To reach parity without a second copy of the (correctness-sensitive, still-evolving) flag/hex logic, the **language server** should own and expose it.

## What's here

- **`src/language/composer-commands.ts`** — thin pass-through handlers re-exposing the pure API over `bbj/composer/*` custom LSP requests (the same mechanism as the existing `bbj/refreshJavaClasses`):
  - `bbj/composer/catalogs` — both composers' option catalogs (fetched once, client renders its own UI).
  - MSGBOX: `encode`, `decode`, `compose`, `describe`, `validateString`, `parseLine`.
  - addWindow: `encodeFlags`, `encodeEventMask`, `decodeFlags`, `decodeEventMask`, `compose`, `schematic`, `parseHex`, `parseLine`.
  - **No new flag/hex logic** — every handler delegates to the existing pure functions, so the LS and the VS Code UI remain a single source of truth.
- **`main.ts`** — `registerComposerRequests(connection)` wired at startup.
- Handlers are `export`ed so they unit-test directly without a live LSP connection.

## Impact / risk

- **VS Code behavior is unchanged** — the webviews still import the pure modules directly; this PR is purely additive.
- The LS bundle now carries the composer logic (esbuild follows the imports — verified in the built `out/language/main.cjs`).
- This layer becomes load-bearing once IntelliJ consumes it; a follow-up can optionally refactor the VS Code webviews to call these requests too, retiring the direct imports.

## Testing

- 8 new handler tests (`composer-commands.test.ts`); **48** composer tests pass across the three suites.
- `npm run build` (tsc + esbuild, both entrypoints) green · ESLint clean.

## Next

The IntelliJ action + JCEF/Swing composer that calls these requests and applies edits via LSP. That needs a running IntelliJ IDE to validate the UI, so it lands as a separate increment.

Part of #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)