### PR TITLE
IntelliJ visual composers (MSGBOX + addWindow): create + edit-in-place (#433)

### DIFF
--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjComposeAddWindowAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjComposeAddWindowAction.java
@@ -1,0 +1,78 @@
+package com.basis.bbj.intellij.actions;
+
+import com.basis.bbj.intellij.composer.AddWindowComposerDialog;
+import com.basis.bbj.intellij.composer.BbjComposerService;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Editor action: open the visual addWindow composer (#430/#433) and insert the composed
+ * {@code addWindow(...)} statement at the caret. The flag/hex arithmetic runs in the language
+ * server via {@code bbj/composer/*}.
+ */
+public final class BbjComposeAddWindowAction extends AnAction {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        if (project == null || editor == null) {
+            return;
+        }
+        BbjComposerService.server(project).thenAccept(server -> {
+            if (server == null) {
+                notifyNotReady(project);
+                return;
+            }
+            server.composerCatalogs().thenAccept(catalogs ->
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        if (catalogs == null || catalogs.addwindow == null) {
+                            notifyNotReady(project);
+                            return;
+                        }
+                        AddWindowComposerDialog dialog = new AddWindowComposerDialog(project, server, catalogs.addwindow);
+                        if (dialog.showAndGet()) {
+                            insertAtCaret(project, editor, dialog.getStatement());
+                        }
+                    }, ModalityState.defaultModalityState()));
+        });
+    }
+
+    private static void insertAtCaret(Project project, Editor editor, String text) {
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+        WriteCommandAction.runWriteCommandAction(project, "Compose addWindow", null, () -> {
+            int offset = editor.getCaretModel().getOffset();
+            editor.getDocument().insertString(offset, text);
+            editor.getCaretModel().moveToOffset(offset + text.length());
+        });
+    }
+
+    private static void notifyNotReady(Project project) {
+        ApplicationManager.getApplication().invokeLater(() ->
+                Messages.showInfoMessage(project,
+                        "The BBj language server is not ready yet. Open a BBj file and try again.",
+                        "Compose addWindow"),
+                ModalityState.defaultModalityState());
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        e.getPresentation().setEnabledAndVisible(e.getProject() != null && e.getData(CommonDataKeys.EDITOR) != null);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjComposeAddWindowAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjComposeAddWindowAction.java
@@ -1,23 +1,18 @@
 package com.basis.bbj.intellij.actions;
 
-import com.basis.bbj.intellij.composer.AddWindowComposerDialog;
-import com.basis.bbj.intellij.composer.BbjComposerService;
+import com.basis.bbj.intellij.composer.ComposerLauncher;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Editor action: open the visual addWindow composer (#430/#433) and insert the composed
- * {@code addWindow(...)} statement at the caret. The flag/hex arithmetic runs in the language
- * server via {@code bbj/composer/*}.
+ * Editor action: open the visual addWindow composer (#430/#433). Position-aware — if the caret is
+ * inside an existing {@code addWindow(...)} the dialog opens prefilled and rewrites its flag/
+ * event_mask hex in place; otherwise it composes a new statement and inserts it at the caret.
  */
 public final class BbjComposeAddWindowAction extends AnAction {
 
@@ -28,42 +23,7 @@ public final class BbjComposeAddWindowAction extends AnAction {
         if (project == null || editor == null) {
             return;
         }
-        BbjComposerService.server(project).thenAccept(server -> {
-            if (server == null) {
-                notifyNotReady(project);
-                return;
-            }
-            server.composerCatalogs().thenAccept(catalogs ->
-                    ApplicationManager.getApplication().invokeLater(() -> {
-                        if (catalogs == null || catalogs.addwindow == null) {
-                            notifyNotReady(project);
-                            return;
-                        }
-                        AddWindowComposerDialog dialog = new AddWindowComposerDialog(project, server, catalogs.addwindow);
-                        if (dialog.showAndGet()) {
-                            insertAtCaret(project, editor, dialog.getStatement());
-                        }
-                    }, ModalityState.defaultModalityState()));
-        });
-    }
-
-    private static void insertAtCaret(Project project, Editor editor, String text) {
-        if (text == null || text.isEmpty()) {
-            return;
-        }
-        WriteCommandAction.runWriteCommandAction(project, "Compose addWindow", null, () -> {
-            int offset = editor.getCaretModel().getOffset();
-            editor.getDocument().insertString(offset, text);
-            editor.getCaretModel().moveToOffset(offset + text.length());
-        });
-    }
-
-    private static void notifyNotReady(Project project) {
-        ApplicationManager.getApplication().invokeLater(() ->
-                Messages.showInfoMessage(project,
-                        "The BBj language server is not ready yet. Open a BBj file and try again.",
-                        "Compose addWindow"),
-                ModalityState.defaultModalityState());
+        ComposerLauncher.launch(project, editor, ComposerLauncher.Kind.ADDWINDOW);
     }
 
     @Override

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjComposeMsgboxAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjComposeMsgboxAction.java
@@ -1,0 +1,78 @@
+package com.basis.bbj.intellij.actions;
+
+import com.basis.bbj.intellij.composer.BbjComposerService;
+import com.basis.bbj.intellij.composer.MsgboxComposerDialog;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Editor action: open the visual MSGBOX composer (#426/#433) and insert the composed
+ * {@code MSGBOX(...)} statement at the caret. The encode/compose/validate logic runs in the
+ * language server via {@code bbj/composer/*}.
+ */
+public final class BbjComposeMsgboxAction extends AnAction {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        if (project == null || editor == null) {
+            return;
+        }
+        BbjComposerService.server(project).thenAccept(server -> {
+            if (server == null) {
+                notifyNotReady(project);
+                return;
+            }
+            server.composerCatalogs().thenAccept(catalogs ->
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        if (catalogs == null || catalogs.msgbox == null) {
+                            notifyNotReady(project);
+                            return;
+                        }
+                        MsgboxComposerDialog dialog = new MsgboxComposerDialog(project, server, catalogs.msgbox);
+                        if (dialog.showAndGet()) {
+                            insertAtCaret(project, editor, dialog.getStatement());
+                        }
+                    }, ModalityState.defaultModalityState()));
+        });
+    }
+
+    private static void insertAtCaret(Project project, Editor editor, String text) {
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+        WriteCommandAction.runWriteCommandAction(project, "Compose MSGBOX", null, () -> {
+            int offset = editor.getCaretModel().getOffset();
+            editor.getDocument().insertString(offset, text);
+            editor.getCaretModel().moveToOffset(offset + text.length());
+        });
+    }
+
+    private static void notifyNotReady(Project project) {
+        ApplicationManager.getApplication().invokeLater(() ->
+                Messages.showInfoMessage(project,
+                        "The BBj language server is not ready yet. Open a BBj file and try again.",
+                        "Compose MSGBOX"),
+                ModalityState.defaultModalityState());
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        e.getPresentation().setEnabledAndVisible(e.getProject() != null && e.getData(CommonDataKeys.EDITOR) != null);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjComposeMsgboxAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjComposeMsgboxAction.java
@@ -1,23 +1,18 @@
 package com.basis.bbj.intellij.actions;
 
-import com.basis.bbj.intellij.composer.BbjComposerService;
-import com.basis.bbj.intellij.composer.MsgboxComposerDialog;
+import com.basis.bbj.intellij.composer.ComposerLauncher;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Editor action: open the visual MSGBOX composer (#426/#433) and insert the composed
- * {@code MSGBOX(...)} statement at the caret. The encode/compose/validate logic runs in the
- * language server via {@code bbj/composer/*}.
+ * Editor action: open the visual MSGBOX composer (#426/#433). Position-aware — if the caret is
+ * inside an existing {@code MSGBOX(...)} the dialog opens prefilled and reconfigures it in place;
+ * otherwise it composes a new statement and inserts it at the caret.
  */
 public final class BbjComposeMsgboxAction extends AnAction {
 
@@ -28,42 +23,7 @@ public final class BbjComposeMsgboxAction extends AnAction {
         if (project == null || editor == null) {
             return;
         }
-        BbjComposerService.server(project).thenAccept(server -> {
-            if (server == null) {
-                notifyNotReady(project);
-                return;
-            }
-            server.composerCatalogs().thenAccept(catalogs ->
-                    ApplicationManager.getApplication().invokeLater(() -> {
-                        if (catalogs == null || catalogs.msgbox == null) {
-                            notifyNotReady(project);
-                            return;
-                        }
-                        MsgboxComposerDialog dialog = new MsgboxComposerDialog(project, server, catalogs.msgbox);
-                        if (dialog.showAndGet()) {
-                            insertAtCaret(project, editor, dialog.getStatement());
-                        }
-                    }, ModalityState.defaultModalityState()));
-        });
-    }
-
-    private static void insertAtCaret(Project project, Editor editor, String text) {
-        if (text == null || text.isEmpty()) {
-            return;
-        }
-        WriteCommandAction.runWriteCommandAction(project, "Compose MSGBOX", null, () -> {
-            int offset = editor.getCaretModel().getOffset();
-            editor.getDocument().insertString(offset, text);
-            editor.getCaretModel().moveToOffset(offset + text.length());
-        });
-    }
-
-    private static void notifyNotReady(Project project) {
-        ApplicationManager.getApplication().invokeLater(() ->
-                Messages.showInfoMessage(project,
-                        "The BBj language server is not ready yet. Open a BBj file and try again.",
-                        "Compose MSGBOX"),
-                ModalityState.defaultModalityState());
+        ComposerLauncher.launch(project, editor, ComposerLauncher.Kind.MSGBOX);
     }
 
     @Override

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/AddWindowComposerDialog.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/AddWindowComposerDialog.java
@@ -65,18 +65,42 @@ public final class AddWindowComposerDialog extends DialogWrapper {
     private final JBTextField statementField = new JBTextField();
     private final JBLabel flagsSummary = new JBLabel();
     private final JBLabel eventSummary = new JBLabel();
+    private JPanel geometryPanel;
+
+    private final boolean editMode;
+    private final ComposerModels.AddWindowInitial initial;
+    private final long preservedFlagBits;
+    private final long preservedEventBits;
 
     private volatile String statement = "";
+    private volatile String flagsHex = "";
+    private volatile String eventHex;
 
+    /** Create flow. */
     public AddWindowComposerDialog(@Nullable Project project, @NotNull BbjComposerServer server, @NotNull AddWindowCatalogs catalogs) {
+        this(project, server, catalogs, null, false, 0L, 0L);
+    }
+
+    /** Full constructor; pass a non-null {@code initial} for edit-in-place. */
+    public AddWindowComposerDialog(@Nullable Project project, @NotNull BbjComposerServer server, @NotNull AddWindowCatalogs catalogs,
+                                   @Nullable ComposerModels.AddWindowInitial initial, boolean editMode,
+                                   long preservedFlagBits, long preservedEventBits) {
         super(project);
         this.server = server;
         this.catalogs = catalogs;
-        setTitle("Compose addWindow");
-        setOKButtonText("Insert");
+        this.initial = initial;
+        this.editMode = editMode;
+        this.preservedFlagBits = preservedFlagBits;
+        this.preservedEventBits = preservedEventBits;
+        setTitle(editMode ? "Configure window flags" : "Compose addWindow");
+        setOKButtonText(editMode ? "Apply" : "Insert");
         init();
-        // Default to the BASIS doc example: Resizable + Close box + Keyboard navigation.
-        preselect(0x00000001L, 0x00000002L, 0x00010000L);
+        if (initial != null) {
+            prefill(initial);
+        } else {
+            // Create: default to the BASIS doc example (Resizable + Close box + Keyboard navigation).
+            preselect(0x00000001L, 0x00000002L, 0x00010000L);
+        }
         refresh();
     }
 
@@ -107,17 +131,18 @@ public final class AddWindowComposerDialog extends DialogWrapper {
         root.add(eventSummary);
         root.add(Box.createVerticalStrut(JBUI.scale(8)));
 
-        // Statement fields (create flow).
-        JPanel geo = new JPanel(new GridLayout(0, 4, JBUI.scale(6), JBUI.scale(4)));
-        geo.setBorder(BorderFactory.createTitledBorder("Statement"));
-        geo.add(labeled("Assign to", receiver));
-        geo.add(labeled("SysGui expr", sysgui));
-        geo.add(labeled("Title expr", title));
-        geo.add(labeled("x", x));
-        geo.add(labeled("y", y));
-        geo.add(labeled("width", width));
-        geo.add(labeled("height", height));
-        root.add(geo);
+        // Statement fields — create flow only; in edit mode we rewrite just the hex tokens in place.
+        geometryPanel = new JPanel(new GridLayout(0, 4, JBUI.scale(6), JBUI.scale(4)));
+        geometryPanel.setBorder(BorderFactory.createTitledBorder("Statement"));
+        geometryPanel.add(labeled("Assign to", receiver));
+        geometryPanel.add(labeled("SysGui expr", sysgui));
+        geometryPanel.add(labeled("Title expr", title));
+        geometryPanel.add(labeled("x", x));
+        geometryPanel.add(labeled("y", y));
+        geometryPanel.add(labeled("width", width));
+        geometryPanel.add(labeled("height", height));
+        geometryPanel.setVisible(!editMode);
+        root.add(geometryPanel);
 
         // Window flags, grouped.
         JPanel flags = new JPanel();
@@ -205,6 +230,9 @@ public final class AddWindowComposerDialog extends DialogWrapper {
         input.y = y.getText();
         input.width = width.getText();
         input.height = height.getText();
+        input.editMode = editMode;
+        input.preservedFlagBits = preservedFlagBits;
+        input.preservedEventBits = preservedEventBits;
 
         int mySeq = seq.incrementAndGet();
         server.addWindowPreview(new AddWindowPreviewParams(input)).thenAccept(preview ->
@@ -217,10 +245,30 @@ public final class AddWindowComposerDialog extends DialogWrapper {
 
     private void apply(AddWindowPreview p) {
         statement = p.statement;
+        flagsHex = p.flagsHex;
+        eventHex = p.eventHex;
         statementField.setText(p.statement);
         flagsSummary.setText("flags = " + p.flagsHex + "   ·   " + p.flagsSummary);
         eventSummary.setText("event_mask = " + (p.eventHex == null ? "(unset)" : p.eventHex) + "   ·   " + p.eventSummary);
         schematic.setRender(p.render);
+    }
+
+    /** Prefill flag/event selections and title from a decoded call (edit-in-place). */
+    private void prefill(ComposerModels.AddWindowInitial in) {
+        setSelected(flagChecks, in.flags);
+        setSelected(eventChecks, in.eventMask);
+        eventEnabled.setSelected(in.eventMaskEnabled);
+        updateEventEnabled();
+        if (in.title != null) {
+            title.setText(in.title); // kept for the preview even though the geometry panel is hidden
+        }
+    }
+
+    private static void setSelected(Map<Long, JBCheckBox> checks, List<Long> values) {
+        List<Long> on = values == null ? List.of() : values;
+        for (Map.Entry<Long, JBCheckBox> e : checks.entrySet()) {
+            e.getValue().setSelected(on.contains(e.getKey()));
+        }
     }
 
     private static JPanel labeled(String label, JComponent field) {
@@ -230,9 +278,23 @@ public final class AddWindowComposerDialog extends DialogWrapper {
         return panel;
     }
 
-    /** The composed statement to insert; valid after the dialog is accepted. */
+    /** The composed statement to insert (create flow); valid after the dialog is accepted. */
     public @NotNull String getStatement() {
         return statement;
+    }
+
+    /** The `$flags$` hex token (edit flow: replace the existing flags literal with this). */
+    public @NotNull String getFlagsHex() {
+        return flagsHex;
+    }
+
+    /** The `$event_mask$` hex token, or null when the event mask is unset. */
+    public @Nullable String getEventHex() {
+        return eventHex;
+    }
+
+    public boolean isEventEnabled() {
+        return eventEnabled.isSelected();
     }
 
     /** Small DocumentListener that runs one callback on any change. */

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/AddWindowComposerDialog.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/AddWindowComposerDialog.java
@@ -1,0 +1,244 @@
+package com.basis.bbj.intellij.composer;
+
+import com.basis.bbj.intellij.composer.ComposerModels.AddWindowCatalogs;
+import com.basis.bbj.intellij.composer.ComposerModels.AddWindowPreview;
+import com.basis.bbj.intellij.composer.ComposerModels.AddWindowPreviewInput;
+import com.basis.bbj.intellij.composer.ComposerModels.AddWindowPreviewParams;
+import com.basis.bbj.intellij.composer.ComposerModels.CatalogItem;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.components.JBCheckBox;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.util.ui.JBUI;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+/**
+ * Swing composer for {@code BBjSysGui::addWindow} flags + event_mask (#430/#433). Renders grouped
+ * flag checkboxes and an opt-in event-mask section; the language server computes the hex, the
+ * statement, and the schematic ({@code bbj/composer/addwindow/preview}) so no flag logic lives here.
+ * Create flow only for now — inserts a fresh {@code addWindow(...)} statement.
+ */
+public final class AddWindowComposerDialog extends DialogWrapper {
+    private final BbjComposerServer server;
+    private final AddWindowCatalogs catalogs;
+    private final AtomicInteger seq = new AtomicInteger();
+
+    private final Map<Long, JBCheckBox> flagChecks = new LinkedHashMap<>();
+    private final Map<Long, JBCheckBox> eventChecks = new LinkedHashMap<>();
+    private final JBCheckBox eventEnabled = new JBCheckBox("Configure event mask (default: unset)");
+    private JPanel eventPanel;
+
+    private final JBTextField receiver = new JBTextField("window!");
+    private final JBTextField sysgui = new JBTextField("sysgui!");
+    private final JBTextField title = new JBTextField("\"Window\"");
+    private final JBTextField x = new JBTextField("10");
+    private final JBTextField y = new JBTextField("10");
+    private final JBTextField width = new JBTextField("400");
+    private final JBTextField height = new JBTextField("300");
+
+    private final WindowSchematicPanel schematic = new WindowSchematicPanel();
+    private final JBTextField statementField = new JBTextField();
+    private final JBLabel flagsSummary = new JBLabel();
+    private final JBLabel eventSummary = new JBLabel();
+
+    private volatile String statement = "";
+
+    public AddWindowComposerDialog(@Nullable Project project, @NotNull BbjComposerServer server, @NotNull AddWindowCatalogs catalogs) {
+        super(project);
+        this.server = server;
+        this.catalogs = catalogs;
+        setTitle("Compose addWindow");
+        setOKButtonText("Insert");
+        init();
+        // Default to the BASIS doc example: Resizable + Close box + Keyboard navigation.
+        preselect(0x00000001L, 0x00000002L, 0x00010000L);
+        refresh();
+    }
+
+    private void preselect(long... bits) {
+        for (long bit : bits) {
+            JBCheckBox cb = flagChecks.get(bit);
+            if (cb != null) {
+                cb.setSelected(true);
+            }
+        }
+    }
+
+    @Override
+    protected @Nullable JComponent createCenterPanel() {
+        JPanel root = new JPanel();
+        root.setLayout(new BoxLayout(root, BoxLayout.Y_AXIS));
+
+        // Live schematic preview.
+        JPanel preview = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        preview.add(schematic);
+        root.add(preview);
+
+        statementField.setEditable(false);
+        root.add(labeled("Generated statement", statementField));
+        flagsSummary.setComponentStyle(com.intellij.util.ui.UIUtil.ComponentStyle.SMALL);
+        eventSummary.setComponentStyle(com.intellij.util.ui.UIUtil.ComponentStyle.SMALL);
+        root.add(flagsSummary);
+        root.add(eventSummary);
+        root.add(Box.createVerticalStrut(JBUI.scale(8)));
+
+        // Statement fields (create flow).
+        JPanel geo = new JPanel(new GridLayout(0, 4, JBUI.scale(6), JBUI.scale(4)));
+        geo.setBorder(BorderFactory.createTitledBorder("Statement"));
+        geo.add(labeled("Assign to", receiver));
+        geo.add(labeled("SysGui expr", sysgui));
+        geo.add(labeled("Title expr", title));
+        geo.add(labeled("x", x));
+        geo.add(labeled("y", y));
+        geo.add(labeled("width", width));
+        geo.add(labeled("height", height));
+        root.add(geo);
+
+        // Window flags, grouped.
+        JPanel flags = new JPanel();
+        flags.setLayout(new BoxLayout(flags, BoxLayout.Y_AXIS));
+        flags.setBorder(BorderFactory.createTitledBorder("Window flags"));
+        addGroupedChecks(flags, catalogs.flags, flagChecks);
+        root.add(flags);
+
+        // Event mask, opt-in.
+        JPanel eventSection = new JPanel(new BorderLayout());
+        eventSection.setBorder(BorderFactory.createTitledBorder("Event mask"));
+        eventEnabled.addActionListener(e -> { updateEventEnabled(); refresh(); });
+        eventSection.add(eventEnabled, BorderLayout.NORTH);
+        eventPanel = new JPanel();
+        eventPanel.setLayout(new BoxLayout(eventPanel, BoxLayout.Y_AXIS));
+        addGroupedChecks(eventPanel, catalogs.eventBits, eventChecks);
+        eventSection.add(eventPanel, BorderLayout.CENTER);
+        root.add(eventSection);
+        updateEventEnabled();
+
+        // Text fields trigger a refresh as the user types.
+        for (JBTextField f : new JBTextField[]{receiver, sysgui, title, x, y, width, height}) {
+            f.getDocument().addDocumentListener(new SimpleDocumentListener(this::refresh));
+        }
+
+        JBScrollPane scroll = new JBScrollPane(root);
+        scroll.setPreferredSize(new Dimension(JBUI.scale(560), JBUI.scale(680)));
+        scroll.setBorder(null);
+        return scroll;
+    }
+
+    private void updateEventEnabled() {
+        setEnabledRecursive(eventPanel, eventEnabled.isSelected());
+    }
+
+    private static void setEnabledRecursive(JComponent c, boolean enabled) {
+        c.setEnabled(enabled);
+        for (java.awt.Component child : c.getComponents()) {
+            if (child instanceof JComponent) {
+                setEnabledRecursive((JComponent) child, enabled);
+            }
+        }
+    }
+
+    /** Add checkboxes to `parent`, one titled sub-panel per catalog group (in catalog order). */
+    private void addGroupedChecks(JPanel parent, List<CatalogItem> items, Map<Long, JBCheckBox> into) {
+        String currentGroup = null;
+        JPanel groupPanel = null;
+        for (CatalogItem it : items) {
+            if (!Objects.equals(it.group, currentGroup)) {
+                currentGroup = it.group;
+                groupPanel = new JPanel(new GridLayout(0, 2, JBUI.scale(8), 0));
+                if (currentGroup != null) {
+                    groupPanel.setBorder(BorderFactory.createTitledBorder(currentGroup));
+                }
+                parent.add(groupPanel);
+            }
+            JBCheckBox cb = new JBCheckBox(it.label);
+            cb.addActionListener(e -> refresh());
+            into.put(it.value, cb);
+            groupPanel.add(cb);
+        }
+    }
+
+    private List<Long> selected(Map<Long, JBCheckBox> checks) {
+        List<Long> out = new ArrayList<>();
+        for (Map.Entry<Long, JBCheckBox> e : checks.entrySet()) {
+            if (e.getValue().isSelected()) {
+                out.add(e.getKey());
+            }
+        }
+        return out;
+    }
+
+    /** Build the current selection, ask the LS for a preview, and update the UI on the EDT. */
+    private void refresh() {
+        AddWindowPreviewInput input = new AddWindowPreviewInput();
+        input.flags = selected(flagChecks);
+        input.eventMaskEnabled = eventEnabled.isSelected();
+        input.eventMask = selected(eventChecks);
+        input.receiver = receiver.getText();
+        input.sysgui = sysgui.getText();
+        input.title = title.getText();
+        input.x = x.getText();
+        input.y = y.getText();
+        input.width = width.getText();
+        input.height = height.getText();
+
+        int mySeq = seq.incrementAndGet();
+        server.addWindowPreview(new AddWindowPreviewParams(input)).thenAccept(preview ->
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    if (mySeq == seq.get() && preview != null) {
+                        apply(preview);
+                    }
+                }, ModalityState.any()));
+    }
+
+    private void apply(AddWindowPreview p) {
+        statement = p.statement;
+        statementField.setText(p.statement);
+        flagsSummary.setText("flags = " + p.flagsHex + "   ·   " + p.flagsSummary);
+        eventSummary.setText("event_mask = " + (p.eventHex == null ? "(unset)" : p.eventHex) + "   ·   " + p.eventSummary);
+        schematic.setRender(p.render);
+    }
+
+    private static JPanel labeled(String label, JComponent field) {
+        JPanel panel = new JPanel(new BorderLayout(0, JBUI.scale(2)));
+        panel.add(new JBLabel(label), BorderLayout.NORTH);
+        panel.add(field, BorderLayout.CENTER);
+        return panel;
+    }
+
+    /** The composed statement to insert; valid after the dialog is accepted. */
+    public @NotNull String getStatement() {
+        return statement;
+    }
+
+    /** Small DocumentListener that runs one callback on any change. */
+    private record SimpleDocumentListener(Runnable onChange) implements DocumentListener {
+        @Override public void insertUpdate(DocumentEvent e) { onChange.run(); }
+        @Override public void removeUpdate(DocumentEvent e) { onChange.run(); }
+        @Override public void changedUpdate(DocumentEvent e) { onChange.run(); }
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/BbjComposerServer.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/BbjComposerServer.java
@@ -1,8 +1,11 @@
 package com.basis.bbj.intellij.composer;
 
+import com.basis.bbj.intellij.composer.ComposerModels.AddWindowDecodeResult;
 import com.basis.bbj.intellij.composer.ComposerModels.AddWindowPreview;
 import com.basis.bbj.intellij.composer.ComposerModels.AddWindowPreviewParams;
 import com.basis.bbj.intellij.composer.ComposerModels.ComposerCatalogs;
+import com.basis.bbj.intellij.composer.ComposerModels.DecodeCallParams;
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxDecodeResult;
 import com.basis.bbj.intellij.composer.ComposerModels.MsgboxPreview;
 import com.basis.bbj.intellij.composer.ComposerModels.MsgboxPreviewParams;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
@@ -29,4 +32,12 @@ public interface BbjComposerServer extends LanguageServer {
     /** Full addWindow preview (flags/event hex + statement + summaries + schematic) for one selection. */
     @JsonRequest("bbj/composer/addwindow/preview")
     CompletableFuture<AddWindowPreview> addWindowPreview(AddWindowPreviewParams params);
+
+    /** Decode the MSGBOX call at the caret into a prefill payload + the call span to replace. */
+    @JsonRequest("bbj/composer/msgbox/decodeCall")
+    CompletableFuture<MsgboxDecodeResult> msgboxDecodeCall(DecodeCallParams params);
+
+    /** Decode the addWindow call at the caret into a prefill payload + token ranges to rewrite. */
+    @JsonRequest("bbj/composer/addwindow/decodeCall")
+    CompletableFuture<AddWindowDecodeResult> addWindowDecodeCall(DecodeCallParams params);
 }

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/BbjComposerServer.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/BbjComposerServer.java
@@ -1,0 +1,32 @@
+package com.basis.bbj.intellij.composer;
+
+import com.basis.bbj.intellij.composer.ComposerModels.AddWindowPreview;
+import com.basis.bbj.intellij.composer.ComposerModels.AddWindowPreviewParams;
+import com.basis.bbj.intellij.composer.ComposerModels.ComposerCatalogs;
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxPreview;
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxPreviewParams;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4j.services.LanguageServer;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The BBj language server, extended with the custom {@code bbj/composer/*} requests (#433) so the
+ * visual composers can reuse the server's flag/hex arithmetic instead of re-implementing it in Java.
+ * Registered as the server proxy interface via {@code BbjLanguageServerFactory#getServerInterface()};
+ * LSP4IJ builds a dynamic proxy that dispatches these methods over LSP.
+ */
+public interface BbjComposerServer extends LanguageServer {
+
+    /** Static option catalogs for both composers — fetched once, then rendered client-side. */
+    @JsonRequest("bbj/composer/catalogs")
+    CompletableFuture<ComposerCatalogs> composerCatalogs();
+
+    /** Full MSGBOX preview (expr + statement + validation + render) for one selection. */
+    @JsonRequest("bbj/composer/msgbox/preview")
+    CompletableFuture<MsgboxPreview> msgboxPreview(MsgboxPreviewParams params);
+
+    /** Full addWindow preview (flags/event hex + statement + summaries + schematic) for one selection. */
+    @JsonRequest("bbj/composer/addwindow/preview")
+    CompletableFuture<AddWindowPreview> addWindowPreview(AddWindowPreviewParams params);
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/BbjComposerService.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/BbjComposerService.java
@@ -1,0 +1,30 @@
+package com.basis.bbj.intellij.composer;
+
+import com.intellij.openapi.project.Project;
+import com.redhat.devtools.lsp4ij.LanguageServerManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Resolves the running BBj language server as a {@link BbjComposerServer} proxy so the composer
+ * dialogs/actions can call the {@code bbj/composer/*} requests (#433). The server id matches the
+ * {@code <server id="bbjLanguageServer">} declaration in {@code plugin.xml}.
+ */
+public final class BbjComposerService {
+    private static final String SERVER_ID = "bbjLanguageServer";
+
+    private BbjComposerService() {}
+
+    /**
+     * The composer server proxy, or a future completing with {@code null} when the server is not
+     * running (e.g. no BBj file has been opened yet). Callers must handle the null case.
+     */
+    public static @NotNull CompletableFuture<BbjComposerServer> server(@NotNull Project project) {
+        // Ensure the server is (being) started, then resolve the proxy.
+        LanguageServerManager.getInstance(project).start(SERVER_ID);
+        return LanguageServerManager.getInstance(project)
+                .getLanguageServer(SERVER_ID)
+                .thenApply(item -> item == null ? null : (BbjComposerServer) item.getServer());
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ComposerLauncher.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ComposerLauncher.java
@@ -1,0 +1,183 @@
+package com.basis.bbj.intellij.composer;
+
+import com.basis.bbj.intellij.composer.ComposerModels.AddWindowCatalogs;
+import com.basis.bbj.intellij.composer.ComposerModels.AddWindowDecodeResult;
+import com.basis.bbj.intellij.composer.ComposerModels.AddWindowEdit;
+import com.basis.bbj.intellij.composer.ComposerModels.DecodeCallParams;
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxCatalogs;
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxDecodeResult;
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxEdit;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.TextRange;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Shared entry point for both composer UIs (#430/#433). Captures the caret context, asks the
+ * language server to decode the call the caret is inside (the {@code decodeCall} requests), and
+ * opens the dialog either prefilled for edit-in-place (replacing the call/tokens) or blank for
+ * create (inserting at the caret). Used by the editor-popup actions and the lightbulb intentions,
+ * so both are position-aware with identical behaviour.
+ */
+public final class ComposerLauncher {
+
+    public enum Kind { MSGBOX, ADDWINDOW }
+
+    private ComposerLauncher() {}
+
+    /**
+     * Cheap, synchronous heuristic for whether the caret sits on a line with the given call keyword
+     * (e.g. {@code "msgbox"}), at or after its start — used by the lightbulb intentions' isAvailable
+     * without an LSP round-trip. The precise decode happens on invoke.
+     */
+    public static boolean isCaretOnCall(@NotNull Editor editor, @NotNull String keyword) {
+        Document doc = editor.getDocument();
+        int caret = editor.getCaretModel().getOffset();
+        if (caret > doc.getTextLength()) {
+            return false;
+        }
+        int line = doc.getLineNumber(caret);
+        int lineStart = doc.getLineStartOffset(line);
+        String text = doc.getText(new TextRange(lineStart, doc.getLineEndOffset(line)))
+                .toLowerCase(java.util.Locale.ROOT);
+        int idx = text.indexOf(keyword);
+        return idx >= 0 && (caret - lineStart) >= idx;
+    }
+
+    public static void launch(@NotNull Project project, @NotNull Editor editor, @NotNull Kind kind) {
+        // Capture the caret's line/column on the EDT before going async.
+        Document doc = editor.getDocument();
+        int caret = editor.getCaretModel().getOffset();
+        int line = doc.getLineNumber(caret);
+        int lineStart = doc.getLineStartOffset(line);
+        String lineText = doc.getText(new TextRange(lineStart, doc.getLineEndOffset(line)));
+        int col = caret - lineStart;
+
+        BbjComposerService.server(project).thenAccept(server -> {
+            if (server == null) {
+                notifyNotReady(project, kind);
+                return;
+            }
+            server.composerCatalogs().thenAccept(catalogs -> {
+                if (catalogs == null) {
+                    notifyNotReady(project, kind);
+                    return;
+                }
+                if (kind == Kind.MSGBOX) {
+                    server.msgboxDecodeCall(new DecodeCallParams(lineText, col)).thenAccept(decoded ->
+                            onEdt(() -> openMsgbox(project, editor, server, catalogs.msgbox, decoded, line)));
+                } else {
+                    server.addWindowDecodeCall(new DecodeCallParams(lineText, col)).thenAccept(decoded ->
+                            onEdt(() -> openAddWindow(project, editor, server, catalogs.addwindow, decoded, line)));
+                }
+            });
+        });
+    }
+
+    private static void openMsgbox(Project project, Editor editor, BbjComposerServer server,
+                                   MsgboxCatalogs catalogs, MsgboxDecodeResult decoded, int line) {
+        if (catalogs == null) {
+            notifyNotReady(project, Kind.MSGBOX);
+            return;
+        }
+        boolean edit = decoded != null && decoded.found;
+        MsgboxComposerDialog dialog = edit
+                ? new MsgboxComposerDialog(project, server, catalogs, decoded.initial, true, decoded.trailingArgs)
+                : new MsgboxComposerDialog(project, server, catalogs, null, false, null);
+        if (!dialog.showAndGet()) {
+            return;
+        }
+        String text = dialog.getStatement();
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+        if (edit) {
+            MsgboxEdit ed = decoded.edit;
+            WriteCommandAction.runWriteCommandAction(project, "Configure MSGBOX", null, () -> {
+                int ls = editor.getDocument().getLineStartOffset(line);
+                editor.getDocument().replaceString(ls + ed.callStart, ls + ed.callEnd, text);
+            });
+        } else {
+            insertAtCaret(project, editor, text, "Compose MSGBOX");
+        }
+    }
+
+    private static void openAddWindow(Project project, Editor editor, BbjComposerServer server,
+                                      AddWindowCatalogs catalogs, AddWindowDecodeResult decoded, int line) {
+        if (catalogs == null) {
+            notifyNotReady(project, Kind.ADDWINDOW);
+            return;
+        }
+        boolean edit = decoded != null && decoded.found;
+        AddWindowComposerDialog dialog = edit
+                ? new AddWindowComposerDialog(project, server, catalogs, decoded.initial, true,
+                        decoded.edit.preservedFlagBits, decoded.edit.preservedEventBits)
+                : new AddWindowComposerDialog(project, server, catalogs);
+        if (!dialog.showAndGet()) {
+            return;
+        }
+        if (edit) {
+            applyAddWindowEdit(project, editor, line, decoded.edit, dialog);
+        } else {
+            insertAtCaret(project, editor, dialog.getStatement(), "Compose addWindow");
+        }
+    }
+
+    /** Rewrite the flags (and, if enabled, event_mask) hex tokens in place, right-to-left. */
+    private static void applyAddWindowEdit(Project project, Editor editor, int line, AddWindowEdit ed, AddWindowComposerDialog dialog) {
+        WriteCommandAction.runWriteCommandAction(project, "Configure window flags", null, () -> {
+            Document doc = editor.getDocument();
+            int ls = doc.getLineStartOffset(line);
+            List<Op> ops = new ArrayList<>();
+            if (ed.flagsRange != null) {
+                ops.add(new Op(ls + ed.flagsRange[0], ls + ed.flagsRange[1], dialog.getFlagsHex()));
+            } else if (ed.flagsInsertOffset != null) {
+                ops.add(new Op(ls + ed.flagsInsertOffset, ls + ed.flagsInsertOffset, ", " + dialog.getFlagsHex()));
+            }
+            if (dialog.isEventEnabled() && dialog.getEventHex() != null) {
+                if (ed.eventMaskRange != null) {
+                    ops.add(new Op(ls + ed.eventMaskRange[0], ls + ed.eventMaskRange[1], dialog.getEventHex()));
+                } else if (ed.eventMaskInsertOffset != null) {
+                    ops.add(new Op(ls + ed.eventMaskInsertOffset, ls + ed.eventMaskInsertOffset, ", " + dialog.getEventHex()));
+                }
+            }
+            // Apply from the highest offset down so earlier edits don't shift later ranges.
+            ops.sort(Comparator.comparingInt((Op o) -> o.start).reversed());
+            for (Op op : ops) {
+                doc.replaceString(op.start, op.end, op.text);
+            }
+        });
+    }
+
+    private static void insertAtCaret(Project project, Editor editor, String text, String command) {
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+        WriteCommandAction.runWriteCommandAction(project, command, null, () -> {
+            int offset = editor.getCaretModel().getOffset();
+            editor.getDocument().insertString(offset, text);
+            editor.getCaretModel().moveToOffset(offset + text.length());
+        });
+    }
+
+    private static void notifyNotReady(Project project, Kind kind) {
+        String title = kind == Kind.MSGBOX ? "Compose MSGBOX" : "Compose addWindow";
+        onEdt(() -> Messages.showInfoMessage(project,
+                "The BBj language server is not ready yet. Open a BBj file and try again.", title));
+    }
+
+    private static void onEdt(Runnable runnable) {
+        ApplicationManager.getApplication().invokeLater(runnable, ModalityState.defaultModalityState());
+    }
+
+    private record Op(int start, int end, String text) {}
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ComposerModels.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ComposerModels.java
@@ -53,6 +53,7 @@ public final class ComposerModels {
         public List<String> customButtons;
         public List<String> trailingArgs;
         public Boolean editMode;
+        public Boolean useConstants;
     }
 
     /** Param wrapper: the handler expects {@code { "input": ... }}. */

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ComposerModels.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ComposerModels.java
@@ -130,4 +130,51 @@ public final class ComposerModels {
         public String eventSummary;
         public WindowRender render;
     }
+
+    // ---- decodeCall (edit-in-place) --------------------------------------------------------------
+
+    /** Params for the {@code decodeCall} requests: a source line and the caret column within it. */
+    public static final class DecodeCallParams {
+        public String line;
+        public Integer character;
+        public DecodeCallParams(String line, int character) { this.line = line; this.character = character; }
+    }
+
+    /** The MSGBOX call span (line-relative) to replace when reconfiguring in place. */
+    public static final class MsgboxEdit {
+        public int callStart;
+        public int callEnd;
+    }
+
+    /** Result of {@code bbj/composer/msgbox/decodeCall}; {@code found=false} when none at the caret. */
+    public static final class MsgboxDecodeResult {
+        public boolean found;
+        public MsgboxEdit edit;
+        public List<String> trailingArgs;
+        public MsgboxPreviewInput initial;
+    }
+
+    /** addWindow token ranges / insert offsets (line-relative) to rewrite in place. */
+    public static final class AddWindowEdit {
+        public int[] flagsRange;
+        public Integer flagsInsertOffset;
+        public int[] eventMaskRange;
+        public Integer eventMaskInsertOffset;
+        public long preservedFlagBits;
+        public long preservedEventBits;
+    }
+
+    public static final class AddWindowInitial {
+        public List<Long> flags;
+        public boolean eventMaskEnabled;
+        public List<Long> eventMask;
+        public String title;
+    }
+
+    /** Result of {@code bbj/composer/addwindow/decodeCall}; {@code found=false} when none at the caret. */
+    public static final class AddWindowDecodeResult {
+        public boolean found;
+        public AddWindowEdit edit;
+        public AddWindowInitial initial;
+    }
 }

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ComposerModels.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ComposerModels.java
@@ -1,0 +1,133 @@
+package com.basis.bbj.intellij.composer;
+
+import java.util.List;
+
+/**
+ * Gson-serializable data objects mirroring the language server's {@code bbj/composer/*} request
+ * params and results (see {@code bbj-vscode/src/language/composer-commands.ts}). The BBj-side
+ * TypeScript is the single source of truth for the flag/hex arithmetic (#433); these classes only
+ * carry the JSON across LSP4IJ. Field names must match the JSON keys exactly.
+ *
+ * Note: flag/event-mask bit values can set the 32-bit sign bit ({@code $80000000$} = 2147483648),
+ * which overflows a Java {@code int}, so every raw bit value is a {@code long}.
+ */
+public final class ComposerModels {
+    private ComposerModels() {}
+
+    /** One selectable option: a bit/number value, a label, and (addWindow only) a UI group. */
+    public static final class CatalogItem {
+        public long value;
+        public String label;
+        public String group;
+        public String detail;
+    }
+
+    public static final class MsgboxCatalogs {
+        public List<CatalogItem> buttonSets;
+        public List<CatalogItem> icons;
+        public List<CatalogItem> defaultButtons;
+        public List<CatalogItem> flags;
+    }
+
+    public static final class AddWindowCatalogs {
+        public List<CatalogItem> flags;
+        public List<CatalogItem> eventBits;
+    }
+
+    /** Result of {@code bbj/composer/catalogs}. */
+    public static final class ComposerCatalogs {
+        public MsgboxCatalogs msgbox;
+        public AddWindowCatalogs addwindow;
+    }
+
+    // ---- MSGBOX ----------------------------------------------------------------------------------
+
+    public static final class MsgboxPreviewInput {
+        public String message = "";
+        public String title = "";
+        public String assignTo;
+        public int buttonSet;
+        public int icon;
+        public int defaultButton;
+        public List<Long> flags;
+        public List<String> customButtons;
+        public List<String> trailingArgs;
+        public Boolean editMode;
+    }
+
+    /** Param wrapper: the handler expects {@code { "input": ... }}. */
+    public static final class MsgboxPreviewParams {
+        public MsgboxPreviewInput input;
+        public MsgboxPreviewParams(MsgboxPreviewInput input) { this.input = input; }
+    }
+
+    public static final class MsgboxRender {
+        public String title;
+        public String message;
+        public int icon;
+        public List<String> buttons;
+        public int defaultIndex;
+    }
+
+    public static final class MsgboxPreview {
+        public int expr;
+        public String statement;
+        public String summary;
+        public String messageError;
+        public String titleError;
+        public String customError;
+        public boolean valid;
+        public MsgboxRender render;
+    }
+
+    // ---- addWindow -------------------------------------------------------------------------------
+
+    public static final class AddWindowPreviewInput {
+        public List<Long> flags;
+        public boolean eventMaskEnabled;
+        public List<Long> eventMask;
+        public String receiver;
+        public String sysgui = "sysgui!";
+        public String x = "10";
+        public String y = "10";
+        public String width = "400";
+        public String height = "300";
+        public String title = "\"Window\"";
+        public Boolean editMode;
+        public Long preservedFlagBits;
+        public Long preservedEventBits;
+    }
+
+    public static final class AddWindowPreviewParams {
+        public AddWindowPreviewInput input;
+        public AddWindowPreviewParams(AddWindowPreviewInput input) { this.input = input; }
+    }
+
+    public static final class WindowRender {
+        public boolean titleBar;
+        public boolean closeBox;
+        public boolean minMax;
+        public boolean menuBar;
+        public boolean hScroll;
+        public boolean vScroll;
+        public boolean border;
+        public boolean resizable;
+        public boolean disabled;
+        public boolean invisible;
+        public boolean minimized;
+        public boolean maximized;
+        public List<String> badges;
+        public String title;
+    }
+
+    public static final class AddWindowPreview {
+        public long flags;
+        public Long eventMask;
+        public String flagsHex;
+        public String eventHex;
+        public String statement;
+        public String flagsSummary;
+        public String eventSummary;
+        public WindowRender render;
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ConfigureAddWindowIntention.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ConfigureAddWindowIntention.java
@@ -1,0 +1,50 @@
+package com.basis.bbj.intellij.composer;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Lightbulb (Alt+Enter) intention offered when the caret is on a {@code addWindow(...)} call: opens
+ * the visual composer prefilled from the current call and rewrites its flag/event_mask hex in place
+ * (#430/#433).
+ */
+public final class ConfigureAddWindowIntention implements IntentionAction {
+
+    @Override
+    public @NotNull String getText() {
+        return "Configure window flags…";
+    }
+
+    @Override
+    public @NotNull String getFamilyName() {
+        return "BBj visual composer";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, @Nullable Editor editor, @Nullable PsiFile file) {
+        return editor != null && ComposerLauncher.isCaretOnCall(editor, "addwindow");
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, @Nullable Editor editor, @Nullable PsiFile file) throws IncorrectOperationException {
+        if (editor != null) {
+            ComposerLauncher.launch(project, editor, ComposerLauncher.Kind.ADDWINDOW);
+        }
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+        return false;
+    }
+
+    @Override
+    public @NotNull IntentionPreviewInfo generatePreview(@NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file) {
+        return IntentionPreviewInfo.EMPTY;
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ConfigureMsgboxIntention.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/ConfigureMsgboxIntention.java
@@ -1,0 +1,49 @@
+package com.basis.bbj.intellij.composer;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Lightbulb (Alt+Enter) intention offered when the caret is on a {@code MSGBOX(...)} call: opens the
+ * visual composer prefilled from the current call and reconfigures it in place (#426/#433).
+ */
+public final class ConfigureMsgboxIntention implements IntentionAction {
+
+    @Override
+    public @NotNull String getText() {
+        return "Configure MSGBOX options…";
+    }
+
+    @Override
+    public @NotNull String getFamilyName() {
+        return "BBj visual composer";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, @Nullable Editor editor, @Nullable PsiFile file) {
+        return editor != null && ComposerLauncher.isCaretOnCall(editor, "msgbox");
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, @Nullable Editor editor, @Nullable PsiFile file) throws IncorrectOperationException {
+        if (editor != null) {
+            ComposerLauncher.launch(project, editor, ComposerLauncher.Kind.MSGBOX);
+        }
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+        return false; // opens a modal dialog, then applies its own write command
+    }
+
+    @Override
+    public @NotNull IntentionPreviewInfo generatePreview(@NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file) {
+        return IntentionPreviewInfo.EMPTY; // interactive dialog — no inline preview
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/MsgboxComposerDialog.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/MsgboxComposerDialog.java
@@ -1,0 +1,220 @@
+package com.basis.bbj.intellij.composer;
+
+import com.basis.bbj.intellij.composer.ComposerModels.CatalogItem;
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxCatalogs;
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxPreview;
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxPreviewInput;
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxPreviewParams;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.SimpleListCellRenderer;
+import com.intellij.ui.components.JBCheckBox;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.GridLayout;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Swing composer for {@code MSGBOX()} (#426/#433): pick icon / button set / default button / flags
+ * and message/title, and the language server encodes the numeric {@code expr}, composes the
+ * statement, and validates the string fields ({@code bbj/composer/msgbox/preview}). Create flow —
+ * inserts a fresh {@code MSGBOX(...)} statement.
+ */
+public final class MsgboxComposerDialog extends DialogWrapper {
+    private static final int CUSTOM_BUTTON_SET = 7;
+
+    private final BbjComposerServer server;
+    private final MsgboxCatalogs catalogs;
+    private final AtomicInteger seq = new AtomicInteger();
+
+    private final JBTextField message = new JBTextField("\"Message\"");
+    private final JBTextField titleField = new JBTextField();
+    private final JBTextField assignTo = new JBTextField("ret!");
+    private final ComboBox<CatalogItem> icon = new ComboBox<>();
+    private final ComboBox<CatalogItem> buttonSet = new ComboBox<>();
+    private final ComboBox<CatalogItem> defaultButton = new ComboBox<>();
+    private final Map<Long, JBCheckBox> flagChecks = new LinkedHashMap<>();
+    private final JBTextField[] customButtons = { new JBTextField(), new JBTextField(), new JBTextField() };
+    private JPanel customPanel;
+
+    private final JBTextField statementField = new JBTextField();
+    private final JBLabel summary = new JBLabel();
+    private final JBLabel messageError = errorLabel();
+    private final JBLabel titleError = errorLabel();
+    private final JBLabel customError = errorLabel();
+
+    private volatile String statement = "";
+
+    public MsgboxComposerDialog(@Nullable Project project, @NotNull BbjComposerServer server, @NotNull MsgboxCatalogs catalogs) {
+        super(project);
+        this.server = server;
+        this.catalogs = catalogs;
+        setTitle("Compose MSGBOX");
+        setOKButtonText("Insert");
+        init();
+        refresh();
+    }
+
+    @Override
+    protected @Nullable JComponent createCenterPanel() {
+        JPanel root = new JPanel();
+        root.setLayout(new BoxLayout(root, BoxLayout.Y_AXIS));
+
+        statementField.setEditable(false);
+        root.add(labeled("Generated statement", statementField));
+        summary.setComponentStyle(UIUtil.ComponentStyle.SMALL);
+        root.add(summary);
+        root.add(Box.createVerticalStrut(JBUI.scale(8)));
+
+        root.add(labeled("Message expression", message));
+        root.add(messageError);
+        root.add(labeled("Title expression (optional)", titleField));
+        root.add(titleError);
+        root.add(labeled("Assign result to (optional)", assignTo));
+
+        fillCombo(icon, catalogs.icons);
+        fillCombo(buttonSet, catalogs.buttonSets);
+        fillCombo(defaultButton, catalogs.defaultButtons);
+        JPanel combos = new JPanel(new GridLayout(0, 3, JBUI.scale(6), JBUI.scale(4)));
+        combos.add(labeled("Icon", icon));
+        combos.add(labeled("Buttons", buttonSet));
+        combos.add(labeled("Default button", defaultButton));
+        root.add(combos);
+
+        // Custom button labels — only meaningful for the "Custom" button set.
+        customPanel = new JPanel();
+        customPanel.setLayout(new BoxLayout(customPanel, BoxLayout.Y_AXIS));
+        customPanel.setBorder(BorderFactory.createTitledBorder("Custom button labels"));
+        for (JBTextField cb : customButtons) {
+            customPanel.add(cb);
+            cb.getDocument().addDocumentListener(new SimpleDocumentListener(this::refresh));
+        }
+        customPanel.add(customError);
+        root.add(customPanel);
+
+        JPanel flags = new JPanel();
+        flags.setLayout(new BoxLayout(flags, BoxLayout.Y_AXIS));
+        flags.setBorder(BorderFactory.createTitledBorder("Extra options"));
+        for (CatalogItem it : catalogs.flags) {
+            JBCheckBox cb = new JBCheckBox(it.label);
+            cb.addActionListener(e -> refresh());
+            flagChecks.put(it.value, cb);
+            flags.add(cb);
+        }
+        root.add(flags);
+
+        buttonSet.addActionListener(e -> { updateCustomVisibility(); refresh(); });
+        icon.addActionListener(e -> refresh());
+        defaultButton.addActionListener(e -> refresh());
+        message.getDocument().addDocumentListener(new SimpleDocumentListener(this::refresh));
+        titleField.getDocument().addDocumentListener(new SimpleDocumentListener(this::refresh));
+        assignTo.getDocument().addDocumentListener(new SimpleDocumentListener(this::refresh));
+        updateCustomVisibility();
+        return root;
+    }
+
+    private void updateCustomVisibility() {
+        customPanel.setVisible(value(buttonSet) == CUSTOM_BUTTON_SET);
+    }
+
+    private void refresh() {
+        MsgboxPreviewInput input = new MsgboxPreviewInput();
+        input.message = message.getText();
+        input.title = titleField.getText();
+        input.assignTo = assignTo.getText();
+        input.buttonSet = value(buttonSet);
+        input.icon = value(icon);
+        input.defaultButton = value(defaultButton);
+        input.flags = selectedFlags();
+        List<String> custom = new ArrayList<>();
+        for (JBTextField cb : customButtons) {
+            custom.add(cb.getText());
+        }
+        input.customButtons = custom;
+
+        int mySeq = seq.incrementAndGet();
+        server.msgboxPreview(new MsgboxPreviewParams(input)).thenAccept(preview ->
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    if (mySeq == seq.get() && preview != null) {
+                        apply(preview);
+                    }
+                }, ModalityState.any()));
+    }
+
+    private void apply(MsgboxPreview p) {
+        statement = p.statement;
+        statementField.setText(p.statement);
+        summary.setText("expr = " + p.expr + "   ·   " + p.summary);
+        messageError.setText(p.messageError == null ? " " : p.messageError);
+        titleError.setText(p.titleError == null ? " " : p.titleError);
+        customError.setText(p.customError == null ? " " : p.customError);
+        setOKActionEnabled(p.valid);
+    }
+
+    private List<Long> selectedFlags() {
+        List<Long> out = new ArrayList<>();
+        for (Map.Entry<Long, JBCheckBox> e : flagChecks.entrySet()) {
+            if (e.getValue().isSelected()) {
+                out.add(e.getKey());
+            }
+        }
+        return out;
+    }
+
+    private static int value(ComboBox<CatalogItem> combo) {
+        CatalogItem item = (CatalogItem) combo.getSelectedItem();
+        return item == null ? 0 : (int) item.value;
+    }
+
+    private static void fillCombo(ComboBox<CatalogItem> combo, List<CatalogItem> items) {
+        for (CatalogItem it : items) {
+            combo.addItem(it);
+        }
+        combo.setRenderer(SimpleListCellRenderer.create("", it -> it.label + "  (" + it.value + ")"));
+    }
+
+    private static JBLabel errorLabel() {
+        JBLabel label = new JBLabel(" ");
+        label.setComponentStyle(UIUtil.ComponentStyle.SMALL);
+        label.setForeground(new Color(0xC0392B));
+        return label;
+    }
+
+    private static JPanel labeled(String label, JComponent field) {
+        JPanel panel = new JPanel(new BorderLayout(0, JBUI.scale(2)));
+        panel.add(new JBLabel(label), BorderLayout.NORTH);
+        panel.add(field, BorderLayout.CENTER);
+        return panel;
+    }
+
+    public @NotNull String getStatement() {
+        return statement;
+    }
+
+    private record SimpleDocumentListener(Runnable onChange) implements DocumentListener {
+        @Override public void insertUpdate(DocumentEvent e) { onChange.run(); }
+        @Override public void removeUpdate(DocumentEvent e) { onChange.run(); }
+        @Override public void changedUpdate(DocumentEvent e) { onChange.run(); }
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/MsgboxComposerDialog.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/MsgboxComposerDialog.java
@@ -28,6 +28,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.FlowLayout;
 import java.awt.GridLayout;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -62,6 +63,7 @@ public final class MsgboxComposerDialog extends DialogWrapper {
     private final JBTextField[] customButtons = { new JBTextField(), new JBTextField(), new JBTextField() };
     private JPanel customPanel;
 
+    private final MsgboxSchematicPanel schematic = new MsgboxSchematicPanel();
     private final JBTextField statementField = new JBTextField();
     private final JBLabel summary = new JBLabel();
     private final JBLabel messageError = errorLabel();
@@ -91,6 +93,10 @@ public final class MsgboxComposerDialog extends DialogWrapper {
     protected @Nullable JComponent createCenterPanel() {
         JPanel root = new JPanel();
         root.setLayout(new BoxLayout(root, BoxLayout.Y_AXIS));
+
+        JPanel preview = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        preview.add(schematic);
+        root.add(preview);
 
         statementField.setEditable(false);
         root.add(labeled("Generated statement", statementField));
@@ -211,6 +217,7 @@ public final class MsgboxComposerDialog extends DialogWrapper {
         messageError.setText(p.messageError == null ? " " : p.messageError);
         titleError.setText(p.titleError == null ? " " : p.titleError);
         customError.setText(p.customError == null ? " " : p.customError);
+        schematic.setRender(p.render);
         setOKActionEnabled(p.valid);
     }
 

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/MsgboxComposerDialog.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/MsgboxComposerDialog.java
@@ -46,7 +46,11 @@ public final class MsgboxComposerDialog extends DialogWrapper {
 
     private final BbjComposerServer server;
     private final MsgboxCatalogs catalogs;
+    private final boolean editMode;
+    private final ComposerModels.MsgboxPreviewInput initial;
+    private final List<String> trailingArgs;
     private final AtomicInteger seq = new AtomicInteger();
+    private JPanel assignToRow;
 
     private final JBTextField message = new JBTextField("\"Message\"");
     private final JBTextField titleField = new JBTextField();
@@ -66,13 +70,20 @@ public final class MsgboxComposerDialog extends DialogWrapper {
 
     private volatile String statement = "";
 
-    public MsgboxComposerDialog(@Nullable Project project, @NotNull BbjComposerServer server, @NotNull MsgboxCatalogs catalogs) {
+    public MsgboxComposerDialog(@Nullable Project project, @NotNull BbjComposerServer server, @NotNull MsgboxCatalogs catalogs,
+                               @Nullable ComposerModels.MsgboxPreviewInput initial, boolean editMode, @Nullable List<String> trailingArgs) {
         super(project);
         this.server = server;
         this.catalogs = catalogs;
-        setTitle("Compose MSGBOX");
-        setOKButtonText("Insert");
+        this.initial = initial;
+        this.editMode = editMode;
+        this.trailingArgs = trailingArgs;
+        setTitle(editMode ? "Configure MSGBOX" : "Compose MSGBOX");
+        setOKButtonText(editMode ? "Apply" : "Insert");
         init();
+        if (initial != null) {
+            prefill(initial);
+        }
         refresh();
     }
 
@@ -91,7 +102,9 @@ public final class MsgboxComposerDialog extends DialogWrapper {
         root.add(messageError);
         root.add(labeled("Title expression (optional)", titleField));
         root.add(titleError);
-        root.add(labeled("Assign result to (optional)", assignTo));
+        assignToRow = labeled("Assign result to (optional)", assignTo);
+        assignToRow.setVisible(!editMode); // in edit mode the assignment lives outside the replaced call span
+        root.add(assignToRow);
 
         fillCombo(icon, catalogs.icons);
         fillCombo(buttonSet, catalogs.buttonSets);
@@ -138,6 +151,33 @@ public final class MsgboxComposerDialog extends DialogWrapper {
         customPanel.setVisible(value(buttonSet) == CUSTOM_BUTTON_SET);
     }
 
+    /** Prefill the controls from a decoded call (edit-in-place). */
+    private void prefill(ComposerModels.MsgboxPreviewInput in) {
+        message.setText(in.message == null ? "" : in.message);
+        titleField.setText(in.title == null ? "" : in.title);
+        selectByValue(icon, in.icon);
+        selectByValue(buttonSet, in.buttonSet);
+        selectByValue(defaultButton, in.defaultButton);
+        List<Long> flags = in.flags == null ? List.of() : in.flags;
+        for (Map.Entry<Long, JBCheckBox> e : flagChecks.entrySet()) {
+            e.getValue().setSelected(flags.contains(e.getKey()));
+        }
+        List<String> custom = in.customButtons == null ? List.of() : in.customButtons;
+        for (int i = 0; i < customButtons.length; i++) {
+            customButtons[i].setText(i < custom.size() ? custom.get(i) : "");
+        }
+        updateCustomVisibility();
+    }
+
+    private static void selectByValue(ComboBox<CatalogItem> combo, long value) {
+        for (int i = 0; i < combo.getItemCount(); i++) {
+            if (combo.getItemAt(i).value == value) {
+                combo.setSelectedIndex(i);
+                return;
+            }
+        }
+    }
+
     private void refresh() {
         MsgboxPreviewInput input = new MsgboxPreviewInput();
         input.message = message.getText();
@@ -152,6 +192,8 @@ public final class MsgboxComposerDialog extends DialogWrapper {
             custom.add(cb.getText());
         }
         input.customButtons = custom;
+        input.editMode = editMode;
+        input.trailingArgs = trailingArgs;
 
         int mySeq = seq.incrementAndGet();
         server.msgboxPreview(new MsgboxPreviewParams(input)).thenAccept(preview ->

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/MsgboxComposerDialog.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/MsgboxComposerDialog.java
@@ -62,6 +62,7 @@ public final class MsgboxComposerDialog extends DialogWrapper {
     private final Map<Long, JBCheckBox> flagChecks = new LinkedHashMap<>();
     private final JBTextField[] customButtons = { new JBTextField(), new JBTextField(), new JBTextField() };
     private JPanel customPanel;
+    private final JBCheckBox useConstants = new JBCheckBox("Use named constants (BBjMsgBox.*) instead of a numeric code");
 
     private final MsgboxSchematicPanel schematic = new MsgboxSchematicPanel();
     private final JBTextField statementField = new JBTextField();
@@ -142,10 +143,12 @@ public final class MsgboxComposerDialog extends DialogWrapper {
             flags.add(cb);
         }
         root.add(flags);
+        root.add(useConstants);
 
         buttonSet.addActionListener(e -> { updateCustomVisibility(); refresh(); });
         icon.addActionListener(e -> refresh());
         defaultButton.addActionListener(e -> refresh());
+        useConstants.addActionListener(e -> refresh());
         message.getDocument().addDocumentListener(new SimpleDocumentListener(this::refresh));
         titleField.getDocument().addDocumentListener(new SimpleDocumentListener(this::refresh));
         assignTo.getDocument().addDocumentListener(new SimpleDocumentListener(this::refresh));
@@ -200,6 +203,7 @@ public final class MsgboxComposerDialog extends DialogWrapper {
         input.customButtons = custom;
         input.editMode = editMode;
         input.trailingArgs = trailingArgs;
+        input.useConstants = useConstants.isSelected();
 
         int mySeq = seq.incrementAndGet();
         server.msgboxPreview(new MsgboxPreviewParams(input)).thenAccept(preview ->

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/MsgboxSchematicPanel.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/MsgboxSchematicPanel.java
@@ -1,0 +1,180 @@
+package com.basis.bbj.intellij.composer;
+
+import com.basis.bbj.intellij.composer.ComposerModels.MsgboxRender;
+import com.intellij.ui.JBColor;
+import com.intellij.util.ui.JBUI;
+
+import javax.swing.JPanel;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Custom-painted schematic of the MSGBOX dialog a selection produces — the IntelliJ counterpart of
+ * the VS Code webview's HTML mock. Driven by the {@link MsgboxRender} descriptor computed by the
+ * language server (#426/#433): title bar, icon, message, and the button row with the default button
+ * highlighted. No MSGBOX logic lives here.
+ */
+public final class MsgboxSchematicPanel extends JPanel {
+    private MsgboxRender render;
+
+    public MsgboxSchematicPanel() {
+        setPreferredSize(new Dimension(JBUI.scale(320), JBUI.scale(150)));
+        setOpaque(false);
+    }
+
+    public void setRender(MsgboxRender render) {
+        this.render = render;
+        repaint();
+    }
+
+    @Override
+    protected void paintComponent(Graphics g0) {
+        super.paintComponent(g0);
+        if (render == null) {
+            return;
+        }
+        Graphics2D g = (Graphics2D) g0.create();
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+        int pad = JBUI.scale(10);
+        int x = pad, y = pad, w = getWidth() - 2 * pad, h = getHeight() - 2 * pad;
+        int arc = JBUI.scale(8);
+
+        Color frame = JBColor.namedColor("Component.borderColor", JBColor.GRAY);
+        Color titleBg = JBColor.namedColor("TitlePane.background", new JBColor(new Color(0xE3E3E3), new Color(0x3C3F41)));
+        Color bodyBg = JBColor.namedColor("EditorPane.background", JBColor.background());
+        Color fg = JBColor.foreground();
+
+        g.setColor(bodyBg);
+        g.fillRoundRect(x, y, w, h, arc, arc);
+        g.setColor(frame);
+        g.drawRoundRect(x, y, w, h, arc, arc);
+
+        // Title bar
+        int titleH = JBUI.scale(22);
+        g.setColor(titleBg);
+        g.fillRoundRect(x + 1, y + 1, w - 2, titleH, arc, arc);
+        g.fillRect(x + 1, y + titleH - JBUI.scale(6), w - 2, JBUI.scale(6));
+        g.setColor(fg);
+        String title = render.title == null || render.title.isEmpty() ? "(no title)" : render.title;
+        g.drawString(clip(g, title, w - JBUI.scale(20)), x + JBUI.scale(8), y + JBUI.scale(15));
+
+        // Body: icon + message
+        int bodyTop = y + titleH + JBUI.scale(10);
+        int textLeft = x + JBUI.scale(12);
+        if (render.icon != 0) {
+            drawIcon(g, render.icon, x + JBUI.scale(12), bodyTop, JBUI.scale(24));
+            textLeft = x + JBUI.scale(44);
+        }
+        g.setColor(fg);
+        int buttonsTop = y + h - JBUI.scale(36);
+        String message = render.message == null ? "" : render.message;
+        int textRight = x + w - JBUI.scale(12);
+        int ty = bodyTop + JBUI.scale(12);
+        for (String lineText : wrap(g.getFontMetrics(), message, textRight - textLeft)) {
+            if (ty > buttonsTop - JBUI.scale(2)) {
+                break;
+            }
+            g.drawString(lineText, textLeft, ty);
+            ty += g.getFontMetrics().getHeight();
+        }
+
+        // Button row (right-aligned), default button highlighted
+        drawButtons(g, x, w, buttonsTop, frame, fg);
+        g.dispose();
+    }
+
+    private void drawButtons(Graphics2D g, int x, int w, int top, Color frame, Color fg) {
+        List<String> buttons = render.buttons == null ? List.of() : render.buttons;
+        if (buttons.isEmpty()) {
+            return;
+        }
+        FontMetrics fm = g.getFontMetrics();
+        int gap = JBUI.scale(6), padX = JBUI.scale(10), bh = JBUI.scale(22), arc = JBUI.scale(4);
+        int[] widths = new int[buttons.size()];
+        int total = 0;
+        for (int i = 0; i < buttons.size(); i++) {
+            widths[i] = Math.max(JBUI.scale(48), fm.stringWidth(buttons.get(i)) + 2 * padX);
+            total += widths[i] + (i > 0 ? gap : 0);
+        }
+        Color accent = JBColor.namedColor("Button.default.startBackground", new JBColor(new Color(0x3574F0), new Color(0x3574F0)));
+        int bx = x + w - JBUI.scale(12) - total;
+        for (int i = 0; i < buttons.size(); i++) {
+            boolean isDefault = i == render.defaultIndex;
+            g.setColor(isDefault ? accent : frame);
+            if (isDefault) {
+                g.fillRoundRect(bx, top, widths[i], bh, arc, arc);
+            } else {
+                g.drawRoundRect(bx, top, widths[i], bh, arc, arc);
+            }
+            g.setColor(isDefault ? JBColor.namedColor("Button.default.foreground", Color.WHITE) : fg);
+            int tw = fm.stringWidth(buttons.get(i));
+            g.drawString(clip(g, buttons.get(i), widths[i] - JBUI.scale(6)),
+                    bx + (widths[i] - Math.min(tw, widths[i] - JBUI.scale(6))) / 2, top + JBUI.scale(15));
+            bx += widths[i] + gap;
+        }
+    }
+
+    /** Draw the MSGBOX icon (16 Stop / 32 Question / 48 Exclamation / 64 Information) as a glyph. */
+    private void drawIcon(Graphics2D g, int icon, int x, int y, int size) {
+        Color color;
+        String glyph;
+        switch (icon) {
+            case 16 -> { color = new JBColor(new Color(0xD64541), new Color(0xD64541)); glyph = "✕"; } // Stop
+            case 32 -> { color = new JBColor(new Color(0x3574F0), new Color(0x3574F0)); glyph = "?"; }       // Question
+            case 48 -> { color = new JBColor(new Color(0xE0A030), new Color(0xE0A030)); glyph = "!"; }       // Exclamation
+            case 64 -> { color = new JBColor(new Color(0x3574F0), new Color(0x3574F0)); glyph = "i"; }       // Information
+            default -> { return; }
+        }
+        g.setColor(color);
+        g.fillOval(x, y, size, size);
+        g.setColor(Color.WHITE);
+        g.setStroke(new BasicStroke(JBUI.scale(1)));
+        FontMetrics fm = g.getFontMetrics();
+        int gw = fm.stringWidth(glyph);
+        g.drawString(glyph, x + (size - gw) / 2, y + size - JBUI.scale(6));
+    }
+
+    private static List<String> wrap(FontMetrics fm, String text, int maxWidth) {
+        List<String> lines = new ArrayList<>();
+        if (text.isEmpty()) {
+            return lines;
+        }
+        StringBuilder line = new StringBuilder();
+        for (String word : text.split(" ")) {
+            String candidate = line.isEmpty() ? word : line + " " + word;
+            if (fm.stringWidth(candidate) > maxWidth && !line.isEmpty()) {
+                lines.add(line.toString());
+                line = new StringBuilder(word);
+            } else {
+                line = new StringBuilder(candidate);
+            }
+        }
+        if (!line.isEmpty()) {
+            lines.add(line.toString());
+        }
+        return lines;
+    }
+
+    private static String clip(Graphics2D g, String s, int maxWidth) {
+        FontMetrics fm = g.getFontMetrics();
+        if (fm.stringWidth(s) <= maxWidth) {
+            return s;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            if (fm.stringWidth(sb.toString() + s.charAt(i) + "…") > maxWidth) {
+                break;
+            }
+            sb.append(s.charAt(i));
+        }
+        return sb + "…";
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/WindowSchematicPanel.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/composer/WindowSchematicPanel.java
@@ -1,0 +1,132 @@
+package com.basis.bbj.intellij.composer;
+
+import com.basis.bbj.intellij.composer.ComposerModels.WindowRender;
+import com.intellij.ui.JBColor;
+import com.intellij.util.ui.JBUI;
+
+import javax.swing.JPanel;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+
+/**
+ * Custom-painted schematic preview of the window a flag mask produces — the IntelliJ counterpart of
+ * the VS Code webview's HTML mock. Driven entirely by a {@link WindowRender} descriptor computed by
+ * the language server (#433), so no flag logic lives here.
+ */
+public final class WindowSchematicPanel extends JPanel {
+    private WindowRender render;
+
+    public WindowSchematicPanel() {
+        setPreferredSize(new Dimension(JBUI.scale(300), JBUI.scale(200)));
+        setOpaque(false);
+    }
+
+    public void setRender(WindowRender render) {
+        this.render = render;
+        repaint();
+    }
+
+    @Override
+    protected void paintComponent(Graphics g0) {
+        super.paintComponent(g0);
+        if (render == null) {
+            return;
+        }
+        Graphics2D g = (Graphics2D) g0.create();
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+        int pad = JBUI.scale(14);
+        int x = pad, y = pad;
+        int w = getWidth() - 2 * pad;
+        int h = getHeight() - 2 * pad;
+
+        Color frame = JBColor.namedColor("Component.borderColor", JBColor.GRAY);
+        Color titleBg = JBColor.namedColor("TitlePane.background", new JBColor(new Color(0xE3E3E3), new Color(0x3C3F41)));
+        Color bodyBg = JBColor.namedColor("EditorPane.background", JBColor.background());
+        Color fg = JBColor.foreground();
+
+        float alpha = render.invisible ? 0.30f : render.disabled ? 0.5f : 1.0f;
+        g.setComposite(java.awt.AlphaComposite.getInstance(java.awt.AlphaComposite.SRC_OVER, alpha));
+
+        // Body
+        g.setColor(bodyBg);
+        g.fillRoundRect(x, y, w, h, JBUI.scale(8), JBUI.scale(8));
+
+        // Frame (thicker with the Border flag; dashed when invisible)
+        g.setStroke(new java.awt.BasicStroke(render.border ? JBUI.scale(3) : JBUI.scale(1),
+                java.awt.BasicStroke.CAP_BUTT, java.awt.BasicStroke.JOIN_MITER, 10f,
+                render.invisible ? new float[]{JBUI.scale(4), JBUI.scale(4)} : null, 0f));
+        g.setColor(frame);
+        g.drawRoundRect(x, y, w, h, JBUI.scale(8), JBUI.scale(8));
+        g.setStroke(new java.awt.BasicStroke(JBUI.scale(1)));
+
+        int contentTop = y;
+        int titleH = JBUI.scale(22);
+        if (render.titleBar) {
+            g.setColor(titleBg);
+            g.fillRoundRect(x + 1, y + 1, w - 2, titleH, JBUI.scale(8), JBUI.scale(8));
+            g.fillRect(x + 1, y + titleH - JBUI.scale(6), w - 2, JBUI.scale(6)); // square off the bottom
+            g.setColor(fg);
+            String title = render.title == null || render.title.isEmpty() ? "(no title)" : render.title;
+            g.drawString(clip(g, title, w - JBUI.scale(70)), x + JBUI.scale(8), y + JBUI.scale(15));
+
+            // Title-bar buttons, right-aligned: [– □] then [×]
+            int bx = x + w - JBUI.scale(18);
+            if (render.closeBox) { g.drawString("×", bx, y + JBUI.scale(15)); bx -= JBUI.scale(16); }
+            if (render.minMax) { g.drawString("□", bx, y + JBUI.scale(15)); bx -= JBUI.scale(14);
+                                 g.drawString("–", bx, y + JBUI.scale(15)); }
+            contentTop = y + titleH;
+        }
+
+        if (render.menuBar) {
+            int menuH = JBUI.scale(16);
+            g.setColor(fg);
+            g.drawLine(x + 1, contentTop + menuH, x + w - 1, contentTop + menuH);
+            g.drawString("File   Edit   Help", x + JBUI.scale(8), contentTop + JBUI.scale(12));
+            contentTop += menuH;
+        }
+
+        int bodyBottom = y + h;
+        if (render.vScroll) {
+            int sw = JBUI.scale(10);
+            g.setColor(frame);
+            g.fillRect(x + w - sw - 1, contentTop + 1, sw, bodyBottom - contentTop - 2);
+        }
+        if (render.hScroll) {
+            int sh = JBUI.scale(10);
+            g.setColor(frame);
+            g.fillRect(x + 1, bodyBottom - sh - 1, w - 2, sh);
+        }
+
+        if (render.minimized || render.maximized) {
+            g.setColor(fg);
+            String state = render.minimized ? "(minimized)" : "(maximized)";
+            int sw = g.getFontMetrics().stringWidth(state);
+            g.drawString(state, x + (w - sw) / 2, contentTop + (bodyBottom - contentTop) / 2);
+        }
+
+        if (render.resizable) {
+            g.setColor(fg);
+            g.drawString("◢", x + w - JBUI.scale(14), y + h - JBUI.scale(4));
+        }
+        g.dispose();
+    }
+
+    private static String clip(Graphics2D g, String s, int maxWidth) {
+        if (g.getFontMetrics().stringWidth(s) <= maxWidth) {
+            return s;
+        }
+        String ell = "…";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            if (g.getFontMetrics().stringWidth(sb.toString() + s.charAt(i) + ell) > maxWidth) {
+                break;
+            }
+            sb.append(s.charAt(i));
+        }
+        return sb + ell;
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjLanguageServerFactory.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjLanguageServerFactory.java
@@ -1,6 +1,7 @@
 package com.basis.bbj.intellij.lsp;
 
 import com.basis.bbj.intellij.BbjSettings;
+import com.basis.bbj.intellij.composer.BbjComposerServer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
@@ -10,6 +11,7 @@ import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.client.features.LSPDocumentLinkFeature;
 import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider;
 import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.services.LanguageServer;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -26,6 +28,12 @@ public final class BbjLanguageServerFactory implements LanguageServerFactory {
     @Override
     public @NotNull LanguageClientImpl createLanguageClient(@NotNull Project project) {
         return new BbjLanguageClient(project);
+    }
+
+    @Override
+    public @NotNull Class<? extends LanguageServer> getServerInterface() {
+        // Extend the server proxy with the custom bbj/composer/* requests (#433).
+        return BbjComposerServer.class;
     }
 
     @Override

--- a/bbj-intellij/src/main/resources/META-INF/plugin.xml
+++ b/bbj-intellij/src/main/resources/META-INF/plugin.xml
@@ -101,6 +101,18 @@
         <!-- Welcome notification on first launch -->
         <postStartupActivity implementation="com.basis.bbj.intellij.BbjWelcomeNotification"/>
 
+        <!-- Visual composer lightbulb intentions (#426 / #430) -->
+        <intentionAction>
+            <language>BBj</language>
+            <className>com.basis.bbj.intellij.composer.ConfigureMsgboxIntention</className>
+            <category>BBj</category>
+        </intentionAction>
+        <intentionAction>
+            <language>BBj</language>
+            <className>com.basis.bbj.intellij.composer.ConfigureAddWindowIntention</className>
+            <category>BBj</category>
+        </intentionAction>
+
         <fileType
             name="BBj"
             implementationClass="com.basis.bbj.intellij.BbjFileType"

--- a/bbj-intellij/src/main/resources/META-INF/plugin.xml
+++ b/bbj-intellij/src/main/resources/META-INF/plugin.xml
@@ -58,6 +58,21 @@
             <keyboard-shortcut keymap="$default" first-keystroke="alt D"/>
         </action>
 
+        <!-- BBj Visual Composers (#426 / #430) -->
+        <action id="bbj.composeMsgbox"
+                class="com.basis.bbj.intellij.actions.BbjComposeMsgboxAction"
+                text="Compose MSGBOX…"
+                description="Visually compose a MSGBOX(...) statement">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+        </action>
+
+        <action id="bbj.composeAddWindow"
+                class="com.basis.bbj.intellij.actions.BbjComposeAddWindowAction"
+                text="Compose addWindow…"
+                description="Visually compose a BBjSysGui addWindow(...) statement">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+        </action>
+
         <!-- BBj Compile Action -->
         <action id="bbj.compile"
                 class="com.basis.bbj.intellij.actions.BbjCompileAction"

--- a/bbj-vscode/src/addwindow-composer-webview.ts
+++ b/bbj-vscode/src/addwindow-composer-webview.ts
@@ -14,11 +14,8 @@
  */
 import * as vscode from 'vscode';
 import {
-    WINDOW_FLAGS, EVENT_MASK_BITS, encodeBits, formatHex, describeFlags,
-    describeEventMask, windowSchematic, composeAddWindow,
+    WINDOW_FLAGS, EVENT_MASK_BITS, addwindowPreview,
 } from './addwindow-composer.js';
-// Reuse the small display-text helper from the MSGBOX composer scaffolding (#426).
-import { expressionDisplayText } from './msgbox-composer.js';
 
 /** Where/how to apply an EDIT: token ranges to replace, or offsets to insert at. */
 export interface AddWindowEditTarget {
@@ -100,27 +97,13 @@ export function openAddWindowComposerPanel(context: vscode.ExtensionContext, arg
     );
     panel.webview.html = getHtml(panel.webview);
 
-    function build(sel: Selection) {
-        const flags = encodeBits(sel.flags);
-        const eventMask = sel.eventMaskEnabled ? encodeBits(sel.eventMask) : null;
-        const flagsHex = formatHex(flags | (target?.preservedFlagBits ?? 0));
-        const eventHex = eventMask === null ? null : formatHex(eventMask | (target?.preservedEventBits ?? 0));
-
-        const statement = composeAddWindow({
-            receiver: editMode ? undefined : (sel.receiver || undefined),
-            sysgui: sel.sysgui || 'sysgui!',
-            x: sel.x || '0', y: sel.y || '0', width: sel.width || '0', height: sel.height || '0',
-            title: sel.title || '""',
-            flags, eventMask,
-        });
-
-        return {
-            flagsHex, eventHex, statement,
-            flagsSummary: describeFlags(flags),
-            eventSummary: eventMask === null ? '(default)' : describeEventMask(eventMask),
-            render: { ...windowSchematic(flags), title: expressionDisplayText(sel.title) },
-        };
-    }
+    // Single source of truth: the hex/compose/schematic logic lives in the shared pure module,
+    // which the IntelliJ client reaches over the LS (#433).
+    const build = (sel: Selection) => addwindowPreview({
+        ...sel, editMode,
+        preservedFlagBits: target?.preservedFlagBits ?? 0,
+        preservedEventBits: target?.preservedEventBits ?? 0,
+    });
 
     panel.webview.onDidReceiveMessage(async (msg: { type: string; payload?: Selection }) => {
         switch (msg.type) {

--- a/bbj-vscode/src/addwindow-composer.ts
+++ b/bbj-vscode/src/addwindow-composer.ts
@@ -13,6 +13,8 @@
  * This module owns the two catalogs and the mask <-> hex <-> statement conversions with NO
  * `vscode` dependency, so it is unit-testable and reusable by the IntelliJ client later.
  */
+// Reuse the shared BBj display-text helper from the MSGBOX composer scaffolding (#426).
+import { expressionDisplayText } from './msgbox-composer.js';
 
 export interface FlagItem {
     /** The single bit this toggle sets, e.g. 0x00000002. */
@@ -205,6 +207,68 @@ export interface AddWindowInput {
     flags: number;
     /** Event mask bitmask, or null/undefined to leave it unset (omit the argument = window default). */
     eventMask?: number | null;
+}
+
+/** Flat UI selection for an addWindow preview — shared by the VS Code webview and IntelliJ. */
+export interface AddWindowPreviewInput {
+    /** Chosen window-flag bit values. */
+    flags: number[];
+    /** When false the event_mask argument is omitted entirely (window default). */
+    eventMaskEnabled: boolean;
+    /** Chosen event-mask bit values (only meaningful when enabled). */
+    eventMask: number[];
+    receiver?: string;
+    sysgui: string;
+    x: string;
+    y: string;
+    width: string;
+    height: string;
+    title: string;
+    /** In edit mode the assignment/geometry live in the source; only the hex tokens are rewritten. */
+    editMode?: boolean;
+    /** Undocumented bits to OR back into the flags/event mask so a round-trip preserves them. */
+    preservedFlagBits?: number;
+    preservedEventBits?: number;
+}
+
+export interface AddWindowPreview {
+    flags: number;
+    eventMask: number | null;
+    flagsHex: string;
+    eventHex: string | null;
+    statement: string;
+    flagsSummary: string;
+    eventSummary: string;
+    render: WindowSchematic & { title: string };
+}
+
+/**
+ * Compute the full preview payload for an addWindow selection — the single entry point every UI
+ * uses, so the hex/compose/schematic logic lives in exactly one place.
+ */
+export function addwindowPreview(input: AddWindowPreviewInput): AddWindowPreview {
+    const flags = encodeBits(input.flags);
+    const eventMask = input.eventMaskEnabled ? encodeBits(input.eventMask) : null;
+    // The hex and the composed statement both carry the preserved (undocumented) bits, so they
+    // stay coherent; the summaries/schematic use the catalog-only mask (preserved bits are unlabeled).
+    const flagsFull = (flags | (input.preservedFlagBits ?? 0)) >>> 0;
+    const eventFull = eventMask === null ? null : (eventMask | (input.preservedEventBits ?? 0)) >>> 0;
+
+    const statement = composeAddWindow({
+        receiver: input.editMode ? undefined : (input.receiver || undefined),
+        sysgui: input.sysgui || 'sysgui!',
+        x: input.x || '0', y: input.y || '0', width: input.width || '0', height: input.height || '0',
+        title: input.title || '""',
+        flags: flagsFull, eventMask: eventFull,
+    });
+
+    return {
+        flags, eventMask, flagsHex: formatHex(flagsFull), eventHex: eventFull === null ? null : formatHex(eventFull),
+        statement,
+        flagsSummary: describeFlags(flags),
+        eventSummary: eventMask === null ? '(default)' : describeEventMask(eventMask),
+        render: { ...windowSchematic(flags), title: expressionDisplayText(input.title) },
+    };
 }
 
 /** Build an `addWindow(...)` statement, emitting the event_mask argument only when it is set. */

--- a/bbj-vscode/src/language/composer-commands.ts
+++ b/bbj-vscode/src/language/composer-commands.ts
@@ -16,6 +16,7 @@ import {
     BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS,
     encode, decode, describe as describeMsgbox, composeStatement, stateFromSelection, flagsFromState,
     validateStringField, findMsgboxCallAt, parseMsgboxCallOnLine, msgboxPreview,
+    splitButtonsAndTrailing,
     type ComposeInput, type MsgboxPreviewInput,
 } from '../msgbox-composer.js';
 import {
@@ -28,6 +29,12 @@ import {
 
 /** A line + optional cursor column; when `character` is set, only the call at the cursor is returned. */
 interface LineQuery { line: string; character?: number }
+
+/** Best-effort title for an addWindow preview: the last string-literal argument in the call. */
+function addWindowTitleArg(args: string[]): string {
+    const literal = [...args].reverse().find(a => /^"([^"]|"")*"$/.test(a));
+    return literal ?? '"Window"';
+}
 
 /**
  * The composer request handlers, keyed by LSP method. Exported (not just wired) so they can be
@@ -59,6 +66,33 @@ export const composerHandlers = {
     /** Locate a MSGBOX call on a line (the one at `character`, or the first). */
     'bbj/composer/msgbox/parseLine': (p: LineQuery) =>
         ({ call: p.character === undefined ? parseMsgboxCallOnLine(p.line) : findMsgboxCallAt(p.line, p.character) }),
+    /**
+     * Find the MSGBOX call at the caret and decode it into a ready-to-prefill payload + the call
+     * span to replace (edit-in-place). `found: false` when the caret is not inside a MSGBOX call.
+     */
+    'bbj/composer/msgbox/decodeCall': (p: LineQuery) => {
+        const info = p.character === undefined ? parseMsgboxCallOnLine(p.line) : findMsgboxCallAt(p.line, p.character);
+        const hasExpr = !!info && info.exprRange !== undefined && info.exprValue !== undefined;
+        const canAddOptions = !!info && info.optionInsertOffset !== undefined;
+        if (!info || (!hasExpr && !canAddOptions)) {
+            return { found: false };
+        }
+        const st = decode(hasExpr ? info.exprValue! : 0);
+        const { buttons, trailing } = hasExpr
+            ? splitButtonsAndTrailing(info.args.slice(3), st.buttonSet === 7)
+            : { buttons: [], trailing: [] };
+        return {
+            found: true,
+            edit: { callStart: info.callStart, callEnd: info.callEnd },
+            trailingArgs: trailing,
+            initial: {
+                message: info.args[0] ?? '""',
+                title: hasExpr ? (info.args[2] ?? '') : '',
+                buttonSet: st.buttonSet, icon: st.icon, defaultButton: st.defaultButton,
+                flags: flagsFromState(st), customButtons: buttons,
+            },
+        };
+    },
 
     // ---- addWindow -------------------------------------------------------------------------------
     /** Chosen flag bits -> mask + `$........$` hex (unknown bits OR-ed back for round-trip safety). */
@@ -91,6 +125,34 @@ export const composerHandlers = {
     /** Locate an addWindow call on a line (the one at `character`, or the first). */
     'bbj/composer/addwindow/parseLine': (p: LineQuery) =>
         ({ call: p.character === undefined ? parseAddWindowCallOnLine(p.line) : findAddWindowCallAt(p.line, p.character) }),
+    /**
+     * Find the addWindow call at the caret and decode it into a prefill payload + the token ranges/
+     * insert offsets to rewrite in place. `found: false` when the caret is not inside such a call.
+     */
+    'bbj/composer/addwindow/decodeCall': (p: LineQuery) => {
+        const info = p.character === undefined ? parseAddWindowCallOnLine(p.line) : findAddWindowCallAt(p.line, p.character);
+        if (!info) {
+            return { found: false };
+        }
+        const flags = info.flagsValue ?? 0;
+        const hasEvent = info.eventMaskValue !== undefined;
+        const eventMask = info.eventMaskValue ?? 0;
+        return {
+            found: true,
+            edit: {
+                flagsRange: info.flagsRange, flagsInsertOffset: info.flagsInsertOffset,
+                eventMaskRange: info.eventMaskRange, eventMaskInsertOffset: info.eventMaskInsertOffset,
+                preservedFlagBits: unknownBits(flags, WINDOW_FLAGS),
+                preservedEventBits: hasEvent ? unknownBits(eventMask, EVENT_MASK_BITS) : 0,
+            },
+            initial: {
+                flags: bitsSet(flags, WINDOW_FLAGS),
+                eventMaskEnabled: hasEvent,
+                eventMask: hasEvent ? bitsSet(eventMask, EVENT_MASK_BITS) : [],
+                title: addWindowTitleArg(info.args),
+            },
+        };
+    },
 } as const;
 
 /** Register every composer request on the LSP connection. Call once during server startup. */

--- a/bbj-vscode/src/language/composer-commands.ts
+++ b/bbj-vscode/src/language/composer-commands.ts
@@ -15,15 +15,15 @@ import type { Connection } from 'vscode-languageserver';
 import {
     BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS,
     encode, decode, describe as describeMsgbox, composeStatement, stateFromSelection, flagsFromState,
-    validateStringField, findMsgboxCallAt, parseMsgboxCallOnLine,
-    type ComposeInput,
+    validateStringField, findMsgboxCallAt, parseMsgboxCallOnLine, msgboxPreview,
+    type ComposeInput, type MsgboxPreviewInput,
 } from '../msgbox-composer.js';
 import {
     WINDOW_FLAGS, EVENT_MASK_BITS,
     encodeBits, bitsSet, unknownBits, formatHex, parseHexLiteral,
-    describeFlags, describeEventMask, windowSchematic, composeAddWindow,
+    describeFlags, describeEventMask, windowSchematic, composeAddWindow, addwindowPreview,
     findAddWindowCallAt, parseAddWindowCallOnLine,
-    type AddWindowInput,
+    type AddWindowInput, type AddWindowPreviewInput,
 } from '../addwindow-composer.js';
 
 /** A line + optional cursor column; when `character` is set, only the call at the cursor is returned. */
@@ -49,6 +49,8 @@ export const composerHandlers = {
         const s = decode(p.expr);
         return { buttonSet: s.buttonSet, icon: s.icon, defaultButton: s.defaultButton, flags: flagsFromState(s) };
     },
+    /** Aggregate: full UI payload (statement + validation + render) for one selection in a single call. */
+    'bbj/composer/msgbox/preview': (p: { input: MsgboxPreviewInput }) => msgboxPreview(p.input),
     'bbj/composer/msgbox/compose': (p: { input: ComposeInput }) => ({ statement: composeStatement(p.input) }),
     'bbj/composer/msgbox/describe': (p: { expr: number }) => ({ text: describeMsgbox(p.expr) }),
     /** Validate a string-typed field (message/title/button) — resolves-to-String + structural. */
@@ -80,6 +82,8 @@ export const composerHandlers = {
         unknownBits: unknownBits(p.mask, EVENT_MASK_BITS),
         text: describeEventMask(p.mask),
     }),
+    /** Aggregate: full UI payload (statement + flags/event hex + summaries + schematic) in one call. */
+    'bbj/composer/addwindow/preview': (p: { input: AddWindowPreviewInput }) => addwindowPreview(p.input),
     'bbj/composer/addwindow/compose': (p: { input: AddWindowInput }) => ({ statement: composeAddWindow(p.input) }),
     'bbj/composer/addwindow/schematic': (p: { mask: number }) => windowSchematic(p.mask),
     /** Parse a `$HHHHHHHH$` hex literal to an unsigned number (or undefined). */

--- a/bbj-vscode/src/msgbox-composer-webview.ts
+++ b/bbj-vscode/src/msgbox-composer-webview.ts
@@ -42,6 +42,7 @@ interface Selection {
     message: string;
     title: string;
     assignTo: string;
+    useConstants: boolean;
 }
 
 export function openMsgboxComposerPanel(context: vscode.ExtensionContext, arg?: MsgboxPanelArg): void {
@@ -242,6 +243,11 @@ function getHtml(webview: vscode.Webview): string {
 
   <fieldset id="flags"><legend>Extra options</legend></fieldset>
 
+  <div class="check" style="margin: 4px 0 10px;">
+    <input type="checkbox" id="useConstants">
+    <label for="useConstants" style="opacity:1;">Use named constants (<code>BBjMsgBox.*</code>) instead of a numeric code</label>
+  </div>
+
   <div class="preview">
     <label>Generated statement</label>
     <pre id="preview">—</pre>
@@ -284,6 +290,7 @@ function getHtml(webview: vscode.Webview): string {
       message: $('message').value,
       title: $('title').value,
       assignTo: $('assignTo').value,
+      useConstants: $('useConstants').checked,
     };
   }
 
@@ -346,6 +353,7 @@ function getHtml(webview: vscode.Webview): string {
     $(id).addEventListener('input', change);
     $(id).addEventListener('change', change);
   }
+  $('useConstants').addEventListener('change', change);
   $('insert').addEventListener('click', () => vscode.postMessage({ type: 'insert', payload: readForm() }));
   $('cancel').addEventListener('click', () => vscode.postMessage({ type: 'cancel' }));
 

--- a/bbj-vscode/src/msgbox-composer-webview.ts
+++ b/bbj-vscode/src/msgbox-composer-webview.ts
@@ -14,8 +14,7 @@
 import * as vscode from 'vscode';
 import {
     BUTTON_SETS, ICONS, DEFAULT_BUTTONS, FLAGS,
-    encode, describe, composeStatement, stateFromSelection, validateStringField,
-    buttonLabels, expressionDisplayText,
+    msgboxPreview,
 } from './msgbox-composer.js';
 
 export interface MsgboxPanelArg {
@@ -75,43 +74,9 @@ export function openMsgboxComposerPanel(context: vscode.ExtensionContext, arg?: 
     );
     panel.webview.html = getHtml(panel.webview);
 
-    function build(sel: Selection) {
-        const state = stateFromSelection(sel);
-        const isCustom = state.buttonSet === 7;
-        const cleanCustom = (sel.customButtons ?? []).map(s => s.trim()).filter(s => s !== '');
-        const expr = encode(state);
-
-        const msgV = validateStringField(sel.message, { required: true });
-        const titleV = validateStringField(sel.title, { required: false });
-        const firstBadButton = cleanCustom.map(b => validateStringField(b)).find(v => !v.ok);
-        const customOk = !isCustom || (cleanCustom.length > 0 && !firstBadButton);
-
-        const statement = composeStatement({
-            message: sel.message || '""',
-            expr,
-            title: sel.title || undefined,
-            buttons: isCustom ? cleanCustom : undefined,
-            trailingArgs,
-            assignTo: editMode ? undefined : (sel.assignTo || undefined),
-        });
-
-        const labels = buttonLabels(state.buttonSet, sel.customButtons);
-        const defaultIndex = state.defaultButton === 256 ? 1 : state.defaultButton === 512 ? 2 : 0;
-        return {
-            expr, statement, summary: describe(expr),
-            messageError: msgV.ok ? undefined : msgV.message,
-            titleError: titleV.ok ? undefined : titleV.message,
-            customError: customOk ? undefined : (cleanCustom.length === 0 ? 'Add at least one button label' : (firstBadButton?.message ?? 'Invalid button expression')),
-            valid: msgV.ok && titleV.ok && customOk,
-            render: {
-                title: expressionDisplayText(sel.title),
-                message: expressionDisplayText(sel.message),
-                icon: state.icon,
-                buttons: labels,
-                defaultIndex: Math.max(0, Math.min(defaultIndex, labels.length - 1)),
-            },
-        };
-    }
+    // Single source of truth: the compose/validate/render logic lives in the shared pure module,
+    // which the IntelliJ client reaches over the LS (#433).
+    const build = (sel: Selection) => msgboxPreview({ ...sel, trailingArgs, editMode });
 
     panel.webview.onDidReceiveMessage(async (msg: { type: string; payload?: Selection }) => {
         switch (msg.type) {

--- a/bbj-vscode/src/msgbox-composer.ts
+++ b/bbj-vscode/src/msgbox-composer.ts
@@ -331,6 +331,77 @@ export function buttonLabels(buttonSet: number, customButtons: string[] = []): s
     return STANDARD_BUTTON_LABELS[buttonSet] ?? ['OK'];
 }
 
+/** Flat UI selection for a MSGBOX preview (message/title/options), shared by every client. */
+export interface MsgboxPreviewInput {
+    message: string;
+    title: string;
+    assignTo?: string;
+    buttonSet: number;
+    icon: number;
+    defaultButton: number;
+    flags: number[];
+    customButtons: string[];
+    /** Verbatim args past the title to preserve when rewriting an existing call. */
+    trailingArgs?: string[];
+    /** In edit mode the assignment prefix already exists in the source, so it is omitted. */
+    editMode?: boolean;
+}
+
+/** Everything a composer UI needs to render one state: the statement, validation, and a schematic. */
+export interface MsgboxPreview {
+    expr: number;
+    statement: string;
+    summary: string;
+    messageError?: string;
+    titleError?: string;
+    customError?: string;
+    valid: boolean;
+    render: { title: string; message: string; icon: number; buttons: string[]; defaultIndex: number };
+}
+
+/**
+ * Compute the full preview payload for a MSGBOX selection — the single entry point every UI (the
+ * VS Code webview and the IntelliJ dialog, via the LS) uses so the compose/validate/render logic
+ * lives in exactly one place.
+ */
+export function msgboxPreview(input: MsgboxPreviewInput): MsgboxPreview {
+    const state = stateFromSelection(input);
+    const isCustom = state.buttonSet === 7;
+    const cleanCustom = (input.customButtons ?? []).map(s => s.trim()).filter(s => s !== '');
+    const expr = encode(state);
+
+    const msgV = validateStringField(input.message, { required: true });
+    const titleV = validateStringField(input.title, { required: false });
+    const firstBadButton = cleanCustom.map(b => validateStringField(b)).find(v => !v.ok);
+    const customOk = !isCustom || (cleanCustom.length > 0 && !firstBadButton);
+
+    const statement = composeStatement({
+        message: input.message || '""',
+        expr,
+        title: input.title || undefined,
+        buttons: isCustom ? cleanCustom : undefined,
+        trailingArgs: input.trailingArgs,
+        assignTo: input.editMode ? undefined : (input.assignTo || undefined),
+    });
+
+    const labels = buttonLabels(state.buttonSet, input.customButtons);
+    const defaultIndex = state.defaultButton === 256 ? 1 : state.defaultButton === 512 ? 2 : 0;
+    return {
+        expr, statement, summary: describe(expr),
+        messageError: msgV.ok ? undefined : msgV.message,
+        titleError: titleV.ok ? undefined : titleV.message,
+        customError: customOk ? undefined : (cleanCustom.length === 0 ? 'Add at least one button label' : (firstBadButton?.message ?? 'Invalid button expression')),
+        valid: msgV.ok && titleV.ok && customOk,
+        render: {
+            title: expressionDisplayText(input.title),
+            message: expressionDisplayText(input.message),
+            icon: state.icon,
+            buttons: labels,
+            defaultIndex: Math.max(0, Math.min(defaultIndex, labels.length - 1)),
+        },
+    };
+}
+
 /**
  * Split the args past the title (args[3..]) into custom button labels and the remaining trailing
  * args to preserve verbatim. Positional buttons only apply to the "Custom" set (7) and stop at the

--- a/bbj-vscode/src/msgbox-composer.ts
+++ b/bbj-vscode/src/msgbox-composer.ts
@@ -13,40 +13,42 @@ export interface CatalogItem {
     value: number;
     label: string;
     detail?: string;
+    /** The `BBjMsgBox.*` constant name for this value (for the readable constants form). */
+    constant?: string;
 }
 
 /** Button sets — the low bits of `expr` (0..7). */
 export const BUTTON_SETS: CatalogItem[] = [
-    { value: 0, label: 'OK' },
-    { value: 1, label: 'OK, Cancel' },
-    { value: 2, label: 'Abort, Retry, Ignore' },
-    { value: 3, label: 'Yes, No, Cancel' },
-    { value: 4, label: 'Yes, No' },
-    { value: 5, label: 'Retry, Cancel' },
-    { value: 7, label: 'Custom (button1..button3)' },
+    { value: 0, label: 'OK', constant: 'MSGBOX_BUTTONS_OK' },
+    { value: 1, label: 'OK, Cancel', constant: 'MSGBOX_BUTTONS_OK_CANCEL' },
+    { value: 2, label: 'Abort, Retry, Ignore', constant: 'MSGBOX_BUTTONS_ABORT_RETRY_IGNORE' },
+    { value: 3, label: 'Yes, No, Cancel', constant: 'MSGBOX_BUTTONS_YES_NO_CANCEL' },
+    { value: 4, label: 'Yes, No', constant: 'MSGBOX_BUTTONS_YES_NO' },
+    { value: 5, label: 'Retry, Cancel', constant: 'MSGBOX_BUTTONS_RETRY_CANCEL' },
+    { value: 7, label: 'Custom (button1..button3)', constant: 'MSGBOX_BUTTONS_CUSTOM' },
 ];
 
 /** Icon — added to the button value. */
 export const ICONS: CatalogItem[] = [
-    { value: 0, label: 'None' },
-    { value: 16, label: 'Stop' },
-    { value: 32, label: 'Question' },
-    { value: 48, label: 'Exclamation' },
-    { value: 64, label: 'Information' },
+    { value: 0, label: 'None', constant: 'MSGBOX_ICON_NONE' },
+    { value: 16, label: 'Stop', constant: 'MSGBOX_ICON_STOP' },
+    { value: 32, label: 'Question', constant: 'MSGBOX_ICON_QUESTION' },
+    { value: 48, label: 'Exclamation', constant: 'MSGBOX_ICON_EXCLAMATION' },
+    { value: 64, label: 'Information', constant: 'MSGBOX_ICON_INFORMATION' },
 ];
 
 /** Default button — added on top. */
 export const DEFAULT_BUTTONS: CatalogItem[] = [
-    { value: 0, label: 'First button' },
-    { value: 256, label: 'Second button' },
-    { value: 512, label: 'Third button' },
+    { value: 0, label: 'First button', constant: 'MSGBOX_DEFAULT_FIRST' },
+    { value: 256, label: 'Second button', constant: 'MSGBOX_DEFAULT_SECOND' },
+    { value: 512, label: 'Third button', constant: 'MSGBOX_DEFAULT_THIRD' },
 ];
 
 /** Independent flags (multi-select). */
 export const FLAGS: CatalogItem[] = [
-    { value: 65536, label: 'Do not allow Enter selection' },
-    { value: 32768, label: 'Disable HTML processing' },
-    { value: 131072, label: 'Restrict to MDI desktop' },
+    { value: 65536, label: 'Do not allow Enter selection', constant: 'MSGBOX_DEFAULT_NONE' },
+    { value: 32768, label: 'Disable HTML processing', constant: 'MSGBOX_RAW_TEXT' },
+    { value: 131072, label: 'Restrict to MDI desktop', constant: 'MSGBOX_MDI_DESKTOP' },
 ];
 
 const BUTTON_MASK = 0x7;     // 0..7
@@ -128,6 +130,8 @@ export interface ComposeInput {
     /** BBj expression text for the message, e.g. `"Are you sure?"` or a variable. */
     message: string;
     expr: number;
+    /** Overrides how the `expr` argument is rendered (e.g. the `BBjMsgBox.*` constants form). */
+    exprText?: string;
     /** BBj expression text for the title, if any. */
     title?: string;
     /** Custom button label expressions (only meaningful with the "Custom" button set). */
@@ -146,15 +150,32 @@ export function composeStatement(input: ComposeInput): string {
     const extras = [...(input.buttons ?? []), ...(input.trailingArgs ?? [])];
     const hasExtras = extras.length > 0;
     const needTitle = (input.title !== undefined && input.title !== '') || hasExtras;
-    const needExpr = input.expr !== 0 || needTitle;
+    const hasExprText = input.exprText !== undefined && input.exprText !== '';
+    const needExpr = input.expr !== 0 || needTitle || hasExprText;
 
     const args: string[] = [input.message];
-    if (needExpr) args.push(String(input.expr));
+    if (needExpr) args.push(hasExprText ? input.exprText! : String(input.expr));
     if (needTitle) args.push(input.title || '""');
     if (hasExtras) args.push(...extras);
 
     const call = `MSGBOX(${args.join(', ')})`;
     return input.assignTo ? `${input.assignTo} = ${call}` : call;
+}
+
+/**
+ * Render `expr` as the readable `BBjMsgBox.*` constants form, e.g.
+ * `BBjMsgBox.MSGBOX_BUTTONS_OK_CANCEL+BBjMsgBox.MSGBOX_ICON_QUESTION`. The button-set constant is
+ * always emitted (it is the base); the zero-valued icon/default-button are omitted.
+ */
+export function msgboxConstantsExpr(s: MsgboxState): string {
+    const constOf = (catalog: CatalogItem[], value: number) => catalog.find(i => i.value === value)?.constant;
+    const parts: string[] = [];
+    const button = constOf(BUTTON_SETS, s.buttonSet);
+    if (button) parts.push(button);
+    if (s.icon) { const c = constOf(ICONS, s.icon); if (c) parts.push(c); }
+    if (s.defaultButton) { const c = constOf(DEFAULT_BUTTONS, s.defaultButton); if (c) parts.push(c); }
+    for (const flag of flagsFromState(s)) { const c = constOf(FLAGS, flag); if (c) parts.push(c); }
+    return parts.map(p => `BBjMsgBox.${p}`).join('+');
 }
 
 /** The flag values (65536/32768/131072) set on a state — inverse of the flag part of stateFromSelection. */
@@ -345,11 +366,15 @@ export interface MsgboxPreviewInput {
     trailingArgs?: string[];
     /** In edit mode the assignment prefix already exists in the source, so it is omitted. */
     editMode?: boolean;
+    /** Emit the readable `BBjMsgBox.*` constants form for `expr` instead of the numeric literal. */
+    useConstants?: boolean;
 }
 
 /** Everything a composer UI needs to render one state: the statement, validation, and a schematic. */
 export interface MsgboxPreview {
     expr: number;
+    /** The constants form of `expr` when `useConstants` is set (else undefined). */
+    exprText?: string;
     statement: string;
     summary: string;
     messageError?: string;
@@ -375,9 +400,10 @@ export function msgboxPreview(input: MsgboxPreviewInput): MsgboxPreview {
     const firstBadButton = cleanCustom.map(b => validateStringField(b)).find(v => !v.ok);
     const customOk = !isCustom || (cleanCustom.length > 0 && !firstBadButton);
 
+    const exprText = input.useConstants ? msgboxConstantsExpr(state) : undefined;
     const statement = composeStatement({
         message: input.message || '""',
-        expr,
+        expr, exprText,
         title: input.title || undefined,
         buttons: isCustom ? cleanCustom : undefined,
         trailingArgs: input.trailingArgs,
@@ -387,7 +413,7 @@ export function msgboxPreview(input: MsgboxPreviewInput): MsgboxPreview {
     const labels = buttonLabels(state.buttonSet, input.customButtons);
     const defaultIndex = state.defaultButton === 256 ? 1 : state.defaultButton === 512 ? 2 : 0;
     return {
-        expr, statement, summary: describe(expr),
+        expr, exprText, statement, summary: describe(expr),
         messageError: msgV.ok ? undefined : msgV.message,
         titleError: titleV.ok ? undefined : titleV.message,
         customError: customOk ? undefined : (cleanCustom.length === 0 ? 'Add at least one button label' : (firstBadButton?.message ?? 'Invalid button expression')),

--- a/bbj-vscode/test/addwindow-composer.test.ts
+++ b/bbj-vscode/test/addwindow-composer.test.ts
@@ -3,6 +3,7 @@ import {
     WINDOW_FLAGS, EVENT_MASK_BITS, encodeBits, bitsSet, unknownBits, knownMask,
     formatHex, parseHexLiteral, describeMask, describeFlags, describeEventMask,
     composeAddWindow, parseAddWindowCallOnLine, findAddWindowCallAt, windowSchematic, WINDOW_FLAG,
+    addwindowPreview,
 } from '../src/addwindow-composer';
 
 describe('addWindow composer logic (#430)', () => {
@@ -85,6 +86,30 @@ describe('addWindow composer logic (#430)', () => {
         const dialog = windowSchematic(0x00080000 | 0x00020000); // Dialog + Always on top
         expect(dialog.badges).toContain('Dialog');
         expect(dialog.badges).toContain('Always on top');
+    });
+
+    test('addwindowPreview aggregates hex + compose + summaries + schematic', () => {
+        const p = addwindowPreview({
+            flags: [WINDOW_FLAG.RESIZABLE, WINDOW_FLAG.CLOSE_BOX], eventMaskEnabled: false, eventMask: [],
+            receiver: 'window!', sysgui: 'sysgui!', x: '10', y: '10', width: '400', height: '300', title: '"Win"',
+        });
+        expect(p.flagsHex).toBe('$00000003$');
+        expect(p.eventHex).toBeNull();
+        expect(p.eventSummary).toBe('(default)');
+        expect(p.statement).toBe('window! = sysgui!.addWindow(10, 10, 400, 300, "Win", $00000003$)');
+        expect(p.render.title).toBe('Win');
+        expect(p.render.closeBox).toBe(true);
+    });
+
+    test('addwindowPreview enables event mask + preserves unknown bits, drops receiver in edit mode', () => {
+        const p = addwindowPreview({
+            flags: [WINDOW_FLAG.RESIZABLE], eventMaskEnabled: true, eventMask: [0x00000040],
+            sysgui: 'g!', x: '0', y: '0', width: '9', height: '9', title: '"T"',
+            editMode: true, preservedFlagBits: 0x00004000,
+        });
+        expect(p.flagsHex).toBe('$00004001$');           // reserved bit OR-ed back in
+        expect(p.eventHex).toBe('$00000040$');
+        expect(p.statement).toBe('g!.addWindow(0, 0, 9, 9, "T", $00004001$, $00000040$)'); // no receiver
     });
 
     test('composeAddWindow renders the call and omits event_mask when unset', () => {

--- a/bbj-vscode/test/composer-commands.test.ts
+++ b/bbj-vscode/test/composer-commands.test.ts
@@ -88,6 +88,45 @@ describe('composer LS command layer (#433)', () => {
         expect(parsed.call.flagsValue).toBe(0x00080002);
     });
 
+    test('msgbox/decodeCall decodes the call at the caret into a prefill + call span', () => {
+        const line = '    ret! = MSGBOX("Are you sure?", 36, "Confirm")';
+        const r = call('bbj/composer/msgbox/decodeCall', { line, character: line.indexOf('36') }) as any;
+        expect(r.found).toBe(true);
+        expect(r.initial.message).toBe('"Are you sure?"');
+        expect(r.initial.title).toBe('"Confirm"');
+        expect(r.initial.buttonSet).toBe(4);  // Yes/No
+        expect(r.initial.icon).toBe(32);       // Question
+        expect(line.slice(r.edit.callStart, r.edit.callEnd)).toBe('MSGBOX("Are you sure?", 36, "Confirm")');
+
+        // caret outside any call -> not found
+        expect((call('bbj/composer/msgbox/decodeCall', { line, character: 0 }) as any).found).toBe(false);
+        // bare call -> found (lets the UI add options), zeroed selection
+        const bare = call('bbj/composer/msgbox/decodeCall', { line: 'x = MSGBOX("Hi")', character: 12 }) as any;
+        expect(bare.found).toBe(true);
+        expect(bare.initial.buttonSet).toBe(0);
+        expect(bare.initial.message).toBe('"Hi"');
+    });
+
+    test('addwindow/decodeCall decodes flags/event bits + token ranges at the caret', () => {
+        const line = 'w! = g!.addWindow(0, 0, 9, 9, "T", $01000002$, $00000440$)';
+        const r = call('bbj/composer/addwindow/decodeCall', { line, character: line.indexOf('$01000002$') }) as any;
+        expect(r.found).toBe(true);
+        expect(r.initial.flags).toContain(0x00000002);       // Close box
+        expect(r.initial.flags).toContain(0x01000000);       // No title bar
+        expect(r.initial.eventMaskEnabled).toBe(true);
+        expect(r.initial.eventMask).toContain(0x00000040);   // Mouse button down
+        expect(r.initial.title).toBe('"T"');
+        expect(line.slice(r.edit.flagsRange[0], r.edit.flagsRange[1])).toBe('$01000002$');
+        expect(line.slice(r.edit.eventMaskRange[0], r.edit.eventMaskRange[1])).toBe('$00000440$');
+
+        // a call with no flags yet -> found, with a flags-insert offset and no event mask
+        const bare = call('bbj/composer/addwindow/decodeCall', { line: 'g!.addWindow("T")', character: 5 }) as any;
+        expect(bare.found).toBe(true);
+        expect(bare.initial.flags).toEqual([]);
+        expect(bare.edit.flagsInsertOffset).toBeGreaterThan(0);
+        expect(bare.edit.eventMaskRange).toBeUndefined();
+    });
+
     test('registerComposerRequests wires every handler onto the connection', () => {
         const onRequest = vi.fn();
         registerComposerRequests({ onRequest } as any);

--- a/bbj-vscode/test/composer-commands.test.ts
+++ b/bbj-vscode/test/composer-commands.test.ts
@@ -30,6 +30,25 @@ describe('composer LS command layer (#433)', () => {
         expect((call('bbj/composer/msgbox/validateString', { text: '"Caption"' }) as any).ok).toBe(true);
     });
 
+    test('msgbox/preview returns the full aggregate UI payload in one call', () => {
+        const p = call('bbj/composer/msgbox/preview', {
+            input: { message: '"Hi"', title: '', buttonSet: 4, icon: 32, defaultButton: 0, flags: [], customButtons: [] },
+        }) as any;
+        expect(p.expr).toBe(36);
+        expect(p.statement).toBe('MSGBOX("Hi", 36)');
+        expect(p.valid).toBe(true);
+        expect(p.render.buttons).toEqual(['Yes', 'No']);
+    });
+
+    test('addwindow/preview returns hex + statement + schematic in one call', () => {
+        const p = call('bbj/composer/addwindow/preview', {
+            input: { flags: [0x1, 0x2], eventMaskEnabled: false, eventMask: [], receiver: 'w!', sysgui: 'g!', x: '0', y: '0', width: '9', height: '9', title: '"T"' },
+        }) as any;
+        expect(p.flagsHex).toBe('$00000003$');
+        expect(p.statement).toBe('w! = g!.addWindow(0, 0, 9, 9, "T", $00000003$)');
+        expect(p.render.closeBox).toBe(true);
+    });
+
     test('msgbox parseLine finds the call (first, or the one at the cursor)', () => {
         const first = call('bbj/composer/msgbox/parseLine', { line: 'x = MSGBOX("a", 36)' }) as any;
         expect(first.call.exprValue).toBe(36);

--- a/bbj-vscode/test/msgbox-composer.test.ts
+++ b/bbj-vscode/test/msgbox-composer.test.ts
@@ -3,6 +3,7 @@ import {
     encode, decode, describe as describeExpr, composeStatement, parseMsgboxCallOnLine, findMsgboxCallAt,
     stateFromSelection, flagsFromState, validateBbjExpression, expressionDisplayText, buttonLabels,
     splitButtonsAndTrailing, DEFAULT_STATE, resolvesToString, validateStringField, quoteAsStringLiteral,
+    msgboxPreview,
 } from '../src/msgbox-composer';
 
 describe('MSGBOX composer logic (#426)', () => {
@@ -120,6 +121,27 @@ describe('MSGBOX composer logic (#426)', () => {
 
         // structural errors still win over the typing check
         expect(validateStringField('"TEST').ok).toBe(false); // unterminated literal
+    });
+
+    test('msgboxPreview aggregates encode + compose + validate + render for a UI', () => {
+        const p = msgboxPreview({
+            message: '"Are you sure?"', title: '"Confirm"', assignTo: 'ret!',
+            buttonSet: 4, icon: 32, defaultButton: 256, flags: [65536], customButtons: [],
+        });
+        expect(p.expr).toBe(4 + 32 + 256 + 65536);
+        expect(p.statement).toBe('ret! = MSGBOX("Are you sure?", 65828, "Confirm")');
+        expect(p.summary).toContain('Yes, No');
+        expect(p.valid).toBe(true);
+        expect(p.render).toEqual({ title: 'Confirm', message: 'Are you sure?', icon: 32, buttons: ['Yes', 'No'], defaultIndex: 1 });
+    });
+
+    test('msgboxPreview surfaces a bare-string error and drops the assignment in edit mode', () => {
+        const bad = msgboxPreview({ message: 'Caption', title: '', buttonSet: 0, icon: 0, defaultButton: 0, flags: [], customButtons: [] });
+        expect(bad.valid).toBe(false);
+        expect(bad.messageError).toContain('"Caption"');
+
+        const edit = msgboxPreview({ message: '"Hi"', title: '', assignTo: 'ret!', editMode: true, buttonSet: 0, icon: 0, defaultButton: 0, flags: [], customButtons: [] });
+        expect(edit.statement).toBe('MSGBOX("Hi")'); // no `ret! =` prefix in edit mode
     });
 
     test('expressionDisplayText unquotes string literals, passes expressions through', () => {

--- a/bbj-vscode/test/msgbox-composer.test.ts
+++ b/bbj-vscode/test/msgbox-composer.test.ts
@@ -3,7 +3,7 @@ import {
     encode, decode, describe as describeExpr, composeStatement, parseMsgboxCallOnLine, findMsgboxCallAt,
     stateFromSelection, flagsFromState, validateBbjExpression, expressionDisplayText, buttonLabels,
     splitButtonsAndTrailing, DEFAULT_STATE, resolvesToString, validateStringField, quoteAsStringLiteral,
-    msgboxPreview,
+    msgboxPreview, msgboxConstantsExpr,
 } from '../src/msgbox-composer';
 
 describe('MSGBOX composer logic (#426)', () => {
@@ -133,6 +133,28 @@ describe('MSGBOX composer logic (#426)', () => {
         expect(p.summary).toContain('Yes, No');
         expect(p.valid).toBe(true);
         expect(p.render).toEqual({ title: 'Confirm', message: 'Are you sure?', icon: 32, buttons: ['Yes', 'No'], defaultIndex: 1 });
+    });
+
+    test('msgboxConstantsExpr renders the readable BBjMsgBox.* form', () => {
+        // Yes/No + Question + Second-button (the example from the issue)
+        expect(msgboxConstantsExpr(stateFromSelection({ buttonSet: 1, icon: 32, defaultButton: 256 })))
+            .toBe('BBjMsgBox.MSGBOX_BUTTONS_OK_CANCEL+BBjMsgBox.MSGBOX_ICON_QUESTION+BBjMsgBox.MSGBOX_DEFAULT_SECOND');
+        // Plain OK -> just the base button constant (icon None / default First are omitted)
+        expect(msgboxConstantsExpr(stateFromSelection({}))).toBe('BBjMsgBox.MSGBOX_BUTTONS_OK');
+        // Flags map to their constants too
+        expect(msgboxConstantsExpr(stateFromSelection({ buttonSet: 4, flags: [32768, 131072] })))
+            .toBe('BBjMsgBox.MSGBOX_BUTTONS_YES_NO+BBjMsgBox.MSGBOX_RAW_TEXT+BBjMsgBox.MSGBOX_MDI_DESKTOP');
+    });
+
+    test('msgboxPreview emits the constants form when useConstants is set', () => {
+        const numeric = msgboxPreview({ message: '"test"', title: '"Title String"', buttonSet: 1, icon: 32, defaultButton: 256, flags: [], customButtons: [] });
+        expect(numeric.statement).toBe('MSGBOX("test", 289, "Title String")');
+        expect(numeric.exprText).toBeUndefined();
+
+        const constants = msgboxPreview({ message: '"test"', title: '"Title String"', buttonSet: 1, icon: 32, defaultButton: 256, flags: [], customButtons: [], useConstants: true });
+        expect(constants.exprText).toBe('BBjMsgBox.MSGBOX_BUTTONS_OK_CANCEL+BBjMsgBox.MSGBOX_ICON_QUESTION+BBjMsgBox.MSGBOX_DEFAULT_SECOND');
+        expect(constants.statement).toBe('MSGBOX("test", BBjMsgBox.MSGBOX_BUTTONS_OK_CANCEL+BBjMsgBox.MSGBOX_ICON_QUESTION+BBjMsgBox.MSGBOX_DEFAULT_SECOND, "Title String")');
+        expect(constants.expr).toBe(289); // numeric value still reported for the summary
     });
 
     test('msgboxPreview surfaces a bare-string error and drops the assignment in edit mode', () => {


### PR DESCRIPTION
Brings both visual composers to the **IntelliJ** plugin (#433), driving the **same** flag/hex arithmetic as the VS Code webviews through the language server — no domain logic ported to Java. UI is **native Swing**, per the chosen approach.

## TS / language server — single source of truth

- Added pure `msgboxPreview()` / `addwindowPreview()` to the composer modules: the full UI payload (statement + validation + render/schematic) computed in one place.
- **Both VS Code webviews now delegate** their `build()` to these functions — removing duplicated assembly; behaviour unchanged and covered by the existing tests.
- The LS exposes them as aggregate requests `bbj/composer/msgbox/preview` and `bbj/composer/addwindow/preview`, so a client renders a full preview with **one round-trip per change** (keeps the Swing code simple and robust).
- Fixed a latent incoherence the sharing surfaced: the addWindow **statement** now includes preserved (undocumented) bits, matching `flagsHex` (previously only the applied hex token carried them).

## IntelliJ (`bbj-intellij`, native Swing)

- **`BbjComposerServer`** — the `LanguageServer` proxy extended with `@JsonRequest("bbj/composer/*")` methods; registered via `BbjLanguageServerFactory.getServerInterface()`. **`BbjComposerService`** resolves the proxy through LSP4IJ's `LanguageServerManager`.
- **`MsgboxComposerDialog`** — icon/button/default combos + flag checkboxes + message/title fields with live, server-driven validation gating the **Insert** button.
- **`AddWindowComposerDialog`** — grouped flag checkboxes, an opt-in event-mask section, and a custom-painted **`WindowSchematicPanel`** driven entirely by the LS render descriptor (title bar/none, close & min/max, menu bar, scrollbars, border, disabled/invisible/min/maximized, badges).
- Both are **create-flow** actions on the editor popup menu, inserting the composed statement at the caret via `WriteCommandAction`.

## Verification

- **54** TS composer tests pass; full VS Code build (`tsc` + `esbuild`) green; ESLint clean.
- IntelliJ **`compileJava`** and **`verifyPluginProjectConfiguration`** pass (offline).
- ⚠️ **Not validated in this environment:** the IntelliJ UI at runtime — dialog rendering, the LSP round-trip returning data, schematic painting, and caret insertion. These need a running IntelliJ IDE; please smoke-test from a `runIde`/sandbox build.

## Scope / follow-ups

- **Create-flow only.** Edit-in-place intentions (decode an existing `MSGBOX(...)` / `addWindow(...)` and reconfigure it — the IntelliJ analogue of the VS Code Code Actions) are a follow-up; the `bbj/composer/*/parseLine` requests to support them already exist.
- Optionally retire the VS Code webviews' direct module imports in favour of the same LS `preview` requests, fully unifying both clients.

Closes #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)