### PR TITLE
Validation: missing methodret (#372), CASE outside SWITCH (#206), BBj word separators (#112)

### DIFF
--- a/bbj-vscode/bbj-language-configuration.json
+++ b/bbj-vscode/bbj-language-configuration.json
@@ -2,6 +2,7 @@
     "comments": {
         "lineComment": "REM"
     },
+    "wordPattern": "(-?\\d*\\.\\d\\w*)|(#?[A-Za-z_][A-Za-z0-9_]*[!$%@]?)",
     "brackets": [
         [
             "{",

--- a/bbj-vscode/bbx-language-configuration.json
+++ b/bbj-vscode/bbx-language-configuration.json
@@ -2,6 +2,7 @@
     "comments": {
         "lineComment": "#"
     },
+    "wordPattern": "(-?\\d*\\.\\d\\w*)|(#?[A-Za-z_][A-Za-z0-9_]*[!$%@]?)",
     "brackets": [
         [
             "{",

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -570,6 +570,9 @@
       "files.associations": {
         "config.bbx": "plaintext",
         "config.min": "plaintext"
+      },
+      "[bbj]": {
+        "editor.wordSeparators": "`~^&*()-=+[{]}\\|;:'\",.<>/?"
       }
     }
   },

--- a/bbj-vscode/src/language/bbj-validator.ts
+++ b/bbj-vscode/src/language/bbj-validator.ts
@@ -8,7 +8,7 @@ import { AstNode, AstUtils, CompositeCstNode, CstNode, DiagnosticInfo, IndexMana
 import { basename, dirname, isAbsolute, normalize, relative, resolve } from 'path';
 import type { BBjServices } from './bbj-module.js';
 import { TypeInferer } from './bbj-type-inferer.js';
-import { BBjAstType, BbjClass, BeginStatement, CastExpression, Class, CommentStatement, DefFunction, EraseStatement, FieldDecl, InitFileStatement, JavaField, JavaMethod, KeyedFileStatement, LabelDecl, MemberCall, MethodDecl, OpenStatement, Option, SymbolicLabelRef, Use, VariableDecl, isArrayElement, isBBjClassMember, isBBjTypeRef, isBbjClass, isClass, isKeywordStatement, isLabelDecl, isOption, isSimpleTypeRef, isSymbolRef } from './generated/ast.js';
+import { BBjAstType, BbjClass, BeginStatement, CastExpression, Class, CommentStatement, DefFunction, EraseStatement, FieldDecl, InitFileStatement, JavaField, JavaMethod, KeyedFileStatement, LabelDecl, MemberCall, MethodDecl, OpenStatement, Option, SwitchCase, SymbolicLabelRef, Use, VariableDecl, isArrayElement, isBBjClassMember, isBBjTypeRef, isBbjClass, isClass, isCompoundStatement, isKeywordStatement, isLabelDecl, isOption, isSimpleTypeRef, isSwitchStatement, isSymbolRef } from './generated/ast.js';
 import { JavaInteropService } from './java-interop.js';
 import { BBjPathPattern } from './bbj-scope.js';
 import { BBjWorkspaceManager } from './bbj-ws-manager.js';
@@ -50,6 +50,7 @@ export function registerValidationChecks(services: BBjServices) {
 
         BeginStatement: validator.checkExceptClause,
         VariableDecl: validator.checkDeclareNotInClassBody,
+        SwitchCase: validator.checkSwitchCaseInSwitch,
     };
     registry.register(checks, validator);
     registerClassChecks(registry);
@@ -73,6 +74,64 @@ export class BBjValidator {
                 node: except
             });
         }
+    }
+
+    /**
+     * `CASE`/`CASE DEFAULT` is only valid inside a `SWITCH`...`SWEND` block. SWITCH, CASE and
+     * SWEND are modeled as flat sibling statements, so a stray CASE parses without error. Scan the
+     * preceding siblings, matching each SWEND to an inner SWITCH; if an unmatched open SWITCH is
+     * found, the CASE is enclosed and valid. See issue #206.
+     */
+    checkSwitchCaseInSwitch(node: SwitchCase, accept: ValidationAcceptor): void {
+        // LabelDecl is a subtype of SwitchCase (the grammar rule starts with an optional label),
+        // so this check also fires on plain labels — only real CASE nodes are relevant here.
+        if (node.$type !== 'SwitchCase') return;
+
+        // SWITCH, CASE and SWEND are flat sibling statements within a block (Program / method /
+        // DEF function body). A one-line `SWITCH x; CASE 1; ... SWEND` nests them one level deep
+        // inside a CompoundStatement, so resolve the enclosing block and flatten compounds to get
+        // the switch markers in document order.
+        let block: AstNode = node.$container;
+        let blockProperty = node.$containerProperty;
+        if (isCompoundStatement(block)) {
+            blockProperty = block.$containerProperty;
+            block = block.$container;
+        }
+        const statements = blockProperty ? (block as unknown as Record<string, unknown>)[blockProperty] : undefined;
+        if (!Array.isArray(statements)) {
+            return;
+        }
+        const flat: AstNode[] = [];
+        for (const statement of statements) {
+            if (isCompoundStatement(statement)) {
+                flat.push(...statement.statements);
+            } else {
+                flat.push(statement);
+            }
+        }
+        const index = flat.indexOf(node);
+        if (index < 0) {
+            return;
+        }
+        let pendingSwends = 0;
+        for (let i = index - 1; i >= 0; i--) {
+            const sibling = flat[i];
+            if (isSwitchStatement(sibling)) {
+                if (sibling.end) {
+                    // A SWEND closes an inner SWITCH nested below this CASE.
+                    pendingSwends++;
+                } else if (pendingSwends > 0) {
+                    // This SWITCH opens the inner block closed above.
+                    pendingSwends--;
+                } else {
+                    // An unmatched open SWITCH encloses this CASE: it is valid.
+                    return;
+                }
+            }
+        }
+        accept('error', `'${node.default ? 'CASE DEFAULT' : 'CASE'}' is only allowed inside a SWITCH block.`, {
+            node
+        });
     }
 
     checkDeclareNotInClassBody(node: VariableDecl, accept: ValidationAcceptor): void {

--- a/bbj-vscode/src/language/validations/check-classes.ts
+++ b/bbj-vscode/src/language/validations/check-classes.ts
@@ -1,7 +1,7 @@
 import { AstNode, AstUtils, DiagnosticInfo, ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
 import { basename, dirname, isAbsolute, relative } from 'path';
 import { getClass, getClassRef } from '../bbj-nodedescription-provider.js';
-import { BBjAstType, BbjClass, isBbjClass, isMethodReturnStatement, MethodDecl, QualifiedClass } from '../generated/ast.js';
+import { BBjAstType, BbjClass, isBbjClass, isMethodReturnStatement, isNumberLiteral, isStringLiteral, MethodDecl, QualifiedClass } from '../generated/ast.js';
 
 export function registerClassChecks(registry: ValidationRegistry) {
     const validator = new ClassValidator();
@@ -129,24 +129,74 @@ class ClassValidator {
         }
     }
 
+    // BBj scalar return types whose value kind can be checked against returned literals without
+    // needing type resolution. Names are compared case-insensitively (BBj is case-insensitive).
+    private static readonly STRING_RETURN_TYPES = new Set(['bbjstring']);
+    private static readonly NUMERIC_RETURN_TYPES = new Set(['bbjnumber']);
+
     /**
-     * A method that declares a non-void return type must return a value via `METHODRET <expr>`.
-     * Interface methods (no body, hence no `endTag`) share the rule but are declared elsewhere,
-     * so they are excluded here. See issue #372.
+     * Two related checks on a method that declares a non-void return type and has a body.
+     * Interface methods (no body, hence no `endTag`) are declared elsewhere and excluded.
+     * See issues #372 (missing METHODRET) and the return-type follow-up.
      */
     public checkMethodReturn(meth: MethodDecl, accept: ValidationAcceptor): void {
         // Only methods with an explicit non-void return type and a body need to return a value.
         if (meth.voidReturn || !meth.returnType || !meth.endTag) {
             return;
         }
-        const returnsValue = AstUtils.streamAllContents(meth)
-            .some(node => isMethodReturnStatement(node) && node.return !== undefined);
-        if (!returnsValue) {
+        const valueReturns = AstUtils.streamAllContents(meth)
+            .filter(isMethodReturnStatement)
+            .filter(ret => ret.return !== undefined)
+            .toArray();
+
+        // #372: a non-void method with no value-returning METHODRET is an error.
+        if (valueReturns.length === 0) {
             accept('error', `Method '${meth.name}' declares a return type but has no METHODRET returning a value.`, {
                 node: meth,
                 property: 'name'
             });
+            return;
         }
+
+        // Return-type check (conservative): for the well-known BBj scalar return types we can flag a
+        // returned literal whose kind plainly contradicts the declaration, without resolving types.
+        // Array return types and all other/unresolved types are left untouched to avoid false
+        // positives on BBj's loose typing.
+        if (meth.array) {
+            return;
+        }
+        const typeName = this.returnTypeName(meth.returnType);
+        if (!typeName) {
+            return;
+        }
+        const expectsNumber = ClassValidator.NUMERIC_RETURN_TYPES.has(typeName.toLowerCase());
+        const expectsString = ClassValidator.STRING_RETURN_TYPES.has(typeName.toLowerCase());
+        if (!expectsNumber && !expectsString) {
+            return;
+        }
+        for (const ret of valueReturns) {
+            const value = ret.return!;
+            if (expectsNumber && isStringLiteral(value)) {
+                accept('error', `Method '${meth.name}' declares return type '${typeName}' but returns a string.`, {
+                    node: ret,
+                    property: 'return'
+                });
+            } else if (expectsString && isNumberLiteral(value)) {
+                accept('error', `Method '${meth.name}' declares return type '${typeName}' but returns a number.`, {
+                    node: ret,
+                    property: 'return'
+                });
+            }
+        }
+    }
+
+    /** Simple (unqualified) name of a declared return type, taken from its source text. */
+    private returnTypeName(returnType: QualifiedClass): string | undefined {
+        const text = returnType.$cstNode?.text?.trim();
+        if (!text) {
+            return undefined;
+        }
+        return text.substring(text.lastIndexOf('.') + 1);
     }
 
     public checkCyclicInheritance(klass: BbjClass, accept: ValidationAcceptor): void {

--- a/bbj-vscode/src/language/validations/check-classes.ts
+++ b/bbj-vscode/src/language/validations/check-classes.ts
@@ -1,7 +1,7 @@
 import { AstNode, AstUtils, DiagnosticInfo, ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
 import { basename, dirname, isAbsolute, relative } from 'path';
 import { getClass, getClassRef } from '../bbj-nodedescription-provider.js';
-import { BBjAstType, BbjClass, isBbjClass, QualifiedClass } from '../generated/ast.js';
+import { BBjAstType, BbjClass, isBbjClass, isMethodReturnStatement, MethodDecl, QualifiedClass } from '../generated/ast.js';
 
 export function registerClassChecks(registry: ValidationRegistry) {
     const validator = new ClassValidator();
@@ -52,10 +52,13 @@ export function registerClassChecks(registry: ValidationRegistry) {
             node: call,
             property: 'klass'
         }),
-        MethodDecl: (meth, accept) => validator.checkClassReference(accept, meth.returnType, {
-            node: meth,
-            property: 'returnType'
-        }),
+        MethodDecl: (meth, accept) => {
+            validator.checkClassReference(accept, meth.returnType, {
+                node: meth,
+                property: 'returnType'
+            });
+            validator.checkMethodReturn(meth, accept);
+        },
         ParameterDecl: (param, accept) => validator.checkClassReference(accept, param.type, {
             node: param,
             property: 'type'
@@ -123,6 +126,26 @@ class ClassValidator {
                     accept("error", `Private ${typeName} '${klass.name}' (declared in ${sourceInfo}) is not visible from this file.`, info);
                 }
                 break;
+        }
+    }
+
+    /**
+     * A method that declares a non-void return type must return a value via `METHODRET <expr>`.
+     * Interface methods (no body, hence no `endTag`) share the rule but are declared elsewhere,
+     * so they are excluded here. See issue #372.
+     */
+    public checkMethodReturn(meth: MethodDecl, accept: ValidationAcceptor): void {
+        // Only methods with an explicit non-void return type and a body need to return a value.
+        if (meth.voidReturn || !meth.returnType || !meth.endTag) {
+            return;
+        }
+        const returnsValue = AstUtils.streamAllContents(meth)
+            .some(node => isMethodReturnStatement(node) && node.return !== undefined);
+        if (!returnsValue) {
+            accept('error', `Method '${meth.name}' declares a return type but has no METHODRET returning a value.`, {
+                node: meth,
+                property: 'name'
+            });
         }
     }
 

--- a/bbj-vscode/src/language/validations/check-classes.ts
+++ b/bbj-vscode/src/language/validations/check-classes.ts
@@ -135,19 +135,37 @@ class ClassValidator {
     private static readonly NUMERIC_RETURN_TYPES = new Set(['bbjnumber']);
 
     /**
-     * Two related checks on a method that declares a non-void return type and has a body.
-     * Interface methods (no body, hence no `endTag`) are declared elsewhere and excluded.
-     * See issues #372 (missing METHODRET) and the return-type follow-up.
+     * Checks on a method's METHODRET statements against its declared return type. Interface methods
+     * (no body, hence no `endTag`) are declared elsewhere and excluded. Covers:
+     *  - void method must not return a value;
+     *  - non-void method with a body must return a value (issue #372);
+     *  - a returned literal whose kind contradicts a BBj scalar return type or a resolvable class.
+     * Java-class and unresolved return types are checked only where it is safe without full
+     * java-interop-backed type inference, to avoid false positives on BBj's loose typing.
      */
     public checkMethodReturn(meth: MethodDecl, accept: ValidationAcceptor): void {
-        // Only methods with an explicit non-void return type and a body need to return a value.
-        if (meth.voidReturn || !meth.returnType || !meth.endTag) {
-            return;
+        if (!meth.endTag) {
+            return; // no body (interface method) — nothing to check
         }
         const valueReturns = AstUtils.streamAllContents(meth)
             .filter(isMethodReturnStatement)
             .filter(ret => ret.return !== undefined)
             .toArray();
+
+        // A void method must not return a value.
+        if (meth.voidReturn) {
+            for (const ret of valueReturns) {
+                accept('error', `Method '${meth.name}' is declared void and must not return a value.`, {
+                    node: ret,
+                    property: 'return'
+                });
+            }
+            return;
+        }
+
+        if (!meth.returnType) {
+            return; // neither void nor an explicit return type — nothing required
+        }
 
         // #372: a non-void method with no value-returning METHODRET is an error.
         if (valueReturns.length === 0) {
@@ -158,10 +176,7 @@ class ClassValidator {
             return;
         }
 
-        // Return-type check (conservative): for the well-known BBj scalar return types we can flag a
-        // returned literal whose kind plainly contradicts the declaration, without resolving types.
-        // Array return types and all other/unresolved types are left untouched to avoid false
-        // positives on BBj's loose typing.
+        // Conservative return-type check on returned literals. Array return types are skipped.
         if (meth.array) {
             return;
         }
@@ -169,20 +184,23 @@ class ClassValidator {
         if (!typeName) {
             return;
         }
-        const expectsNumber = ClassValidator.NUMERIC_RETURN_TYPES.has(typeName.toLowerCase());
-        const expectsString = ClassValidator.STRING_RETURN_TYPES.has(typeName.toLowerCase());
-        if (!expectsNumber && !expectsString) {
-            return;
-        }
+        const lower = typeName.toLowerCase();
+        const expectsNumber = ClassValidator.NUMERIC_RETURN_TYPES.has(lower);
+        const expectsString = ClassValidator.STRING_RETURN_TYPES.has(lower);
+        // A literal is never an instance of a user-defined BBj class/interface, so any literal
+        // returned for a resolvable BBj class is a mismatch.
+        const declaredBBjClass = !expectsNumber && !expectsString && isBbjClass(getClass(meth.returnType));
+
         for (const ret of valueReturns) {
             const value = ret.return!;
-            if (expectsNumber && isStringLiteral(value)) {
-                accept('error', `Method '${meth.name}' declares return type '${typeName}' but returns a string.`, {
-                    node: ret,
-                    property: 'return'
-                });
-            } else if (expectsString && isNumberLiteral(value)) {
-                accept('error', `Method '${meth.name}' declares return type '${typeName}' but returns a number.`, {
+            const returnsString = isStringLiteral(value);
+            const returnsNumber = isNumberLiteral(value);
+            if (!returnsString && !returnsNumber) {
+                continue; // non-literal: needs deeper type inference, left untouched
+            }
+            const returnedKind = returnsString ? 'string' : 'number';
+            if ((expectsNumber && returnsString) || (expectsString && returnsNumber) || declaredBBjClass) {
+                accept('error', `Method '${meth.name}' declares return type '${typeName}' but returns a ${returnedKind}.`, {
                     node: ret,
                     property: 'return'
                 });

--- a/bbj-vscode/test/classes.test.ts
+++ b/bbj-vscode/test/classes.test.ts
@@ -524,4 +524,78 @@ describe("Cyclic inheritance detection", () => {
         const returnErrors = diagnostics.filter(d => d.message.includes('METHODRET'));
         expect(returnErrors).toHaveLength(0);
     });
+
+    // Issue #372 follow-up: returned literal kind must not contradict a BBj scalar return type.
+    test("Flags string literal returned from a BBjNumber method", async () => {
+        const { diagnostics } = await validate(`
+            class public ClassA
+                method public BBjNumber getB()
+                    methodret "2"
+                methodend
+            classend
+        `);
+        const typeErrors = diagnostics.filter(d => d.message.includes("but returns a string"));
+        expect(typeErrors).toHaveLength(1);
+        expect(typeErrors[0].message).toContain("'BBjNumber'");
+    });
+
+    test("Flags number literal returned from a BBjString method", async () => {
+        const { diagnostics } = await validate(`
+            class public ClassA
+                method public BBjString getA()
+                    methodret 42
+                methodend
+            classend
+        `);
+        const typeErrors = diagnostics.filter(d => d.message.includes("but returns a number"));
+        expect(typeErrors).toHaveLength(1);
+        expect(typeErrors[0].message).toContain("'BBjString'");
+    });
+
+    test("No type-mismatch error when literal matches scalar return type", async () => {
+        const { diagnostics } = await validate(`
+            class public ClassA
+                method public BBjNumber getB()
+                    methodret 2
+                methodend
+                method public BBjString getA()
+                    methodret "hello"
+                methodend
+            classend
+        `);
+        const typeErrors = diagnostics.filter(d => d.message.includes('but returns a'));
+        expect(typeErrors).toHaveLength(0);
+    });
+
+    test("No type-mismatch error for non-literal returns (avoids false positives)", async () => {
+        const { diagnostics } = await validate(`
+            class public ClassA
+                method public BBjNumber getB()
+                    declare BBjNumber n!
+                    methodret n!
+                methodend
+            classend
+        `);
+        const typeErrors = diagnostics.filter(d => d.message.includes('but returns a'));
+        expect(typeErrors).toHaveLength(0);
+    });
+
+    // Combined: the issue's original example — two non-void methods missing METHODRET, one void ok.
+    test("Issue #372 example: two missing-METHODRET errors, void method unaffected", async () => {
+        const { diagnostics } = await validate(`
+            class public ClassA
+                method public BBjString getA()
+                methodend
+                method public BBjNumber getB()
+                    methodret "2"
+                methodend
+                method public void doSomething()
+                methodend
+            classend
+        `);
+        const missing = diagnostics.filter(d => d.message.includes('has no METHODRET'));
+        const mismatched = diagnostics.filter(d => d.message.includes('but returns a string'));
+        expect(missing).toHaveLength(1);   // getA has no methodret
+        expect(mismatched).toHaveLength(1); // getB returns "2" for a BBjNumber
+    });
 });

--- a/bbj-vscode/test/classes.test.ts
+++ b/bbj-vscode/test/classes.test.ts
@@ -474,4 +474,54 @@ describe("Cyclic inheritance detection", () => {
         const cyclicErrors = diagnostics.filter(d => d.message.toLowerCase().includes('cyclic'));
         expect(cyclicErrors).toHaveLength(0);
     });
+
+    // Issue #372: a non-void method must return a value via METHODRET.
+    test("Flags non-void method missing METHODRET", async () => {
+        const { diagnostics } = await validate(`
+            class public ClassA
+                method public BBjString getA()
+                methodend
+                method public BBjNumber getB()
+                methodend
+                method public void doSomething()
+                methodend
+            classend
+        `);
+        const returnErrors = diagnostics.filter(d => d.message.includes('METHODRET'));
+        expect(returnErrors).toHaveLength(2);
+        expect(returnErrors.every(d => d.severity === 1 /* Error */)).toBe(true);
+    });
+
+    test("No METHODRET error when method returns a value", async () => {
+        const { diagnostics } = await validate(`
+            class public ClassA
+                method public BBjNumber getB()
+                    methodret 42
+                methodend
+            classend
+        `);
+        const returnErrors = diagnostics.filter(d => d.message.includes('METHODRET'));
+        expect(returnErrors).toHaveLength(0);
+    });
+
+    test("No METHODRET error for void method", async () => {
+        const { diagnostics } = await validate(`
+            class public ClassA
+                method public void doSomething()
+                methodend
+            classend
+        `);
+        const returnErrors = diagnostics.filter(d => d.message.includes('METHODRET'));
+        expect(returnErrors).toHaveLength(0);
+    });
+
+    test("No METHODRET error for interface methods (no body)", async () => {
+        const { diagnostics } = await validate(`
+            interface public MyInterface
+                method public BBjString getName()
+            interfaceend
+        `);
+        const returnErrors = diagnostics.filter(d => d.message.includes('METHODRET'));
+        expect(returnErrors).toHaveLength(0);
+    });
 });

--- a/bbj-vscode/test/classes.test.ts
+++ b/bbj-vscode/test/classes.test.ts
@@ -598,4 +598,58 @@ describe("Cyclic inheritance detection", () => {
         expect(missing).toHaveLength(1);   // getA has no methodret
         expect(mismatched).toHaveLength(1); // getB returns "2" for a BBjNumber
     });
+
+    // A void method must not return a value.
+    test("Flags value returned from a void method", async () => {
+        const { diagnostics } = await validate(`
+            class public ClassA
+                method public void TTT1()
+                    methodret ""
+                methodend
+            classend
+        `);
+        const voidErrors = diagnostics.filter(d => d.message.includes('declared void and must not return a value'));
+        expect(voidErrors).toHaveLength(1);
+    });
+
+    test("Bare methodret (no value) is valid in a void method", async () => {
+        const { diagnostics } = await validate(`
+            class public ClassA
+                method public void doWork()
+                    methodret
+                methodend
+            classend
+        `);
+        const returnErrors = diagnostics.filter(d => d.message.toLowerCase().includes('return'));
+        expect(returnErrors).toHaveLength(0);
+    });
+
+    // A literal is never an instance of a user-defined BBj class.
+    test("Flags literal returned where a BBj class type is declared", async () => {
+        const { diagnostics } = await validate(`
+            class public Foo
+            classend
+            class public ClassA
+                method public Foo getFoo()
+                    methodret ""
+                methodend
+            classend
+        `);
+        const typeErrors = diagnostics.filter(d => d.message.includes("declares return type 'Foo' but returns a string"));
+        expect(typeErrors).toHaveLength(1);
+    });
+
+    test("No error returning an instance for a BBj class type", async () => {
+        const { diagnostics } = await validate(`
+            class public Foo
+            classend
+            class public ClassA
+                method public Foo getFoo()
+                    methodret new Foo()
+                methodend
+            classend
+        `);
+        const typeErrors = diagnostics.filter(d => d.message.includes('but returns a'));
+        expect(typeErrors).toHaveLength(0);
+    });
 });

--- a/bbj-vscode/test/document-symbol.test.ts
+++ b/bbj-vscode/test/document-symbol.test.ts
@@ -63,6 +63,7 @@ describe('DocumentSymbol Tests', async () => {
                     mySales = remmedOutStuff!
                     remainingSeconds = 18
                     print "Seconds: ", remainingSeconds
+                    methodret ""
                 methodend
             classend
 

--- a/bbj-vscode/test/parser.test.ts
+++ b/bbj-vscode/test/parser.test.ts
@@ -605,8 +605,9 @@ describe('Parser Tests', () => {
         CLASS public MyClass
 
             METHOD public MyClass open()
+                METHODRET new MyClass()
             METHODEND
-      
+
         classend
         `, { validation: true });
         expectNoParserLexerErrors(result);

--- a/bbj-vscode/test/validation.test.ts
+++ b/bbj-vscode/test/validation.test.ts
@@ -583,6 +583,84 @@ describe('BBj validation', async () => {
         `, { validation: true });
         expectError(result, "'0' must be symbol reference or array access with ALL", {});
     });
+
+    // Issue #206: CASE is only allowed inside a SWITCH ... SWEND block.
+    test('CASE inside SWITCH is valid (multi-line)', async () => {
+        const result = await validate(`
+        LVL = 3
+        SWITCH LVL
+            CASE 0
+            CASE 1; PRINT "Easy"; BREAK
+            CASE DEFAULT; PRINT "Hard"; BREAK
+        SWEND
+        `, { validation: true });
+        const caseErrors = result.diagnostics.filter(d => d.message.includes('only allowed inside a SWITCH'));
+        expect(caseErrors).toHaveLength(0);
+    });
+
+    test('CASE inside SWITCH is valid (single line)', async () => {
+        const result = await validate(`
+        LET t = 123
+        SWITCH t; CASE 1; PRINT "1"; BREAK; CASE DEFAULT; PRINT "default"; SWEND
+        `, { validation: true });
+        const caseErrors = result.diagnostics.filter(d => d.message.includes('only allowed inside a SWITCH'));
+        expect(caseErrors).toHaveLength(0);
+    });
+
+    test('CASE outside SWITCH is flagged', async () => {
+        const result = await validate(`
+        CASE 1
+        `, { validation: true });
+        expectError(result, "'CASE' is only allowed inside a SWITCH block.", {});
+    });
+
+    test('CASE after SWEND (switch already closed) is flagged', async () => {
+        const result = await validate(`
+        SWITCH x
+            CASE 1; BREAK
+        SWEND
+        CASE 2
+        `, { validation: true });
+        const caseErrors = result.diagnostics.filter(d => d.message.includes('only allowed inside a SWITCH'));
+        expect(caseErrors).toHaveLength(1);
+        expect(caseErrors[0].message).toBe("'CASE' is only allowed inside a SWITCH block.");
+    });
+
+    test('CASE DEFAULT outside SWITCH is flagged', async () => {
+        const result = await validate(`
+        CASE DEFAULT
+        `, { validation: true });
+        expectError(result, "'CASE DEFAULT' is only allowed inside a SWITCH block.", {});
+    });
+
+    test('CASE inside SWITCH within a method body is valid', async () => {
+        const result = await validate(`
+        class public Foo
+            method public void bar(BBjNumber n!)
+                SWITCH n!
+                    CASE 1; BREAK
+                    CASE DEFAULT; BREAK
+                SWEND
+            methodend
+        classend
+        `, { validation: true });
+        const caseErrors = result.diagnostics.filter(d => d.message.includes('only allowed inside a SWITCH'));
+        expect(caseErrors).toHaveLength(0);
+    });
+
+    test('Nested SWITCH blocks resolve CASE correctly', async () => {
+        const result = await validate(`
+        SWITCH a
+            CASE 1
+                SWITCH b
+                    CASE 2; BREAK
+                SWEND
+                CASE 3; BREAK
+        SWEND
+        `, { validation: true });
+        const caseErrors = result.diagnostics.filter(d => d.message.includes('only allowed inside a SWITCH'));
+        expect(caseErrors).toHaveLength(0);
+    });
 });
 
 export function findAll<T extends AstNode = AstNode>(document: LangiumDocument, filter: (item: unknown) => item is T, streamAll: boolean = false): T[] {


### PR DESCRIPTION
Implements three `actionable` issues.

## #372 — METHODRET / return-value validation
Added `checkMethodReturn` to the `MethodDecl` check in `check-classes.ts`. Covers, without requiring java-interop:

1. **Missing METHODRET (the issue):** a non-void method with a body but no value-returning `METHODRET` is an error.
2. **Void method returning a value:** `method public void f() ... methodret ""` is an error (a bare `methodret` with no value stays valid).
3. **Return-type mismatch on literals:**
   - a returned literal contradicting a BBj scalar type — `BBjNumber` with `methodret "2"`, or `BBjString` with `methodret 42`;
   - any literal returned where the declared type resolves to a user-defined BBj class/interface (a literal is never a class instance).

```
Method 'getA' declares a return type but has no METHODRET returning a value.
Method 'TTT1' is declared void and must not return a value.
Method 'getB' declares return type 'BBjNumber' but returns a string.
```

**Deliberately conservative** to avoid false positives on BBj's loose typing: it only reasons about returned *literals* and about types it can identify safely. Two cases are **not** covered here and are better as a focused follow-up because they need reliable java-interop-backed type inference (BBj-scalar↔Java mapping, class-hierarchy assignability, coercion rules):
- a literal/expression returned against an arbitrary **Java** class return type (e.g. `java.util.HashMap`);
- flagging an **unresolvable** return-type identifier (e.g. `SomeInvalidType`) — which really belongs to a broader "validate all type references resolve" check spanning params/fields/variables too.

Reasoning behind the split: the type inferer maps string literals to `java.lang.String` (not `BBjString`), has no numeric-literal handling, and BBj scalars have no Java mapping — so a naive resolve-both-and-compare would both miss the scalar case and false-positive on legal scalar returns.

## #206 — `CASE` only allowed inside `SWITCH`
`SWITCH`/`CASE`/`SWEND` are modeled as flat sibling statements, so a stray `CASE` parsed with no diagnostic. Added `checkSwitchCaseInSwitch` (on `SwitchCase`) in `bbj-validator.ts`: it resolves the enclosing block, flattens one-line `CompoundStatement`s (`SWITCH x; CASE 1; ... SWEND`) into document order, and bracket-matches `SWEND`→`SWITCH` backward from the `CASE`. Nested switches resolve correctly; a `CASE`/`CASE DEFAULT` with no enclosing open `SWITCH` errors.

> Note: `LabelDecl` is an AST subtype of `SwitchCase` (the rule starts with `LabelDecl?`), so the check guards on `node.$type !== 'SwitchCase'` to avoid firing on every label — same pattern as `checkDeclareNotInClassBody`.

## #112 — remove `#`/`!` from word separators
The real fix for double-click selection is `editor.wordSeparators`, **not** `wordPattern` — per the [Language Configuration guide](https://code.visualstudio.com/api/language-extensions/language-configuration-guide) ("this setting won't affect word-related editor commands, which are controlled by the editor setting `editor.wordSeparators`") and [microsoft/vscode#64769](https://github.com/microsoft/vscode/issues/64769). Added a `[bbj]`-scoped `configurationDefaults` in `package.json` removing `#`, `!`, `$`, `%`, `@` from the default separators, so identifiers like `myVar!`, `name$`, `count%`, `#field`, `obj@` are selected whole on double-click. The `wordPattern` added to `bbj/bbx-language-configuration.json` is retained — it still improves word boundaries for code-suggestion features (and the bbx file is consumed by the IntelliJ TextMate bundle).

> Requires reloading the window / reinstalling the extension for the new default to apply.

## Tests
- New: 13 tests for #372 (`classes.test.ts`), 7 for #206 (`validation.test.ts`), covering the review examples (`methodret "2"`, void `methodret ""`, literal-for-class).
- Updated two pre-existing tests (`parser.test.ts`, `document-symbol.test.ts`) whose sample methods declared a return type without `METHODRET` — now legitimately caught — by adding a `METHODRET`, preserving each test's original intent.

Full suite green: 625 passing, 20 skipped (BBj/Java-dependent). Typecheck and lint clean.

Closes #372
Closes #206
Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)