### PR TITLE
docs(#125): document project.properties file location and contents

### DIFF
--- a/documentation/docs/vscode/configuration.md
+++ b/documentation/docs/vscode/configuration.md
@@ -266,6 +266,43 @@ The BBj properties file is located at:
 
 Access it using the **BBj: Show BBj.properties** command.
 
+### project.properties
+
+`project.properties` is an optional per-project file that lets you override the
+classpath and PREFIX directories for a single workspace, without touching your
+global BBj configuration or VS Code settings.
+
+**Location:** the workspace root (the top-level folder you opened in VS Code). If
+the file is not present, the extension falls back to the `bbj.classpath` setting
+and the PREFIX defined in `config.bbx`.
+
+**Format:** a standard Java properties file (`key=value`, one entry per line).
+Only two keys are recognized; any other lines are ignored:
+
+| Key | Description |
+|-----|-------------|
+| `classpath` | A delimiter-separated list of JAR files and/or directories used for Java class resolution. Entries are separated by `:` on Linux/macOS and `;` on Windows. A leading `~` expands to your home directory. When set, this **takes precedence over** the `bbj.classpath` setting. |
+| `PREFIX` | A space-separated list of double-quoted directory paths that are treated as external library locations (the same meaning as the `PREFIX` line in `config.bbx`). A leading `~` in each path expands to your home directory. When set, this **overrides** the PREFIX read from `config.bbx`. |
+
+**Example `project.properties`:**
+
+```properties
+classpath=~/BBJ/lib/*
+PREFIX="~/BBJ/utils/" "~/BBJ/plugins/"
+```
+
+On Windows, use `;` to separate multiple classpath entries:
+
+```properties
+classpath=C:\BBJ\lib\myapp.jar;C:\BBJ\lib\vendor.jar
+```
+
+:::note
+Changes to `project.properties` are picked up when the workspace is
+initialized. Reload the window (**Developer: Reload Window**) after editing it
+so the language server re-reads the classpath and PREFIX values.
+:::
+
 ## Enterprise Manager Authentication
 
 BUI and DWC run commands require authentication with Enterprise Manager.

--- a/documentation/docs/vscode/getting-started.md
+++ b/documentation/docs/vscode/getting-started.md
@@ -76,6 +76,11 @@ To enable Java class completions, configure the classpath:
 
 The extension will automatically detect classpath entries from your BBj installation. Run the command "BBj: Show Available Classpath Entries" to see all available options.
 
+To override the classpath and PREFIX directories for a single project, add a
+`project.properties` file to your workspace root. See
+[project.properties](./configuration.md#projectproperties) in the Configuration
+guide for details.
+
 ## Testing Your Setup
 
 1. Create a new file with a `.bbj` extension


### PR DESCRIPTION
## Summary

Closes #125. The extension reads a `project.properties` file from the workspace root (`bbj-ws-manager.ts` → `initializeWorkspace` / `parseSettings`), but this was never documented on the docs site.

Adds a `project.properties` reference section to the VS Code Configuration guide, grounded in the actual parsing behavior:

- **Location:** workspace root; falls back to the `bbj.classpath` setting and the `config.bbx` PREFIX when absent.
- **`classpath`** — delimiter-separated (`:` Linux/macOS, `;` Windows), `~`-expanded, takes precedence over the `bbj.classpath` setting.
- **`PREFIX`** — space-separated double-quoted paths, `~`-expanded, overrides the PREFIX from `config.bbx`.
- Only these two keys are recognized; other lines are ignored.

Includes format notes, per-OS delimiter examples, and a reload-required note. Cross-linked from Getting Started.

## Changes
- `documentation/docs/vscode/configuration.md` — new `### project.properties` section under "BBj Configuration Files"
- `documentation/docs/vscode/getting-started.md` — pointer under "Configuring Classpath"

## Verification
- The file watcher only covers `**/*.bbj`; `project.properties` is read once at workspace init, so the "reload the window after editing" note is accurate.
- Confirmed the cross-link anchor via `github-slugger` (Docusaurus's slugifier): `project.properties` → `projectproperties`. Uses the repo's `.md#anchor` convention (safe under `onBrokenLinks: 'throw'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)