### PR TITLE
Class validations + void identifier: #79, #80, #86, #87, #439

### DIFF
--- a/bbj-vscode/src/language/bbj-document-validator.ts
+++ b/bbj-vscode/src/language/bbj-document-validator.ts
@@ -2,11 +2,19 @@
 
 import { AstNode, DefaultDocumentValidator, DiagnosticData, DiagnosticInfo, DocumentValidator, getDiagnosticRange, LangiumDocument, toDiagnosticSeverity } from "langium";
 import { CancellationToken, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, Range } from "vscode-languageserver";
+import { isSymbolRef } from "./generated/ast.js";
+import { isInstanceAccessAssignment } from "./bbj-scope.js";
 
 interface LinkingErrorData extends DiagnosticData {
     containerType: string;
     property: string;
     refText: string;
+    /**
+     * True when the unresolved reference is an explicit instance-member access (`#member`).
+     * Such a reference can only denote an instance member of the enclosing class, so a dangling
+     * one is a definite bug and stays at Error severity rather than being downgraded to a warning.
+     */
+    instanceMemberAccess?: boolean;
 }
 
 interface ValidationOptions {
@@ -164,16 +172,20 @@ export class BBjDocumentValidator extends DefaultDocumentValidator {
         for (const reference of document.references) {
             const linkingError = reference.error;
             if (linkingError) {
+                const container = linkingError.info.container;
+                const instanceMemberAccess = (isSymbolRef(container) && container.instanceAccess)
+                    || isInstanceAccessAssignment(container);
                 const info: DiagnosticInfo<AstNode, string> = {
-                    node: linkingError.info.container,
+                    node: container,
                     range: reference.$refNode?.range,
                     property: linkingError.info.property,
                     index: linkingError.info.index,
                     data: {
                         code: DocumentValidator.LinkingError,
-                        containerType: linkingError.info.container.$type,
+                        containerType: container.$type,
                         property: linkingError.info.property,
-                        refText: linkingError.info.reference.$refText
+                        refText: linkingError.info.reference.$refText,
+                        instanceMemberAccess
                     } satisfies LinkingErrorData
                 };
 
@@ -233,8 +245,10 @@ export class BBjDocumentValidator extends DefaultDocumentValidator {
         let diagnosticSeverity: DiagnosticSeverity;
 
         if ((info.data as DiagnosticData)?.code === DocumentValidator.LinkingError) {
-            // Cyclic reference errors stay as Error severity; other linking errors downgrade to Warning
-            diagnosticSeverity = message.includes('Cyclic reference')
+            // Cyclic references and dangling instance-member (`#member`) references stay at Error
+            // severity; other linking errors downgrade to Warning.
+            const linkingData = info.data as LinkingErrorData;
+            diagnosticSeverity = (message.includes('Cyclic reference') || linkingData.instanceMemberAccess)
                 ? DiagnosticSeverity.Error
                 : DiagnosticSeverity.Warning;
         } else {

--- a/bbj-vscode/src/language/bbj-scope.ts
+++ b/bbj-vscode/src/language/bbj-scope.ts
@@ -492,7 +492,7 @@ export class BbjNameProvider extends DefaultNameProvider {
  * rather than the inner `SymbolRef`, so the SymbolRef's own `instanceAccess`
  * flag is false and must be recovered from the enclosing Assignment.
  */
-function isInstanceAccessAssignment(node: AstNode): boolean {
+export function isInstanceAccessAssignment(node: AstNode): boolean {
     // Walk up any `receiver` chain (e.g. `#a!.b! = v` links from the `a!` receiver).
     let current: AstNode = node;
     while (isMemberCall(current.$container) && current.$containerProperty === 'receiver') {

--- a/bbj-vscode/src/language/bbj-scope.ts
+++ b/bbj-vscode/src/language/bbj-scope.ts
@@ -215,20 +215,22 @@ export class BbjScopeProvider extends DefaultScopeProvider {
             }
             return EMPTY_SCOPE;
         } else if (isSymbolRef(context.container)) {
-            var membersStream = EMPTY_STREAM;
             const bbjType = AstUtils.getContainerOfType(context.container, isBbjClass)
-            if (bbjType) {
-                // Instance access is either flagged on the SymbolRef itself (e.g. `#field!`
-                // in expression position) or, on an assignment LHS like `#field! = value`,
-                // consumed by the enclosing Assignment's `instanceAccess` (the grammar binds
-                // the `#` to the Assignment rule, not the inner SymbolRef).
-                if (context.container.instanceAccess || isInstanceAccessAssignment(context.container)) {
-                    membersStream = this.createBBjClassMemberScope(bbjType, false, new Set()).getAllElements()
-                }
+            // Instance access is either flagged on the SymbolRef itself (e.g. `#field!`
+            // in expression position) or, on an assignment LHS like `#field! = value`,
+            // consumed by the enclosing Assignment's `instanceAccess` (the grammar binds
+            // the `#` to the Assignment rule, not the inner SymbolRef).
+            if (bbjType && (context.container.instanceAccess || isInstanceAccessAssignment(context.container))) {
+                // `#name` explicitly addresses an instance member of the enclosing BBj class
+                // (fields, methods, this!/super! and inherited members — all provided by
+                // createBBjClassMemberScope). It must NOT fall back to the lexical scope,
+                // otherwise a same-named method parameter or local variable would satisfy a
+                // reference to an undefined field, hiding the error (#80).
+                return this.createBBjClassMemberScope(bbjType, false, new Set())
             }
             const program = AstUtils.getContainerOfType(context.container, isProgram);
             const memberAndImports = new StreamScopeWithPredicate(
-                membersStream.concat(this.importedBBjClasses(program)),
+                stream(this.importedBBjClasses(program)),
                 this.superGetScope(context)
             );
 

--- a/bbj-vscode/src/language/bbj.langium
+++ b/bbj-vscode/src/language/bbj.langium
@@ -870,7 +870,10 @@ QualifiedBBjClassName returns string:
     BBjFilePath ID;
 
 FeatureName returns string:
-    ID | ID_WITH_SUFFIX;
+    // 'void' is a keyword only for a method's void-return marker (MethodDeclStart), which uses
+    // ValidName for the method name — so it never conflicts here. Allowing it as a FeatureName
+    // lets `void` be used as an ordinary (numeric) variable/field/member name (#439).
+    ID | ID_WITH_SUFFIX | 'void';
 
 ValidName returns string:
     ID

--- a/bbj-vscode/src/language/validations/check-classes.ts
+++ b/bbj-vscode/src/language/validations/check-classes.ts
@@ -1,7 +1,7 @@
 import { AstNode, AstUtils, DiagnosticInfo, ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
 import { basename, dirname, isAbsolute, relative } from 'path';
 import { getClass, getClassRef } from '../bbj-nodedescription-provider.js';
-import { BBjAstType, BbjClass, isBbjClass, isMethodReturnStatement, isNumberLiteral, isStringLiteral, MethodDecl, QualifiedClass } from '../generated/ast.js';
+import { BBjAstType, BbjClass, ConstructorCall, Expression, FieldDecl, isBbjClass, isMethodDecl, isMethodReturnStatement, isNumberLiteral, isStringLiteral, MethodDecl, QualifiedClass } from '../generated/ast.js';
 
 export function registerClassChecks(registry: ValidationRegistry) {
     const validator = new ClassValidator();
@@ -48,10 +48,14 @@ export function registerClassChecks(registry: ValidationRegistry) {
                 validator.checkCyclicInheritance(decl, accept);
             }
         },
-        ConstructorCall: (call, accept) => validator.checkClassReference(accept, call.klass, {
-            node: call,
-            property: 'klass'
-        }),
+        ConstructorCall: (call, accept) => {
+            validator.checkClassReference(accept, call.klass, {
+                node: call,
+                property: 'klass'
+            });
+            validator.checkInstantiable(call, accept);
+            validator.checkConstructorArguments(call, accept);
+        },
         MethodDecl: (meth, accept) => {
             validator.checkClassReference(accept, meth.returnType, {
                 node: meth,
@@ -59,6 +63,7 @@ export function registerClassChecks(registry: ValidationRegistry) {
             });
             validator.checkMethodReturn(meth, accept);
         },
+        FieldDecl: (field, accept) => validator.checkFieldInit(field, accept),
         ParameterDecl: (param, accept) => validator.checkClassReference(accept, param.type, {
             node: param,
             property: 'type'
@@ -180,27 +185,10 @@ class ClassValidator {
         if (meth.array) {
             return;
         }
-        const typeName = this.returnTypeName(meth.returnType);
-        if (!typeName) {
-            return;
-        }
-        const lower = typeName.toLowerCase();
-        const expectsNumber = ClassValidator.NUMERIC_RETURN_TYPES.has(lower);
-        const expectsString = ClassValidator.STRING_RETURN_TYPES.has(lower);
-        // A literal is never an instance of a user-defined BBj class/interface, so any literal
-        // returned for a resolvable BBj class is a mismatch.
-        const declaredBBjClass = !expectsNumber && !expectsString && isBbjClass(getClass(meth.returnType));
-
         for (const ret of valueReturns) {
-            const value = ret.return!;
-            const returnsString = isStringLiteral(value);
-            const returnsNumber = isNumberLiteral(value);
-            if (!returnsString && !returnsNumber) {
-                continue; // non-literal: needs deeper type inference, left untouched
-            }
-            const returnedKind = returnsString ? 'string' : 'number';
-            if ((expectsNumber && returnsString) || (expectsString && returnsNumber) || declaredBBjClass) {
-                accept('error', `Method '${meth.name}' declares return type '${typeName}' but returns a ${returnedKind}.`, {
+            const mismatch = this.literalTypeMismatch(meth.returnType, ret.return!);
+            if (mismatch) {
+                accept('error', `Method '${meth.name}' declares return type '${mismatch.typeName}' but returns a ${mismatch.valueKind}.`, {
                     node: ret,
                     property: 'return'
                 });
@@ -208,13 +196,127 @@ class ClassValidator {
         }
     }
 
-    /** Simple (unqualified) name of a declared return type, taken from its source text. */
-    private returnTypeName(returnType: QualifiedClass): string | undefined {
-        const text = returnType.$cstNode?.text?.trim();
+    /**
+     * Validates a field's literal initializer against its declared type (#79), e.g.
+     * `field public BBjNumber n! = "text"`. Reuses the same conservative, java-interop-free
+     * literal check as method return types.
+     */
+    public checkFieldInit(field: FieldDecl, accept: ValidationAcceptor): void {
+        if (!field.init || field.array) {
+            return; // no initializer, or an array field — nothing to check here
+        }
+        const mismatch = this.literalTypeMismatch(field.type, field.init);
+        if (mismatch) {
+            accept('error', `Field '${field.name}' is declared '${mismatch.typeName}' but is initialized with a ${mismatch.valueKind}.`, {
+                node: field,
+                property: 'init'
+            });
+        }
+    }
+
+    /**
+     * If `value` is a literal whose kind contradicts the declared scalar/class `type`, returns the
+     * expected type name and the literal kind; otherwise undefined. Only cases that are safe
+     * without java-interop-backed type inference are reported, matching BBj's loose typing:
+     * a BBjNumber assigned a string literal, a BBjString assigned a number literal, or any literal
+     * assigned to a resolvable user-defined BBj class/interface.
+     */
+    private literalTypeMismatch(type: QualifiedClass | undefined, value: Expression): { typeName: string, valueKind: string } | undefined {
+        if (!type) {
+            return undefined;
+        }
+        const returnsString = isStringLiteral(value);
+        const returnsNumber = isNumberLiteral(value);
+        if (!returnsString && !returnsNumber) {
+            return undefined; // non-literal: needs deeper type inference, left untouched
+        }
+        const typeName = this.simpleTypeName(type);
+        if (!typeName) {
+            return undefined;
+        }
+        const lower = typeName.toLowerCase();
+        const expectsNumber = ClassValidator.NUMERIC_RETURN_TYPES.has(lower);
+        const expectsString = ClassValidator.STRING_RETURN_TYPES.has(lower);
+        // A literal is never an instance of a user-defined BBj class/interface, so any literal
+        // assigned to a resolvable BBj class is a mismatch.
+        const declaredBBjClass = !expectsNumber && !expectsString && isBbjClass(getClass(type));
+        if ((expectsNumber && returnsString) || (expectsString && returnsNumber) || declaredBBjClass) {
+            return { typeName, valueKind: returnsString ? 'string' : 'number' };
+        }
+        return undefined;
+    }
+
+    /** Simple (unqualified) name of a declared type, taken from its source text. */
+    private simpleTypeName(type: QualifiedClass): string | undefined {
+        const text = type.$cstNode?.text?.trim();
         if (!text) {
             return undefined;
         }
         return text.substring(text.lastIndexOf('.') + 1);
+    }
+
+    /**
+     * An interface cannot be instantiated with `new` (#86). Array allocation `new X[n]` is not an
+     * instantiation of `X` (it creates an array whose element type is `X`) and is left alone.
+     */
+    public checkInstantiable(call: ConstructorCall, accept: ValidationAcceptor): void {
+        if (this.isArrayConstruction(call)) {
+            return;
+        }
+        const klass = getClass(call.klass);
+        if (isBbjClass(klass) && klass.interface) {
+            accept('error', `Interface '${klass.name}' cannot be instantiated.`, {
+                node: call,
+                property: 'klass'
+            });
+        }
+    }
+
+    /**
+     * Validates the argument count of a `new` call against the declared constructors of a BBj class
+     * (#87). BBj constructors are methods whose name matches the class name (case-insensitive), and
+     * a class may declare several overloads. Only checked when the class declares at least one
+     * constructor and the class resolves to a BBj class — Java classes (constructors resolved via
+     * java-interop) and array allocations are left alone. Argument *types* are not checked here, to
+     * avoid false positives without java-interop-backed inference.
+     */
+    public checkConstructorArguments(call: ConstructorCall, accept: ValidationAcceptor): void {
+        if (this.isArrayConstruction(call)) {
+            return;
+        }
+        const klass = getClass(call.klass);
+        if (!isBbjClass(klass) || klass.interface) {
+            return;
+        }
+        const constructors = klass.members.filter(
+            (m): m is MethodDecl => isMethodDecl(m) && m.name.toLowerCase() === klass.name.toLowerCase()
+        );
+        if (constructors.length === 0) {
+            return; // no explicit constructor declared — nothing to check against
+        }
+        const argCount = call.args.length;
+        if (!constructors.some(ctor => ctor.params.length === argCount)) {
+            const counts = [...new Set(constructors.map(c => c.params.length))].sort((a, b) => a - b).join(' or ');
+            accept('error', `No constructor of '${klass.name}' takes ${argCount} argument(s) (expected ${counts}).`, {
+                node: call,
+                property: 'klass'
+            });
+        }
+    }
+
+    /**
+     * Distinguishes array allocation `new X[...]` from object instantiation `new X(...)`. The AST
+     * models both with the same `ConstructorCall.args`, so the bracket is recovered from the CST:
+     * the first delimiter after the class name is `[` for an array allocation.
+     */
+    private isArrayConstruction(call: ConstructorCall): boolean {
+        const callNode = call.$cstNode;
+        const klassNode = call.klass.$cstNode;
+        if (!callNode || !klassNode) {
+            return false;
+        }
+        const afterClass = callNode.text.slice(klassNode.end - callNode.offset).trimStart();
+        return afterClass.startsWith('[');
     }
 
     public checkCyclicInheritance(klass: BbjClass, accept: ValidationAcceptor): void {

--- a/bbj-vscode/test/class-validations-issues.test.ts
+++ b/bbj-vscode/test/class-validations-issues.test.ts
@@ -63,6 +63,26 @@ classend
             expect(messages.some(m => /Could not resolve reference to NamedElement named 'window!'/.test(m))).toBe(true);
         });
 
+        test('a dangling #member reference is a hard error, not a warning', async () => {
+            const result = await validate(`
+class public Test
+  method public void run(BBjWindow window!)
+    ? #window!
+  methodend
+classend
+`);
+            const dangling = (result.diagnostics ?? []).find(d => /named 'window!'/.test(d.message));
+            expect(dangling).toBeDefined();
+            expect(dangling!.severity).toBe(1 /* DiagnosticSeverity.Error */);
+        });
+
+        test('an ordinary unresolved variable reference stays a warning', async () => {
+            const result = await validate(`print undefinedVar\n`);
+            const dangling = (result.diagnostics ?? []).find(d => /named 'undefinedVar'/.test(d.message));
+            expect(dangling).toBeDefined();
+            expect(dangling!.severity).toBe(2 /* DiagnosticSeverity.Warning */);
+        });
+
         test('valid instance member access (#this!, own field) still resolves', async () => {
             const messages = await messagesOf(`
 class public Test

--- a/bbj-vscode/test/class-validations-issues.test.ts
+++ b/bbj-vscode/test/class-validations-issues.test.ts
@@ -1,0 +1,165 @@
+import { EmptyFileSystem } from 'langium';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { parseHelper, validationHelper } from 'langium/test';
+import { createBBjServices } from '../src/language/bbj-module.js';
+import { Model, Program } from '../src/language/generated/ast.js';
+import { initializeWorkspace } from './test-helper.js';
+
+const services = createBBjServices(EmptyFileSystem);
+const validate = validationHelper<Program>(services.BBj);
+const parse = parseHelper<Model>(services.BBj);
+
+// Note: BBj built-in types (BBjNumber, BBjWindow, ...) are provided by the java-interop
+// service, which is not running in these tests. Such type references therefore produce an
+// incidental "Could not resolve reference to Class" diagnostic. The assertions below target
+// the specific validation messages under test rather than the total diagnostic count.
+async function messagesOf(code: string): Promise<string[]> {
+    const result = await validate(code);
+    return (result.diagnostics ?? []).map(d => d.message);
+}
+
+describe('Class validation issues (#79, #80, #86, #87)', () => {
+    beforeAll(async () => { await initializeWorkspace(services.shared); });
+
+    describe('#79 validate field value against the type', () => {
+        test('field initialized with a wrong-kind literal is flagged', async () => {
+            const messages = await messagesOf(`
+class public Test
+  field public BBjNumber DrawerBreakpoint! = "(max-width: 800px)"
+classend
+`);
+            expect(messages).toContain(`Field 'DrawerBreakpoint!' is declared 'BBjNumber' but is initialized with a string.`);
+        });
+
+        test('matching literal initializers are not flagged', async () => {
+            const messages = await messagesOf(`
+class public Test
+  field public BBjNumber n! = 5
+  field public BBjString s! = "text"
+classend
+`);
+            expect(messages.filter(m => m.includes('is initialized with'))).toHaveLength(0);
+        });
+
+        test('non-literal initializer is left to type inference', async () => {
+            const messages = await messagesOf(`
+class public Test
+  field public BBjNumber n! = otherValue!
+classend
+`);
+            expect(messages.filter(m => m.includes('is initialized with'))).toHaveLength(0);
+        });
+    });
+
+    describe('#80 using undefined class fields should produce an error', () => {
+        test('#field referencing an undefined field is flagged even when a parameter shares its name', async () => {
+            const messages = await messagesOf(`
+class public Test
+  method public void run(BBjWindow window!)
+    ? #window!
+  methodend
+classend
+`);
+            expect(messages.some(m => /Could not resolve reference to NamedElement named 'window!'/.test(m))).toBe(true);
+        });
+
+        test('valid instance member access (#this!, own field) still resolves', async () => {
+            const messages = await messagesOf(`
+class public Test
+  field public BBjString s!
+  method public void run()
+    #s! = "x"
+    ? #this!
+  methodend
+classend
+`);
+            expect(messages.some(m => /Could not resolve reference to NamedElement/.test(m))).toBe(false);
+        });
+    });
+
+    describe('#86 validate interfaces cannot be instantiated', () => {
+        test('instantiating an interface is an error', async () => {
+            const messages = await messagesOf(`
+interface public TheInterface
+
+interfaceend
+
+a! = new TheInterface()
+`);
+            expect(messages).toContain(`Interface 'TheInterface' cannot be instantiated.`);
+        });
+
+        test('an array whose element type is an interface is allowed', async () => {
+            const messages = await messagesOf(`
+interface public TheInterface
+
+interfaceend
+
+a! = new TheInterface[5]
+`);
+            expect(messages.some(m => /cannot be instantiated/.test(m))).toBe(false);
+        });
+    });
+
+    describe('#87 validate object constructors', () => {
+        test('constructor called with the wrong number of arguments is an error', async () => {
+            const messages = await messagesOf(`
+class public Test
+  method public Test(BBjNumber a!)
+  methodend
+classend
+
+o! = new Test(1, 5)
+`);
+            expect(messages).toContain(`No constructor of 'Test' takes 2 argument(s) (expected 1).`);
+        });
+
+        test('matching one of several overloaded constructors is allowed', async () => {
+            const messages = await messagesOf(`
+class public Test
+  method public Test()
+  methodend
+  method public Test(BBjNumber a!)
+  methodend
+classend
+
+o! = new Test()
+p! = new Test(1)
+`);
+            expect(messages.some(m => /No constructor of/.test(m))).toBe(false);
+        });
+
+        test('a class without an explicitly declared constructor is not constrained', async () => {
+            const messages = await messagesOf(`
+class public Test
+classend
+
+o! = new Test()
+`);
+            expect(messages.some(m => /No constructor of/.test(m))).toBe(false);
+        });
+    });
+});
+
+describe('#439 void usable as a variable name', () => {
+    beforeAll(async () => { await initializeWorkspace(services.shared); });
+
+    test.each([
+        `void=scall("x &")\n`,
+        `void = 5\nprint void\n`,
+        `x! = void + 1\n`,
+    ])('parses %j without parser errors', async (code) => {
+        const doc = await parse(code, { validation: false });
+        expect(doc.parseResult.parserErrors.map(e => e.message)).toEqual([]);
+    });
+
+    test('void is still recognized as a method void-return marker', async () => {
+        const doc = await parse(`
+class public Test
+  method public void run()
+  methodend
+classend
+`, { validation: false });
+        expect(doc.parseResult.parserErrors.map(e => e.message)).toEqual([]);
+    });
+});


### PR DESCRIPTION
Draft. Addresses five issues; **#82 is already handled on `main`** (see that issue).

## Fixes

| Issue | Fix |
|---|---|
| **#439** `void` flagged as variable | Add `'void'` to `FeatureName`. Method void-return marker uses `ValidName`, so `method public void run()` is unaffected. Requires `npm run langium:generate`. |
| **#80** undefined `#field` not flagged | Two parts: (1) restrict `#member` scope to `createBBjClassMemberScope` (class members + `this!`/`super!`/inherited) so a same-named parameter/local no longer masks an undefined field; (2) report a dangling `#member` reference at **Error** severity instead of the default downgraded Warning — `#` explicitly denotes an instance member, so an unresolved one is a definite bug. |
| **#79** field value vs type | New `FieldDecl` check; flags a literal initializer contradicting a declared BBj scalar type or resolvable user class. Shared literal-vs-type helper with `checkMethodReturn`. |
| **#86** interface instantiation | Flag `new Interface()`. Array allocation `new Interface[n]` (element type) is left alone via CST bracket detection. |
| **#87** constructor arity | Flag a `new` call whose argument count matches no declared constructor (constructors = methods named after the class; overloads supported). |

## Deliberate scoping / judgment calls
- **#87** checks argument *count*, not types, and only when the class declares ≥1 constructor — conservative to avoid false positives without java-interop-backed inference. Argument-type checking is a possible follow-up.
- **#79/#87** type checks are name-based (BBjNumber/BBjString), matching the existing `checkMethodReturn` precedent, because built-in types don't resolve without the Java service.
- **#80** severity: only dangling `#member` (instance-access) references are promoted to Error; ordinary unresolved variables stay warnings as before.
- Noticed but **not** changed (out of scope): `bbj-completion-provider.ts` assumes BBj constructors are named `create`, but real code names them after the class — looks like a latent bug worth a separate issue.

## Verification
- Full suite: **639 passed / 20 skipped**; `tsc -b` + esbuild build clean; ESLint clean (2 pre-existing warnings in an untouched file).
- New tests in `test/class-validations-issues.test.ts` (16) cover all fixes incl. negative cases: valid `#this!`/own-field access, interface arrays, overloaded/ctor-less classes, `void` still valid as a void-return marker, and severity (dangling `#member` = Error, ordinary unresolved var = Warning).
- Built-in types (BBjNumber, BBjWindow) don't resolve in the test env (no java-interop), so those tests assert on the specific validation message/severity rather than total diagnostic count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)