### PR TITLE
Fix #440: resolve event constants on Java class references

### DIFF
--- a/bbj-vscode/src/language/bbj-scope.ts
+++ b/bbj-vscode/src/language/bbj-scope.ts
@@ -178,9 +178,13 @@ export class BbjScopeProvider extends DefaultScopeProvider {
                     ? this.descriptions.createDescription(javaLangClass, 'class')
                     : undefined;
                 if (isClassRef) {
-                    // Class reference access — static methods only (no fields per user decision)
+                    // Class reference access — static members only. Static fields cover the BBj
+                    // event constants (e.g. `BBjHtmlView.ON_HTMLVIEW_DOWNLOAD`, #440), which
+                    // java-interop exposes as inherited `public static final int` fields, matching
+                    // Java semantics for `ClassName.STATIC_FIELD`.
                     const staticMethods = receiverType.methods.filter(m => m.isStatic);
-                    const scope = this.createScopeForNodes(stream(staticMethods));
+                    const staticFields = receiverType.fields.filter(f => f.isStatic);
+                    const scope = this.createScopeForNodes(stream(staticFields).concat(staticMethods));
                     if (classDesc) {
                         return new StreamScopeWithPredicate(stream([classDesc]), scope);
                     }

--- a/bbj-vscode/test/bbj-test-module.ts
+++ b/bbj-vscode/test/bbj-test-module.ts
@@ -4,7 +4,7 @@ import { BBjAddedServices, BBjModule, BBjServices, BBjSharedModule } from "../sr
 import { BBjGeneratedModule, BBjGeneratedSharedModule } from "../src/language/generated/module.js";
 import { registerValidationChecks } from "../src/language/bbj-validator.js";
 import { JavaInteropService } from "../src/language/java-interop.js";
-import { Classpath, JavaClass, JavaMethod } from "../src/language/generated/ast.js";
+import { Classpath, JavaClass, JavaField, JavaMethod } from "../src/language/generated/ast.js";
 import { BbjLexer } from "../src/language/bbj-lexer.js";
 import { JavadocProvider } from "../src/language/java-javadoc.js";
 
@@ -161,6 +161,28 @@ function createJavaLangStringClass(container: Classpath): JavaClass {
         classes: [],
         methods: []
     }
+    fakeStringClass.fields = [
+        {
+            // static field: accessible via class reference `String.CASE_INSENSITIVE_ORDER` (#440)
+            name: 'CASE_INSENSITIVE_ORDER',
+            $containerProperty: 'fields',
+            $container: fakeStringClass,
+            type: 'java.util.Comparator',
+            isStatic: true,
+            deprecated: false,
+            $type: JavaField
+        },
+        {
+            // instance field: must NOT be reachable through a class reference
+            name: 'someInstanceField',
+            $containerProperty: 'fields',
+            $container: fakeStringClass,
+            type: 'int',
+            isStatic: false,
+            deprecated: false,
+            $type: JavaField
+        }
+    ]
     fakeStringClass.methods = [
         {
             name: 'charAt',

--- a/bbj-vscode/test/completion-test.test.ts
+++ b/bbj-vscode/test/completion-test.test.ts
@@ -236,4 +236,25 @@ foo!.<|>
             }
         });
     });
+
+    test('static field (event constant) is offered on a Java class reference - issue #440', async () => {
+        // A class-reference receiver (`String.`) offers static members only. Static fields
+        // cover BBj event constants like `BBjHtmlView.ON_HTMLVIEW_DOWNLOAD`; the fake String
+        // class carries a static `CASE_INSENSITIVE_ORDER` and an instance `someInstanceField`.
+        const text = `
+        use java.lang.String
+        String.<|>
+        `
+        await completion({
+            text,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                // static field present
+                expect(labels).toContain('CASE_INSENSITIVE_ORDER');
+                // instance-only members must NOT leak onto a class reference
+                expect(labels).not.toContain('someInstanceField');
+            }
+        });
+    });
 });

--- a/bbj-vscode/test/functional/issue440-real-interop.test.ts
+++ b/bbj-vscode/test/functional/issue440-real-interop.test.ts
@@ -1,0 +1,63 @@
+import { DocumentValidator, LangiumDocument } from 'langium';
+import { NodeFileSystem } from 'langium/node';
+import { parseHelper } from 'langium/test';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { Model } from '../../src/language/generated/ast.js';
+import { createBBjServices } from '../../src/language/bbj-module.js';
+import { JavadocProvider } from '../../src/language/java-javadoc.js';
+import { initializeWorkspace, shouldRunBBjTests } from '../test-helper.js';
+
+/**
+ * End-to-end verification for issue #440 against the LIVE java-interop service
+ * (real `BBjHtmlView`, not the fake test classpath). Skipped unless a java-interop
+ * service is reachable on :5008 (or RUN_BBJ_TESTS is set).
+ *
+ * Event constants such as `BBjHtmlView.ON_HTMLVIEW_DOWNLOAD` are `public static final int`
+ * fields (inherited from `SysGuiEventConstants`). Accessing them via the class name must
+ * resolve without a linking error, matching Java semantics for `ClassName.STATIC_FIELD`.
+ */
+describe('Issue #440 - event constants on Java class references (real interop)', async () => {
+    const run = await shouldRunBBjTests();
+    const HTML_VIEW_FQN = 'com.basis.bbj.proxies.sysgui.BBjHtmlView';
+
+    const services = createBBjServices(NodeFileSystem);
+    const validate = (content: string) => parseHelper<Model>(services.BBj)(content, { validation: true });
+
+    beforeAll(async () => {
+        if (!run) return;
+        if (!JavadocProvider.getInstance().isInitialized()) {
+            JavadocProvider.getInstance().initialize([], services.shared.workspace.FileSystemProvider);
+        }
+        const interop = services.BBj.java.JavaInteropService;
+        interop.setConnectionConfig('127.0.0.1', 5008);
+        await initializeWorkspace(services.shared);
+
+        // Warm up BBjHtmlView. The real extension pre-loads the classpath (loadClasspath →
+        // loadImplicitImports) so the class is fully resolved AND linked to the classpath
+        // document before any reference is validated. In this bare harness we resolve it on
+        // demand; because it carries 536 fields, the first resolution can exceed the 30s
+        // per-chain timeout and return a not-yet-linked class. The background resolveClass
+        // keeps running and eventually links members to their document, so poll for that.
+        await interop.resolveClassByName(HTML_VIEW_FQN);
+        for (let i = 0; i < 90; i++) {
+            const klass = await interop.getResolvedClass(HTML_VIEW_FQN);
+            const field = klass?.fields?.find(f => f.name === 'ON_HTMLVIEW_DOWNLOAD');
+            if (field?.$container) return;
+            await new Promise(r => setTimeout(r, 1000));
+        }
+    }, 120000);
+
+    function linkingErrors(document: LangiumDocument) {
+        return document.diagnostics?.filter(err => err.data?.code === DocumentValidator.LinkingError) ?? [];
+    }
+
+    test.runIf(run)('BBjHtmlView.ON_HTMLVIEW_DOWNLOAD resolves as a static event constant', async () => {
+        const document = await validate(`
+            use ${HTML_VIEW_FQN}
+            ON_DOWNLOAD = BBjHtmlView.ON_HTMLVIEW_DOWNLOAD
+        `);
+        const errs = linkingErrors(document).map(e => e.message);
+        expect(errs.join('\n')).not.toContain('ON_HTMLVIEW_DOWNLOAD');
+        expect(errs).toHaveLength(0);
+    }, 60000);
+});

--- a/bbj-vscode/test/linking.test.ts
+++ b/bbj-vscode/test/linking.test.ts
@@ -400,6 +400,26 @@ describe('Linking Tests', async () => {
             expectNoErrors(document)
         });
 
+        test('Static field resolves on a Java class reference - issue #440', async () => {
+            // Event constants like `BBjHtmlView.ON_HTMLVIEW_DOWNLOAD` are `public static final int`
+            // fields; accessing them via the class name must resolve without a linking error.
+            const document = await validate(`
+                use java.lang.String
+                x! = String.CASE_INSENSITIVE_ORDER
+            `)
+            expectNoErrors(document)
+        });
+
+        test('Instance field does NOT resolve on a Java class reference - issue #440', async () => {
+            const document = await validate(`
+                use java.lang.String
+                x! = String.someInstanceField
+            `)
+            const linkingErr = findLinkingErrors(document)
+            expect(linkingErr.length).toBe(1)
+            expect(linkingErr[0].message).toContain("someInstanceField")
+        });
+
         test('Package scope as most outer scope', async () => {
             const document = await validate(`
                 declare java.lang.String com


### PR DESCRIPTION
## Problem

Event constants such as `BBjHtmlView.ON_HTMLVIEW_DOWNLOAD` were flagged as a linking error when accessed via the class name, forcing the workaround `htmlview!.ON_HTMLVIEW_DOWNLOAD` via an instance:

```bbj
htmlview!.setCallback(BBjHtmlView.ON_HTMLVIEW_DOWNLOAD, "onDownload")   REM was flagged, works at runtime
htmlview!.setCallback(htmlview!.ON_HTMLVIEW_DOWNLOAD, "onDownload")     REM workaround
```

These constants are real `public static final int` fields (inherited from `SysGuiEventConstants`) that java-interop already exposes on the control classes — confirmed against the live interop service: `BBjHtmlView` reports 149 `ON_*` static fields, including `ON_HTMLVIEW_DOWNLOAD`.

## Root cause

In `BbjScopeProvider.getScope()`, the Java class-reference branch (receiver is a `SymbolRef` to a `JavaClass`) returned **static methods only**. Static fields were deliberately excluded when static-method completion landed (#374), which explicitly deferred static-field-on-class-reference support. This PR is that deferred case.

## Fix

Include static **fields** alongside static methods in the Java class-reference scope, so `ClassName.STATIC_FIELD` resolves — matching Java semantics and the behaviour already allowed for BBj classes (`MyClass.staticField`). Two-line change in `bbj-scope.ts`; instance-only members still do not leak onto a class reference.

## Tests

- **linking** (`test/linking.test.ts`) — static field resolves on a Java class reference; instance field does not.
- **completion** (`test/completion-test.test.ts`) — static field (event constant) is offered on a class reference; instance-only members are not.
- **live-interop E2E** (`test/functional/issue440-real-interop.test.ts`, gated on `RUN_BBJ_TESTS` / a reachable interop on :5008) — `BBjHtmlView.ON_HTMLVIEW_DOWNLOAD` resolves against the real class with zero linking errors.

Fixes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)