### PR TITLE
Fix #445: recover field completion after a dangling '#'

### DIFF
--- a/bbj-vscode/src/language/bbj-completion-provider.ts
+++ b/bbj-vscode/src/language/bbj-completion-provider.ts
@@ -1,10 +1,10 @@
 import { AstNodeDescription, AstUtils, GrammarAST, MaybePromise, ReferenceInfo } from "langium";
-import type { LangiumDocument } from "langium";
+import type { LangiumDocument, LangiumDocumentFactory } from "langium";
 import { CompletionAcceptor, CompletionContext, CompletionValueItem, DefaultCompletionProvider, LangiumServices, NextFeature } from "langium/lsp";
 import { CancellationToken, CompletionItem, CompletionItemKind, CompletionItemTag, CompletionList, CompletionParams } from "vscode-languageserver";
 import { documentationHeader, methodSignature } from "./bbj-hover.js";
 import { isFunctionNodeDescription, type FunctionNodeDescription, getClass } from "./bbj-nodedescription-provider.js";
-import { BbjClass, ConstructorCall, FieldDecl, isBbjClass, isConstructorCall, isDocumented, isFieldDecl, isJavaClass, isJavaField, isJavaMethod, isMethodDecl, LibEventType, LibSymbolicLabelDecl } from "./generated/ast.js";
+import { BbjClass, ConstructorCall, FieldDecl, isBbjClass, isConstructorCall, isDocumented, isFieldDecl, isJavaClass, isJavaField, isJavaMethod, isMethodDecl, LibEventType, LibSymbolicLabelDecl, MethodDecl } from "./generated/ast.js";
 import { findLeafNodeAtOffset } from "./bbj-validator.js";
 
 
@@ -21,8 +21,11 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
      */
     protected dotTriggerActive = false;
 
+    protected readonly documentFactory: LangiumDocumentFactory;
+
     constructor(services: LangiumServices) {
         super(services);
+        this.documentFactory = services.shared.workspace.LangiumDocumentFactory;
     }
 
     protected override completionFor(context: CompletionContext, next: NextFeature, acceptor: CompletionAcceptor): MaybePromise<void> {
@@ -86,13 +89,23 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
         }
         const leafNode = findLeafNodeAtOffset(rootNode.$cstNode, offset - 1);
 
-        if (!leafNode) {
-            return undefined;
-        }
+        // Locate the enclosing class method. A dangling `#` (no field name typed yet)
+        // is an unsatisfiable cross-reference: because newlines are hidden whitespace,
+        // the parser scans past the line end and error recovery unwinds the enclosing
+        // class/method out of the AST, so the container lookup below finds nothing.
+        // In that case, recover the class/method by reparsing a copy of the document
+        // with a synthetic identifier inserted after the `#` (issue #445).
+        let method = leafNode ? AstUtils.getContainerOfType(leafNode.astNode, isMethodDecl) : undefined;
+        let klass = leafNode ? AstUtils.getContainerOfType(leafNode.astNode, isBbjClass) : undefined;
 
-        // Check if cursor is inside a class method body
-        const method = AstUtils.getContainerOfType(leafNode.astNode, isMethodDecl);
-        const klass = AstUtils.getContainerOfType(leafNode.astNode, isBbjClass);
+        // Only reparse when the class may have collapsed. A clean parse means the AST is
+        // trustworthy: if it says we are not in a class method (e.g. a channel `#1` at
+        // program scope), we are not, and there is nothing to recover — so skip the cost.
+        if ((!method || !klass) && document.parseResult.parserErrors.length > 0) {
+            const recovered = this.recoverCollapsedClassMethod(document, offset);
+            method = recovered.method;
+            klass = recovered.klass;
+        }
 
         if (!method || !klass) {
             // Not inside a class method — don't provide field completion
@@ -116,6 +129,43 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
         });
 
         return { items, isIncomplete: false };
+    }
+
+    /**
+     * Recover the class/method enclosing a dangling `#` when error recovery has
+     * collapsed them out of the AST (issue #445). A dangling `#` has no field name,
+     * so the `SymbolRef.symbol` reference is unsatisfiable; because newlines are hidden
+     * whitespace the parser scans past the line end and unwinds the whole class. This
+     * reparses a throwaway copy of the document with a synthetic identifier inserted
+     * right after the `#`, which keeps the class intact, and reads the enclosing
+     * class/method back from that copy at the same offset.
+     *
+     * The copy is only parsed — never registered, indexed, or built — so it cannot
+     * pollute the workspace and has no side effects; it is discarded when this returns.
+     * The recovered class always yields the class's own fields; inherited fields resolve
+     * on a best-effort basis via the global index in a running server.
+     */
+    protected recoverCollapsedClassMethod(document: LangiumDocument, offset: number): { method?: MethodDecl, klass?: BbjClass } {
+        const text = document.textDocument.getText();
+        // The cursor sits directly after the triggering `#`; bail if that is not the case.
+        if (text.charAt(offset - 1) !== '#') {
+            return {};
+        }
+        const patched = text.slice(0, offset) + FIELD_COMPLETION_PROBE_ID + text.slice(offset);
+        // Keep the `.bbj` extension so the service registry resolves BBj services for the probe.
+        const probeUri = document.uri.with({ path: document.uri.path + '.__field-probe__.bbj' });
+        const probeRoot = this.documentFactory.fromString(patched, probeUri).parseResult.value;
+        if (!probeRoot.$cstNode) {
+            return {};
+        }
+        const probeLeaf = findLeafNodeAtOffset(probeRoot.$cstNode, offset);
+        if (!probeLeaf) {
+            return {};
+        }
+        return {
+            method: AstUtils.getContainerOfType(probeLeaf.astNode, isMethodDecl),
+            klass: AstUtils.getContainerOfType(probeLeaf.astNode, isBbjClass)
+        };
     }
 
     protected getConstructorCompletion(document: LangiumDocument, params: CompletionParams): CompletionList | undefined {
@@ -306,6 +356,11 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
     }
 }
 
+
+// Synthetic identifier inserted after a dangling `#` so the class survives reparse
+// during field-completion recovery (see recoverCollapsedClassMethod). Its value is
+// irrelevant — it is only used to keep the parser from unwinding the class.
+const FIELD_COMPLETION_PROBE_ID = 'a';
 
 function toSimpleName(type: string): string {
     return type.split('.').pop() || type

--- a/bbj-vscode/test/completion-test.test.ts
+++ b/bbj-vscode/test/completion-test.test.ts
@@ -1,7 +1,7 @@
 
 import { AstUtils, EMPTY_SCOPE, EmptyFileSystem } from 'langium';
 import { expectCompletion, parseHelper } from 'langium/test';
-import { CompletionTriggerKind } from 'vscode-languageserver';
+import { CompletionParams, CompletionTriggerKind } from 'vscode-languageserver';
 import { describe, expect, test, vi } from 'vitest';
 import { createBBjTestServices } from './bbj-test-module';
 import { isBbjClass, isSymbolRef, Model } from '../src/language/generated/ast.js';
@@ -10,6 +10,25 @@ describe('BBJ completion provider', async () => {
 
     const bbjServices = createBBjTestServices(EmptyFileSystem).BBj;
     const completion = expectCompletion(bbjServices);
+
+    // Drive the completion provider with a '#' trigger context at the '<|>' marker.
+    // expectCompletion() does not let us set a trigger character, and field completion
+    // is only reachable via the '#' trigger, so this drives the request directly. Uses
+    // parseHelper (validation off) like the rest of this file — a full DocumentBuilder
+    // build would run the CPL/interop validation path and reach for the Java service.
+    let fieldCompletionCounter = 0;
+    async function fieldCompletion(text: string) {
+        const offset = text.indexOf('<|>');
+        const clean = text.replace('<|>', '');
+        const doc = await parseHelper<Model>(bbjServices)(
+            clean, { documentUri: `file:///field-completion-${fieldCompletionCounter++}.bbj` });
+        const params: CompletionParams = {
+            textDocument: { uri: doc.textDocument.uri },
+            position: doc.textDocument.positionAt(offset),
+            context: { triggerKind: CompletionTriggerKind.TriggerCharacter, triggerCharacter: '#' }
+        };
+        return bbjServices.lsp.CompletionProvider!.getCompletion(doc, params);
+    }
 
     test('Should propose imported java class', async () => {
         const text = `
@@ -396,5 +415,61 @@ classend`, { documentUri: 'file:///test/dot-no-collapse.bbj' });
                 expect(labels).not.toContain('someInstanceField');
             }
         });
+    });
+
+    test('dangling # in a class method body offers own fields - issue #445', async () => {
+        // A '#' with no field name yet is an unsatisfiable cross-reference that, because
+        // newlines are hidden whitespace, makes error recovery unwind the enclosing class
+        // out of the AST. The provider must recover and still offer the class's fields.
+        const text = `class public C
+    field public HashMap map!
+    field private String secret!
+    method public void m()
+        #<|>
+    methodend
+classend
+`;
+        const countC = () => bbjServices.shared.workspace.IndexManager
+            .allElements().filter(d => d.name === 'C').toArray().length;
+        const cBefore = countC();
+        const list = await fieldCompletion(text);
+        const labels = list?.items.map(i => i.label) ?? [];
+        expect(labels).toContain('map!');
+        expect(labels).toContain('secret!');
+        // recovery must not leak keyword/import fallbacks into field completion
+        expect(labels).not.toContain('HashMap');
+        expect(labels).not.toContain('new');
+        // the throwaway reparse must not leak into the workspace or the global index
+        const docUris = bbjServices.shared.workspace.LangiumDocuments.all.map(d => d.uri.toString()).toArray();
+        expect(docUris.some(u => u.includes('__field-probe__'))).toBe(false);
+        // only the real document adds class C to the index; the throwaway probe adds nothing
+        expect(countC() - cBefore).toBe(1);
+    });
+
+    test('dangling # followed by more code still offers fields - issue #445', async () => {
+        // The class also collapses when the '#' is followed by unrelated statements;
+        // recovery must locate the class from the enclosing method.
+        const text = `class public C
+    field public HashMap map!
+    method public void m()
+        #<|>
+        x = 1
+        y = 2
+    methodend
+classend
+`;
+        const list = await fieldCompletion(text);
+        const labels = list?.items.map(i => i.label) ?? [];
+        expect(labels).toContain('map!');
+    });
+
+    test('# outside any class method offers nothing - issue #445', async () => {
+        // Recovery must not fabricate field completion where there is no enclosing class.
+        const text = `x = 1
+#<|>
+y = 2
+`;
+        const list = await fieldCompletion(text);
+        expect(list?.items ?? []).toHaveLength(0);
     });
 });


### PR DESCRIPTION
## Problem

Fixes #445. Typing `#` in a class method body to trigger field completion offered an empty list (or Ctrl+Space fell back to imports/keywords) instead of the class's fields.

### Root cause

A dangling `#` (before the field name is typed) leaves an unsatisfiable `SymbolRef.symbol` cross-reference. Because newlines are hidden whitespace, the parser scans past the line end looking for an identifier, hits `methodend`, and error recovery **unwinds the enclosing class/method out of the AST**. `getFieldCompletion` then finds no enclosing class and returns nothing. The moment any letter follows the `#` (`#m`), the AST is intact and completion already worked — only the bare `#` collapses the class.

## Fix

When the enclosing-class lookup fails **and** the document has parser errors (the collapse signature), the completion provider reparses a throwaway copy of the document with a synthetic identifier inserted right after the `#`, which keeps the class intact, then reads the enclosing class/method back from that copy.

Design notes:
- **Parse-only, no build** — the copy is never registered, indexed, or built, so it has zero workspace side effects. (A full document build was rejected: it duplicated the class in the global index and `deleteDocument` did not clean it up.)
- **Gated on `parserErrors.length > 0`** so a clean channel reference like `PRINT #1` at program scope never pays for a reparse.
- Own fields always resolve; inherited fields resolve best-effort via the global index in a running server, and self-heal fully on the next keystroke via the normal path.
- Contained entirely to the completion provider — no grammar change (an empty `SymbolRef.symbol` would be far too ambiguous).

## Tests

Adds 3 regression tests to `completion-test.test.ts`, including a guard that the throwaway reparse leaks nothing into `LangiumDocuments` or the global index (class indexed exactly once).

Full suite: 661 passed, 3 skipped. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)