### PR TITLE
Fix #447: suggest missing 'use' statements via quick-fix

### DIFF
--- a/bbj-vscode/src/language/bbj-code-action-provider.ts
+++ b/bbj-vscode/src/language/bbj-code-action-provider.ts
@@ -4,7 +4,7 @@ import { CodeActionProvider } from 'langium/lsp';
 import { CodeAction, CodeActionKind, CodeActionParams, Command, Diagnostic, TextEdit } from 'vscode-languageserver';
 import { BBjServices } from './bbj-module.js';
 import { JavaInteropService } from './java-interop.js';
-import { isBBjTypeRef, isJavaTypeRef, isSimpleTypeRef } from './generated/ast.js';
+import { isBBjTypeRef, isJavaTypeRef, isMemberCall, isSimpleTypeRef, isSymbolRef } from './generated/ast.js';
 import { findLeafNodeAtOffset } from './bbj-validator.js';
 import { useInsertPosition } from './bbj-use-insert.js';
 
@@ -62,9 +62,13 @@ export class BBjCodeActionProvider implements CodeActionProvider {
         if (!node) {
             return undefined;
         }
-        // Only class-type references can be fixed with a `use` statement.
+        // A `use` statement can fix an unresolved class-type reference, or an unresolved receiver
+        // of a member access — `DataRow.fromJson(...)`, i.e. a static/factory call on a class that
+        // just needs importing. Other unresolved references (plain variables, methods) are ignored.
         const isClassRef = (n = node) => isBBjTypeRef(n) || isSimpleTypeRef(n) || isJavaTypeRef(n);
-        if (!isClassRef() && !(node.$container && isClassRef(node.$container))) {
+        const isMemberAccessReceiver = isSymbolRef(node)
+            && node.$containerProperty === 'receiver' && isMemberCall(node.$container);
+        if (!isClassRef() && !(node.$container && isClassRef(node.$container)) && !isMemberAccessReceiver) {
             return undefined;
         }
         const text = document.textDocument.getText(diagnostic.range).trim();

--- a/bbj-vscode/src/language/bbj-code-action-provider.ts
+++ b/bbj-vscode/src/language/bbj-code-action-provider.ts
@@ -1,11 +1,12 @@
-import { AstUtils, DocumentValidator } from 'langium';
+import { DocumentValidator } from 'langium';
 import type { LangiumDocument } from 'langium';
 import { CodeActionProvider } from 'langium/lsp';
-import { CodeAction, CodeActionKind, CodeActionParams, Command, Diagnostic, Position, TextEdit } from 'vscode-languageserver';
+import { CodeAction, CodeActionKind, CodeActionParams, Command, Diagnostic, TextEdit } from 'vscode-languageserver';
 import { BBjServices } from './bbj-module.js';
 import { JavaInteropService } from './java-interop.js';
-import { isBBjTypeRef, isJavaTypeRef, isSimpleTypeRef, isUse } from './generated/ast.js';
+import { isBBjTypeRef, isJavaTypeRef, isSimpleTypeRef } from './generated/ast.js';
 import { findLeafNodeAtOffset } from './bbj-validator.js';
+import { useInsertPosition } from './bbj-use-insert.js';
 
 /**
  * Offers "Add 'use <fqn>'" quick-fixes for an unresolved Java class reference (issue #447),
@@ -75,7 +76,7 @@ export class BBjCodeActionProvider implements CodeActionProvider {
     }
 
     protected createUseAction(document: LangiumDocument, diagnostic: Diagnostic, fqn: string, preferred: boolean): CodeAction {
-        const edit = TextEdit.insert(this.useInsertPosition(document), `use ${fqn}\n`);
+        const edit = TextEdit.insert(useInsertPosition(document), `use ${fqn}\n`);
         return {
             title: `Add 'use ${fqn}'`,
             kind: CodeActionKind.QuickFix,
@@ -87,17 +88,6 @@ export class BBjCodeActionProvider implements CodeActionProvider {
                 }
             }
         };
-    }
-
-    /** Insert new `use` statements right after the last existing one, or at the top of the file. */
-    protected useInsertPosition(document: LangiumDocument): Position {
-        let line = 0;
-        for (const use of AstUtils.streamAllContents(document.parseResult.value)) {
-            if (isUse(use) && use.$cstNode) {
-                line = Math.max(line, use.$cstNode.range.end.line + 1);
-            }
-        }
-        return Position.create(line, 0);
     }
 }
 

--- a/bbj-vscode/src/language/bbj-code-action-provider.ts
+++ b/bbj-vscode/src/language/bbj-code-action-provider.ts
@@ -39,7 +39,9 @@ export class BBjCodeActionProvider implements CodeActionProvider {
             // such as HashMap, which are not implicit imports, are still suggestable).
             const candidates = rankCandidates(await this.javaInterop.resolveClassCandidatesBySimpleName(simpleName));
             candidates.forEach((fqn, index) => {
-                actions.push(this.createUseAction(document, diagnostic, fqn, index === 0 && candidates.length === 1));
+                // Mark the top-ranked candidate preferred so VS Code's Auto Fix (Ctrl/Cmd+.)
+                // applies it directly without opening the quick-fix menu.
+                actions.push(this.createUseAction(document, diagnostic, fqn, index === 0));
             });
         }
         return actions.length > 0 ? actions : undefined;

--- a/bbj-vscode/src/language/bbj-code-action-provider.ts
+++ b/bbj-vscode/src/language/bbj-code-action-provider.ts
@@ -1,0 +1,115 @@
+import { AstUtils, DocumentValidator } from 'langium';
+import type { LangiumDocument } from 'langium';
+import { CodeActionProvider } from 'langium/lsp';
+import { CodeAction, CodeActionKind, CodeActionParams, Command, Diagnostic, Position, TextEdit } from 'vscode-languageserver';
+import { BBjServices } from './bbj-module.js';
+import { JavaInteropService } from './java-interop.js';
+import { isBBjTypeRef, isJavaTypeRef, isSimpleTypeRef, isUse } from './generated/ast.js';
+import { findLeafNodeAtOffset } from './bbj-validator.js';
+
+/**
+ * Offers "Add 'use <fqn>'" quick-fixes for an unresolved Java class reference (issue #447),
+ * mirroring the auto-import assist that Java IDEs provide.
+ *
+ * The candidate lookup is served entirely from the language server's own Java class index
+ * (see {@link JavaInteropService.findClassCandidatesBySimpleName}) — no new BBj-side interop
+ * capability is required, so this works against the already-shipped interop service.
+ */
+export class BBjCodeActionProvider implements CodeActionProvider {
+
+    protected readonly javaInterop: JavaInteropService;
+
+    constructor(services: BBjServices) {
+        this.javaInterop = services.java.JavaInteropService;
+    }
+
+    async getCodeActions(document: LangiumDocument, params: CodeActionParams): Promise<Array<Command | CodeAction> | undefined> {
+        const linkingDiagnostics = params.context.diagnostics.filter(isLinkingDiagnostic);
+        if (linkingDiagnostics.length === 0) {
+            return undefined;
+        }
+
+        const actions: CodeAction[] = [];
+        for (const diagnostic of linkingDiagnostics) {
+            const simpleName = this.unresolvedClassName(document, diagnostic);
+            if (!simpleName) {
+                continue;
+            }
+            // Resolve candidate FQNs (index + a targeted probe of common packages so classes
+            // such as HashMap, which are not implicit imports, are still suggestable).
+            const candidates = rankCandidates(await this.javaInterop.resolveClassCandidatesBySimpleName(simpleName));
+            candidates.forEach((fqn, index) => {
+                actions.push(this.createUseAction(document, diagnostic, fqn, index === 0 && candidates.length === 1));
+            });
+        }
+        return actions.length > 0 ? actions : undefined;
+    }
+
+    /**
+     * Returns the simple class name of an unresolved class reference the diagnostic points at,
+     * or undefined if the diagnostic is not on a (simple, unqualified) class reference.
+     */
+    protected unresolvedClassName(document: LangiumDocument, diagnostic: Diagnostic): string | undefined {
+        const rootCst = document.parseResult.value.$cstNode;
+        if (!rootCst) {
+            return undefined;
+        }
+        const offset = document.textDocument.offsetAt(diagnostic.range.start);
+        const node = findLeafNodeAtOffset(rootCst, offset)?.astNode;
+        if (!node) {
+            return undefined;
+        }
+        // Only class-type references can be fixed with a `use` statement.
+        const isClassRef = (n = node) => isBBjTypeRef(n) || isSimpleTypeRef(n) || isJavaTypeRef(n);
+        if (!isClassRef() && !(node.$container && isClassRef(node.$container))) {
+            return undefined;
+        }
+        const text = document.textDocument.getText(diagnostic.range).trim();
+        // Already-qualified references (java.util.HashMap) or empty ranges are not candidates.
+        if (!text || text.includes('.')) {
+            return undefined;
+        }
+        return text;
+    }
+
+    protected createUseAction(document: LangiumDocument, diagnostic: Diagnostic, fqn: string, preferred: boolean): CodeAction {
+        const edit = TextEdit.insert(this.useInsertPosition(document), `use ${fqn}\n`);
+        return {
+            title: `Add 'use ${fqn}'`,
+            kind: CodeActionKind.QuickFix,
+            diagnostics: [diagnostic],
+            isPreferred: preferred,
+            edit: {
+                changes: {
+                    [document.textDocument.uri]: [edit]
+                }
+            }
+        };
+    }
+
+    /** Insert new `use` statements right after the last existing one, or at the top of the file. */
+    protected useInsertPosition(document: LangiumDocument): Position {
+        let line = 0;
+        for (const use of AstUtils.streamAllContents(document.parseResult.value)) {
+            if (isUse(use) && use.$cstNode) {
+                line = Math.max(line, use.$cstNode.range.end.line + 1);
+            }
+        }
+        return Position.create(line, 0);
+    }
+}
+
+function isLinkingDiagnostic(diagnostic: Diagnostic): boolean {
+    const data = diagnostic.data as { code?: string } | undefined;
+    return data?.code === DocumentValidator.LinkingError;
+}
+
+/** Rank standard-library and BASIS packages ahead of the rest, then alphabetically. */
+function rankCandidates(fqns: string[]): string[] {
+    const rank = (fqn: string) =>
+        fqn.startsWith('java.') ? 0
+            : fqn.startsWith('javax.') ? 1
+                : fqn.startsWith('com.basis.') ? 2
+                    : 3;
+    return [...fqns].sort((a, b) => rank(a) - rank(b) || a.localeCompare(b));
+}

--- a/bbj-vscode/src/language/bbj-completion-provider.ts
+++ b/bbj-vscode/src/language/bbj-completion-provider.ts
@@ -4,7 +4,7 @@ import { CompletionAcceptor, CompletionContext, CompletionValueItem, DefaultComp
 import { CancellationToken, CompletionItem, CompletionItemKind, CompletionItemTag, CompletionList, CompletionParams, TextEdit } from "vscode-languageserver";
 import { documentationHeader, methodSignature } from "./bbj-hover.js";
 import { isFunctionNodeDescription, type FunctionNodeDescription, getClass } from "./bbj-nodedescription-provider.js";
-import { BbjClass, ConstructorCall, FieldDecl, isBbjClass, isConstructorCall, isDocumented, isFieldDecl, isJavaClass, isJavaField, isJavaMethod, isMethodDecl, LibEventType, LibSymbolicLabelDecl, MethodDecl } from "./generated/ast.js";
+import { BbjClass, ConstructorCall, FieldDecl, isBbjClass, isBBjTypeRef, isConstructorCall, isDocumented, isFieldDecl, isJavaClass, isJavaField, isJavaMethod, isJavaTypeRef, isMethodDecl, isSimpleTypeRef, LibEventType, LibSymbolicLabelDecl, MethodDecl } from "./generated/ast.js";
 import { findLeafNodeAtOffset } from "./bbj-validator.js";
 import { BBjServices } from "./bbj-module.js";
 import { JavaInteropService } from "./java-interop.js";
@@ -43,7 +43,7 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
         const recording: CompletionAcceptor = (ctx, item) => { if (item.label) { offered.add(item.label); } acceptor(ctx, item); };
         await super.completionForCrossReference(context, next, recording);
 
-        if (!this.dotTriggerActive && this.isClassCrossReference(next.feature)) {
+        if (!this.dotTriggerActive && this.isClassCrossReference(next.feature) && this.isTypeReferencePosition(context)) {
             await this.completeAutoImportClasses(context, offered, acceptor);
         }
     }
@@ -54,6 +54,23 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
             return false;
         }
         return (feature.type.ref?.name ?? feature.type.$refText) === 'Class';
+    }
+
+    /**
+     * True only where inserting a class name makes sense as a *type*: a declared/cast/extends type
+     * reference node, or a constructor class right after `new`. A bare class name is also grammatically
+     * a valid expression, so without this guard auto-import would fire in argument/assignment
+     * positions (e.g. `new TreeMap(Tree|)`) and nest a class where a value is expected.
+     */
+    protected isTypeReferencePosition(context: CompletionContext): boolean {
+        const node = context.node;
+        if (node && (isSimpleTypeRef(node) || isBBjTypeRef(node) || isJavaTypeRef(node))) {
+            return true;
+        }
+        // A not-yet-completed `new X` does not parse as a ConstructorCall, so detect it from the
+        // preceding `new` keyword (BBj is case-insensitive).
+        const textBefore = context.textDocument.getText().substring(0, context.tokenOffset);
+        return /\bnew\s+$/i.test(textBefore);
     }
 
     /**

--- a/bbj-vscode/src/language/bbj-completion-provider.ts
+++ b/bbj-vscode/src/language/bbj-completion-provider.ts
@@ -1,14 +1,20 @@
 import { AstNodeDescription, AstUtils, GrammarAST, MaybePromise, ReferenceInfo } from "langium";
 import type { LangiumDocument, LangiumDocumentFactory } from "langium";
-import { CompletionAcceptor, CompletionContext, CompletionValueItem, DefaultCompletionProvider, LangiumServices, NextFeature } from "langium/lsp";
-import { CancellationToken, CompletionItem, CompletionItemKind, CompletionItemTag, CompletionList, CompletionParams } from "vscode-languageserver";
+import { CompletionAcceptor, CompletionContext, CompletionValueItem, DefaultCompletionProvider, NextFeature } from "langium/lsp";
+import { CancellationToken, CompletionItem, CompletionItemKind, CompletionItemTag, CompletionList, CompletionParams, TextEdit } from "vscode-languageserver";
 import { documentationHeader, methodSignature } from "./bbj-hover.js";
 import { isFunctionNodeDescription, type FunctionNodeDescription, getClass } from "./bbj-nodedescription-provider.js";
 import { BbjClass, ConstructorCall, FieldDecl, isBbjClass, isConstructorCall, isDocumented, isFieldDecl, isJavaClass, isJavaField, isJavaMethod, isMethodDecl, LibEventType, LibSymbolicLabelDecl, MethodDecl } from "./generated/ast.js";
 import { findLeafNodeAtOffset } from "./bbj-validator.js";
+import { BBjServices } from "./bbj-module.js";
+import { JavaInteropService } from "./java-interop.js";
+import { useInsertPosition } from "./bbj-use-insert.js";
 
 
 export class BBjCompletionProvider extends DefaultCompletionProvider {
+
+    /** Minimum typed prefix before offering (potentially many) auto-import class suggestions. */
+    protected static readonly AUTO_IMPORT_MIN_PREFIX = 2;
 
     override readonly completionOptions = {
         triggerCharacters: ['#', '(', '.']
@@ -22,10 +28,66 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
     protected dotTriggerActive = false;
 
     protected readonly documentFactory: LangiumDocumentFactory;
+    protected readonly javaInterop: JavaInteropService;
 
-    constructor(services: LangiumServices) {
+    constructor(services: BBjServices) {
         super(services);
         this.documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        this.javaInterop = services.java.JavaInteropService;
+    }
+
+    protected override async completionForCrossReference(context: CompletionContext, next: NextFeature<GrammarAST.CrossReference>, acceptor: CompletionAcceptor): Promise<void> {
+        // Record the simple names the default (in-scope) completion already offers, so an
+        // auto-import suggestion is not duplicated for a class that is already imported.
+        const offered = new Set<string>();
+        const recording: CompletionAcceptor = (ctx, item) => { if (item.label) { offered.add(item.label); } acceptor(ctx, item); };
+        await super.completionForCrossReference(context, next, recording);
+
+        if (!this.dotTriggerActive && this.isClassCrossReference(next.feature)) {
+            await this.completeAutoImportClasses(context, offered, acceptor);
+        }
+    }
+
+    /** True if the cross-reference being completed targets a `Class` (BBj or Java type reference). */
+    protected isClassCrossReference(feature: GrammarAST.AbstractElement): boolean {
+        if (!GrammarAST.isCrossReference(feature)) {
+            return false;
+        }
+        return (feature.type.ref?.name ?? feature.type.$refText) === 'Class';
+    }
+
+    /**
+     * Offers Java classes whose simple name matches the typed prefix but which are not yet
+     * imported, inserting the class name and the corresponding `use` statement in one step
+     * (issue #447). Coverage depends on the class index (complete when the augmented bbj-ls is
+     * present, otherwise classes already resolved this session).
+     */
+    protected async completeAutoImportClasses(context: CompletionContext, alreadyOffered: Set<string>, acceptor: CompletionAcceptor): Promise<void> {
+        const prefix = context.textDocument.getText().substring(context.tokenOffset, context.offset);
+        if (prefix.length < BBjCompletionProvider.AUTO_IMPORT_MIN_PREFIX) {
+            return;
+        }
+        const fqns = await this.javaInterop.findClassCandidatesByPrefix(prefix);
+        if (fqns.length === 0) {
+            return;
+        }
+        const insertPosition = useInsertPosition(context.document);
+        for (const fqn of fqns) {
+            const simple = fqn.substring(fqn.lastIndexOf('.') + 1);
+            if (alreadyOffered.has(simple)) {
+                continue; // already reachable in scope — no `use` needed
+            }
+            alreadyOffered.add(simple);
+            acceptor(context, {
+                label: simple,
+                kind: CompletionItemKind.Class,
+                detail: `Auto-import ${fqn}`,
+                labelDetails: { description: fqn },
+                sortText: `zzzz${simple}`, // rank below in-scope suggestions
+                additionalTextEdits: [TextEdit.insert(insertPosition, `use ${fqn}\n`)],
+                documentation: { kind: 'markdown', value: `Adds \`use ${fqn}\`` }
+            });
+        }
     }
 
     protected override completionFor(context: CompletionContext, next: NextFeature, acceptor: CompletionAcceptor): MaybePromise<void> {
@@ -75,7 +137,30 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
         if (constructorCompletion) {
             return constructorCompletion;
         }
-        return super.getCompletion(document, params, cancelToken);
+        const completion = await super.getCompletion(document, params, cancelToken);
+        return completion ? this.dedupeAutoImportItems(completion) : completion;
+    }
+
+    /**
+     * Drops auto-import suggestions that duplicate a class already offered in scope (which needs no
+     * `use`), or that another grammar feature already produced. Cross-reference completion runs
+     * per grammar feature, so this cross-feature pass is where such duplicates are removed.
+     */
+    protected dedupeAutoImportItems(list: CompletionList): CompletionList {
+        const isAutoImport = (item: CompletionItem) => item.detail?.startsWith('Auto-import ') ?? false;
+        const inScopeLabels = new Set(list.items.filter(item => !isAutoImport(item)).map(item => item.label));
+        const seenAutoImport = new Set<string>();
+        list.items = list.items.filter(item => {
+            if (!isAutoImport(item)) {
+                return true;
+            }
+            if (inScopeLabels.has(item.label) || seenAutoImport.has(item.label)) {
+                return false;
+            }
+            seenAutoImport.add(item.label);
+            return true;
+        });
+        return list;
     }
 
     protected async getFieldCompletion(document: LangiumDocument, params: CompletionParams): Promise<CompletionList | undefined> {

--- a/bbj-vscode/src/language/bbj-completion-provider.ts
+++ b/bbj-vscode/src/language/bbj-completion-provider.ts
@@ -301,9 +301,12 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
                     label: `${className}(${paramList})`,
                     kind: CompletionItemKind.Constructor,
                     detail: `new ${className}(${paramList})`,
-                    insertText: ctor.parameters.map((p, i) =>
+                    // Use a textEdit (not insertText): the cursor is between the just-typed `()`, so
+                    // a no-arg constructor must insert nothing. An empty insertText is falsy and the
+                    // client would fall back to the label `Type()`, nesting it as `new Type(Type())`.
+                    textEdit: TextEdit.insert(params.position, ctor.parameters.map((p, i) =>
                         '${' + (i + 1) + ':' + (p.realName ?? p.name) + '}'
-                    ).join(', '),
+                    ).join(', ')),
                     insertTextFormat: 2, // SnippetString
                     tags: ctor.deprecated ? [CompletionItemTag.Deprecated] : undefined,
                 });
@@ -320,9 +323,11 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
                     label: `${klass.name}(${paramList})`,
                     kind: CompletionItemKind.Constructor,
                     detail: `new ${klass.name}(${paramList})`,
-                    insertText: method.params.map((p, i) =>
+                    // textEdit (not insertText) so a no-arg `create` inserts nothing rather than
+                    // falling back to the label — see the Java-class branch above.
+                    textEdit: TextEdit.insert(params.position, method.params.map((p, i) =>
                         '${' + (i + 1) + ':' + p.name + '}'
-                    ).join(', '),
+                    ).join(', ')),
                     insertTextFormat: 2,
                 });
             }

--- a/bbj-vscode/src/language/bbj-module.ts
+++ b/bbj-vscode/src/language/bbj-module.ts
@@ -14,6 +14,7 @@ import {
     prepareLangiumParser
 } from 'langium';
 import { LangiumSharedServices, LangiumServices, PartialLangiumServices, createDefaultSharedModule, createDefaultModule, DefaultSharedModuleContext } from 'langium/lsp';
+import { BBjCodeActionProvider } from './bbj-code-action-provider.js';
 import { BBjCommentProvider } from './bbj-comment-provider.js';
 import { BBjCompletionProvider } from './bbj-completion-provider.js';
 import { BBjDefinitionProvider } from './bbj-definition-provider.js';
@@ -100,6 +101,7 @@ export const BBjModule: Module<BBjServices, PartialLangiumServices & BBjAddedSer
         CompletionProvider: (services) => new BBjCompletionProvider(services),
         SemanticTokenProvider: (services) => new BBjSemanticTokenProvider(services),
         SignatureHelp: () => new BBjSignatureHelpProvider(),
+        CodeActionProvider: (services) => new BBjCodeActionProvider(services),
     },
     parser: {
         LangiumParser: (services) => createBBjParser(services),

--- a/bbj-vscode/src/language/bbj-use-insert.ts
+++ b/bbj-vscode/src/language/bbj-use-insert.ts
@@ -1,0 +1,19 @@
+import { AstUtils } from 'langium';
+import type { LangiumDocument } from 'langium';
+import { Position } from 'vscode-languageserver';
+import { isUse } from './generated/ast.js';
+
+/**
+ * Position at which to insert a new `use` statement: on the line right after the last existing
+ * `use`, or the top of the file when there are none. Shared by the missing-`use` quick-fix and
+ * completion-time auto-import (issue #447).
+ */
+export function useInsertPosition(document: LangiumDocument): Position {
+    let line = 0;
+    for (const node of AstUtils.streamAllContents(document.parseResult.value)) {
+        if (isUse(node) && node.$cstNode) {
+            line = Math.max(line, node.$cstNode.range.end.line + 1);
+        }
+    }
+    return Position.create(line, 0);
+}

--- a/bbj-vscode/src/language/java-interop.ts
+++ b/bbj-vscode/src/language/java-interop.ts
@@ -19,6 +19,15 @@ import { assertType } from './utils.js';
 
 const implicitJavaImports = ['java.lang', 'com.basis.startup.type', 'com.basis.bbj.proxies', 'com.basis.bbj.proxies.sysgui', 'com.basis.bbj.proxies.event', 'com.basis.startup.type.sysgui', 'com.basis.bbj.proxies.servlet']
 
+/**
+ * Packages probed (as `pkg.SimpleName`) when suggesting a `use` statement for an unresolved
+ * class reference (issue #447). Unlike {@link implicitJavaImports}, these are NOT auto-imported;
+ * they are only tried on demand to discover the FQN of a specific simple name. Kept to common
+ * standard-library packages; broader/customer-jar coverage would need a dedicated server-side
+ * lookup (deliberately avoided here so no BBj-side rebuild is required).
+ */
+const autoImportCandidatePackages = ['java.util', 'java.util.concurrent', 'java.util.function', 'java.util.stream', 'java.io', 'java.nio.file', 'java.time', 'java.math', 'java.net', 'java.text']
+
 export const JavaSyntheticDocUri = 'classpath:/bbj.bbl'
 
 /**
@@ -254,6 +263,52 @@ export class JavaInteropService {
             console.error(e)
             return false;
         }
+    }
+
+    /**
+     * Suggests fully-qualified names for an unresolved simple class name, to power missing-`use`
+     * quick-fixes (issue #447). Combines classes already in the index with a cheap, targeted probe
+     * of the curated {@link autoImportCandidatePackages}: it tries to resolve `pkg.SimpleName` for
+     * each candidate package (a handful of on-demand lookups — no full-package enumeration and no
+     * new server capability). Probe failures are ignored. Results are de-duplicated and sorted.
+     */
+    public async resolveClassCandidatesBySimpleName(simpleName: string, token?: CancellationToken): Promise<string[]> {
+        const found = new Set<string>(this.findClassCandidatesBySimpleName(simpleName));
+        await Promise.all(autoImportCandidatePackages.map(async pack => {
+            const fqn = `${pack}.${simpleName}`;
+            try {
+                const resolved = await this.resolveClassByName(fqn, token);
+                if (resolved && !resolved.error) {
+                    found.add(fqn);
+                }
+            } catch (e) {
+                logger.debug(() => `Auto-import probe for ${fqn} failed: ` + (e instanceof Error ? e.message : String(e)));
+            }
+        }));
+        return [...found].sort();
+    }
+
+    /**
+     * Returns fully-qualified names of already-resolved Java classes whose simple name matches
+     * `simpleName` (case-insensitive), used to suggest missing `use` statements (issue #447).
+     * Only classes present in the index are considered; {@link resolveClassCandidatesBySimpleName}
+     * additionally probes common packages. Inner classes and classes without a package (nothing to
+     * `use`) are skipped. Results are de-duplicated and sorted.
+     */
+    public findClassCandidatesBySimpleName(simpleName: string): string[] {
+        const target = simpleName.toLowerCase();
+        const matches = new Set<string>();
+        for (const javaClass of this.resolvedClasses.values()) {
+            if (javaClass.error || !javaClass.packageName) {
+                continue;
+            }
+            const simple = javaClass.name.substring(javaClass.name.lastIndexOf('.') + 1);
+            if (simple.includes('$') || simple.toLowerCase() !== target) {
+                continue;
+            }
+            matches.add(`${javaClass.packageName}.${simple}`);
+        }
+        return [...matches].sort();
     }
 
     /**

--- a/bbj-vscode/src/language/java-interop.ts
+++ b/bbj-vscode/src/language/java-interop.ts
@@ -266,13 +266,87 @@ export class JavaInteropService {
     }
 
     /**
+     * Complete `simpleName(lowercased) → FQN[]` index built from the augmented bbj-ls
+     * `getAllClassNames` endpoint, or null when that endpoint is unavailable (older server).
+     */
+    private completeClassIndex: Map<string, string[]> | null = null;
+    /** True once we have determined — by success or a definitive MethodNotFound — whether {@link completeClassIndex} is available. */
+    private completeIndexResolved = false;
+
+    /**
+     * Builds the {@link completeClassIndex} from the augmented bbj-ls `getAllClassNames` endpoint,
+     * at most once, and reports whether a complete index is available. Servers that predate the
+     * endpoint answer with a MethodNotFound error, which is latched so callers transparently fall
+     * back to the on-demand probe/index (issue #447). Transient connection errors are NOT latched,
+     * so a later call can still succeed once interop is reachable.
+     */
+    public async ensureCompleteClassIndex(token?: CancellationToken): Promise<boolean> {
+        if (this.completeIndexResolved) {
+            return this.completeClassIndex !== null;
+        }
+        try {
+            const connection = await this.connect();
+            const fqns = await connection.sendRequest(getAllClassNamesRequest, {}, token);
+            this.buildCompleteClassIndex(fqns);
+            logger.info(() => `Loaded complete Java class index (${this.completeClassIndex!.size} distinct simple names)`);
+            return true;
+        } catch (e) {
+            if ((e as { code?: number } | undefined)?.code === METHOD_NOT_FOUND) {
+                // Server predates the augmented endpoint — stop probing and use the fallback path.
+                this.completeIndexResolved = true;
+                logger.debug('Interop service has no getAllClassNames; using on-demand class suggestions.');
+            } else {
+                logger.debug(() => 'getAllClassNames failed (will retry): ' + (e instanceof Error ? e.message : String(e)));
+            }
+            return false;
+        }
+    }
+
+    /** True once a complete class index has been built (i.e. the augmented endpoint is available). */
+    public hasCompleteClassIndex(): boolean {
+        return this.completeClassIndex !== null;
+    }
+
+    /** Drops the complete class index so it is rebuilt on the next request (e.g. after a classpath change). */
+    protected clearCompleteClassIndex(): void {
+        this.completeClassIndex = null;
+        this.completeIndexResolved = false;
+    }
+
+    /**
+     * Builds {@link completeClassIndex} from a list of fully-qualified class names, indexing each by
+     * its lowercased simple name. Inner classes and packageless names are skipped. Marks the index
+     * as resolved. Shared by the live `getAllClassNames` path and test seeding.
+     */
+    protected buildCompleteClassIndex(fqns: string[]): void {
+        const index = new Map<string, string[]>();
+        for (const fqn of fqns) {
+            const simple = fqn.substring(fqn.lastIndexOf('.') + 1);
+            if (!simple || simple.includes('$') || !fqn.includes('.')) {
+                continue;
+            }
+            const key = simple.toLowerCase();
+            let bucket = index.get(key);
+            if (!bucket) {
+                index.set(key, bucket = []);
+            }
+            bucket.push(fqn);
+        }
+        this.completeClassIndex = index;
+        this.completeIndexResolved = true;
+    }
+
+    /**
      * Suggests fully-qualified names for an unresolved simple class name, to power missing-`use`
-     * quick-fixes (issue #447). Combines classes already in the index with a cheap, targeted probe
-     * of the curated {@link autoImportCandidatePackages}: it tries to resolve `pkg.SimpleName` for
-     * each candidate package (a handful of on-demand lookups — no full-package enumeration and no
-     * new server capability). Probe failures are ignored. Results are de-duplicated and sorted.
+     * quick-fixes (issue #447). Prefers the complete index when the augmented server provides it;
+     * otherwise falls back to classes already in the index plus a cheap, targeted probe of the
+     * curated {@link autoImportCandidatePackages} (`pkg.SimpleName` lookups — no full-package
+     * enumeration). Results are de-duplicated and sorted.
      */
     public async resolveClassCandidatesBySimpleName(simpleName: string, token?: CancellationToken): Promise<string[]> {
+        if (await this.ensureCompleteClassIndex(token)) {
+            return [...(this.completeClassIndex!.get(simpleName.toLowerCase()) ?? [])].sort();
+        }
         const found = new Set<string>(this.findClassCandidatesBySimpleName(simpleName));
         await Promise.all(autoImportCandidatePackages.map(async pack => {
             const fqn = `${pack}.${simpleName}`;
@@ -286,6 +360,37 @@ export class JavaInteropService {
             }
         }));
         return [...found].sort();
+    }
+
+    /**
+     * Returns fully-qualified names of Java classes whose simple name starts with `prefix`
+     * (case-insensitive), for completion-time auto-import (issue #447). Uses the complete index
+     * when the augmented server provides it; otherwise falls back to classes already resolved in
+     * this session. Inner/packageless classes are skipped and the result is bounded by `limit`.
+     */
+    public async findClassCandidatesByPrefix(prefix: string, limit = 50, token?: CancellationToken): Promise<string[]> {
+        const lower = prefix.toLowerCase();
+        const matches = new Set<string>();
+        if (await this.ensureCompleteClassIndex(token)) {
+            for (const [key, fqns] of this.completeClassIndex!) {
+                if (key.startsWith(lower)) {
+                    fqns.forEach(fqn => matches.add(fqn));
+                    if (matches.size >= limit * 2) break;
+                }
+            }
+        } else {
+            for (const javaClass of this.resolvedClasses.values()) {
+                if (javaClass.error || !javaClass.packageName) {
+                    continue;
+                }
+                const simple = javaClass.name.substring(javaClass.name.lastIndexOf('.') + 1);
+                if (simple.includes('$') || !simple.toLowerCase().startsWith(lower)) {
+                    continue;
+                }
+                matches.add(`${javaClass.packageName}.${simple}`);
+            }
+        }
+        return [...matches].sort().slice(0, limit);
     }
 
     /**
@@ -770,6 +875,16 @@ const getClassInfosRequest = new RequestType<PackageInfoParams, JavaClass[], nul
  * Request type for retrieving all top-level packages available in the classpath.
  */
 const getTopLevelPackages = new RequestType<null, PackageInfoParams[], null>('getTopLevelPackages');
+
+/**
+ * Request type for retrieving every fully-qualified class name known to the interop service
+ * (classpath jars plus JDK modules). Provided only by an augmented bbj-ls; older servers answer
+ * with a MethodNotFound error, which callers use to fall back to on-demand class suggestions.
+ */
+const getAllClassNamesRequest = new RequestType<null, string[], null>('getAllClassNames');
+
+/** JSON-RPC error code returned by a server that does not implement a requested method. */
+const METHOD_NOT_FOUND = -32601;
 
 /**
  * Parameters for class information requests.

--- a/bbj-vscode/test/bbj-test-module.ts
+++ b/bbj-vscode/test/bbj-test-module.ts
@@ -68,9 +68,31 @@ class JavaInteropTestService extends JavaInteropService {
         }
     }
 
-    // The fake service preloads all classes it needs; resolve auto-import candidates only
-    // from the in-memory index so tests never reach the real Java interop socket (:5008).
-    public override async resolveClassCandidatesBySimpleName(simpleName: string): Promise<string[]> {
+    // The fake service must never reach the real Java interop socket (:5008). By default it
+    // behaves like an OLD server with no getAllClassNames endpoint, so ensureCompleteClassIndex
+    // reports "unavailable" and callers exercise the fallback path. Tests can opt into the
+    // augmented-server behaviour with seedCompleteClassIndex().
+    public override async ensureCompleteClassIndex(): Promise<boolean> {
+        return this.hasCompleteClassIndex();
+    }
+
+    /** Test seam: simulate an augmented bbj-ls by seeding the complete class index. */
+    public seedCompleteClassIndex(fqns: string[]): void {
+        this.buildCompleteClassIndex(fqns);
+    }
+
+    /** Test seam: revert to the default old-server behaviour (no complete index). */
+    public resetCompleteClassIndex(): void {
+        this.clearCompleteClassIndex();
+    }
+
+    // Avoid the base class's on-demand package probe (which would resolve uncached FQNs and
+    // reach the interop socket). With a seeded index, defer to the base (index-only) path;
+    // otherwise resolve candidates from the in-memory index alone.
+    public override async resolveClassCandidatesBySimpleName(simpleName: string, token?: CancellationToken): Promise<string[]> {
+        if (this.hasCompleteClassIndex()) {
+            return super.resolveClassCandidatesBySimpleName(simpleName, token);
+        }
         return this.findClassCandidatesBySimpleName(simpleName);
     }
 }

--- a/bbj-vscode/test/bbj-test-module.ts
+++ b/bbj-vscode/test/bbj-test-module.ts
@@ -67,6 +67,12 @@ class JavaInteropTestService extends JavaInteropService {
             this.langiumDocuments.addDocument(this.classpathDocument);
         }
     }
+
+    // The fake service preloads all classes it needs; resolve auto-import candidates only
+    // from the in-memory index so tests never reach the real Java interop socket (:5008).
+    public override async resolveClassCandidatesBySimpleName(simpleName: string): Promise<string[]> {
+        return this.findClassCandidatesBySimpleName(simpleName);
+    }
 }
 
 function createBBjApiClass(container: Classpath) {

--- a/bbj-vscode/test/bbj-test-module.ts
+++ b/bbj-vscode/test/bbj-test-module.ts
@@ -5,6 +5,7 @@ import { BBjGeneratedModule, BBjGeneratedSharedModule } from "../src/language/ge
 import { registerValidationChecks } from "../src/language/bbj-validator.js";
 import { JavaInteropService } from "../src/language/java-interop.js";
 import { Classpath, JavaClass, JavaField, JavaMethod } from "../src/language/generated/ast.js";
+import { CancellationToken, MessageConnection } from "vscode-jsonrpc/node.js";
 import { BbjLexer } from "../src/language/bbj-lexer.js";
 import { JavadocProvider } from "../src/language/java-javadoc.js";
 
@@ -94,6 +95,44 @@ class JavaInteropTestService extends JavaInteropService {
             return super.resolveClassCandidatesBySimpleName(simpleName, token);
         }
         return this.findClassCandidatesBySimpleName(simpleName);
+    }
+
+    // --- Hermetic: the test double must never open a real socket to the interop service. ---
+    // On CI there is no service on :5008, so real connection attempts reject asynchronously and
+    // log via console.*. A late log arriving while a vitest worker closes its RPC channel throws
+    // "EnvironmentTeardownError: Closing rpc while onUserConsoleLog was pending" and fails the whole
+    // run nondeterministically (green on rerun). The double preloads the classes it needs, so every
+    // network path below is a silent no-op instead.
+
+    protected override connect(): Promise<MessageConnection> {
+        return Promise.reject(new Error('Java interop is disabled in the test double'));
+    }
+
+    public override async loadClasspath(): Promise<boolean> {
+        return false;
+    }
+
+    public override async loadImplicitImports(): Promise<boolean> {
+        return false;
+    }
+
+    public override async resolveClassByName(className: string): Promise<JavaClass> {
+        // A preloaded class, or a silent stub for anything else — never a socket, never a log.
+        return this.getResolvedClass(className) ?? this.stubClass(className);
+    }
+
+    private stubClass(className: string): JavaClass {
+        const dot = className.lastIndexOf('.');
+        return {
+            $type: JavaClass.$type,
+            name: className,
+            packageName: dot >= 0 ? className.substring(0, dot) : '',
+            $container: this.classpath,
+            $containerProperty: 'classes',
+            classes: [], fields: [], methods: [], constructors: [],
+            deprecated: false,
+            error: 'not resolved (test double)'
+        } as unknown as JavaClass;
     }
 }
 

--- a/bbj-vscode/test/code-action.test.ts
+++ b/bbj-vscode/test/code-action.test.ts
@@ -81,6 +81,21 @@ describe('BBj code actions — missing use statements (#447)', () => {
         }
     });
 
+    test('offers a use for an unresolved factory-method receiver (DataRow.fromJson) - issue #447', async () => {
+        const interop = bbj.java.JavaInteropService as unknown as {
+            seedCompleteClassIndex(f: string[]): void; resetCompleteClassIndex(): void;
+        };
+        interop.seedCompleteClassIndex(['com.example.DataRow']);
+        try {
+            // `DataRow` is a static/factory receiver (a SymbolRef, not a type reference); the
+            // quick-fix must still offer to import it.
+            const { actions } = await codeActionsFor('dr! = DataRow.fromJson("x")\n');
+            expect(actions.map(a => a.title)).toContain("Add 'use com.example.DataRow'");
+        } finally {
+            interop.resetCompleteClassIndex();
+        }
+    });
+
     test('offers nothing when there are no linking diagnostics', async () => {
         const doc = await parse('use java.util.HashMap\nhm! = new HashMap()\n', { documentUri: 'file:///ca-clean.bbj', validation: true });
         const params: CodeActionParams = {

--- a/bbj-vscode/test/code-action.test.ts
+++ b/bbj-vscode/test/code-action.test.ts
@@ -64,6 +64,23 @@ describe('BBj code actions — missing use statements (#447)', () => {
         expect(actions).toHaveLength(0);
     });
 
+    test('uses the complete index (augmented server) to suggest a class not otherwise loaded', async () => {
+        // Simulate an augmented bbj-ls that provides the full class list; TreeMap is not in the
+        // fake classpath, so this only works via the seeded complete index.
+        const interop = bbj.java.JavaInteropService as unknown as {
+            seedCompleteClassIndex(f: string[]): void; resetCompleteClassIndex(): void;
+        };
+        interop.seedCompleteClassIndex(['java.util.TreeMap', 'java.util.HashMap']);
+        try {
+            expect(await bbj.java.JavaInteropService.resolveClassCandidatesBySimpleName('TreeMap'))
+                .toEqual(['java.util.TreeMap']);
+            const { actions } = await codeActionsFor('tm! = new TreeMap()\n');
+            expect(actions.map(a => a.title)).toContain("Add 'use java.util.TreeMap'");
+        } finally {
+            interop.resetCompleteClassIndex(); // restore default (old-server) behaviour for later tests
+        }
+    });
+
     test('offers nothing when there are no linking diagnostics', async () => {
         const doc = await parse('use java.util.HashMap\nhm! = new HashMap()\n', { documentUri: 'file:///ca-clean.bbj', validation: true });
         const params: CodeActionParams = {

--- a/bbj-vscode/test/code-action.test.ts
+++ b/bbj-vscode/test/code-action.test.ts
@@ -1,0 +1,77 @@
+import { DocumentValidator, EmptyFileSystem, LangiumDocument } from 'langium';
+import { parseHelper } from 'langium/test';
+import { describe, expect, test } from 'vitest';
+import { CodeAction, CodeActionParams, Diagnostic } from 'vscode-languageserver';
+import { createBBjTestServices } from './bbj-test-module';
+import { Model } from '../src/language/generated/ast.js';
+
+const services = createBBjTestServices(EmptyFileSystem);
+const bbj = services.BBj;
+const parse = parseHelper<Model>(bbj);
+
+function linkingDiagnostics(doc: LangiumDocument): Diagnostic[] {
+    return (doc.diagnostics ?? []).filter(d => (d.data as { code?: string } | undefined)?.code === DocumentValidator.LinkingError);
+}
+
+async function codeActionsFor(text: string): Promise<{ doc: LangiumDocument, actions: CodeAction[], linking: Diagnostic[] }> {
+    const doc = await parse(text, { documentUri: `file:///ca-${Math.round(Math.random() * 1e9)}.bbj`, validation: true });
+    const linking = linkingDiagnostics(doc);
+    const params: CodeActionParams = {
+        textDocument: { uri: doc.textDocument.uri },
+        range: linking[0]?.range ?? { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        context: { diagnostics: linking }
+    };
+    const result = await bbj.lsp.CodeActionProvider!.getCodeActions(doc, params);
+    return { doc, actions: (result ?? []) as CodeAction[], linking };
+}
+
+describe('BBj code actions — missing use statements (#447)', () => {
+
+    test('index resolves a simple name to its FQN', () => {
+        expect(bbj.java.JavaInteropService.findClassCandidatesBySimpleName('HashMap')).toEqual(['java.util.HashMap']);
+        // case-insensitive match on the simple name
+        expect(bbj.java.JavaInteropService.findClassCandidatesBySimpleName('hashmap')).toEqual(['java.util.HashMap']);
+        // nothing for an unknown class
+        expect(bbj.java.JavaInteropService.findClassCandidatesBySimpleName('Nope')).toEqual([]);
+    });
+
+    test("offers 'use java.util.HashMap' for an unresolved HashMap reference", async () => {
+        const { actions, linking } = await codeActionsFor('hm! = new HashMap()\n');
+        expect(linking.length).toBe(1);
+        const titles = actions.map(a => a.title);
+        expect(titles).toContain("Add 'use java.util.HashMap'");
+        const action = actions.find(a => a.title === "Add 'use java.util.HashMap'")!;
+        expect(action.kind).toBe('quickfix');
+        expect(action.diagnostics).toEqual(linking);
+        // inserts the use statement at the top of an import-less file
+        const edit = action.edit!.changes![Object.keys(action.edit!.changes!)[0]][0];
+        expect(edit.newText).toBe('use java.util.HashMap\n');
+        expect(edit.range.start).toEqual({ line: 0, character: 0 });
+    });
+
+    test('inserts new use after existing use statements', async () => {
+        const { actions } = await codeActionsFor('use java.lang.String\nhm! = new HashMap()\n');
+        const action = actions.find(a => a.title === "Add 'use java.util.HashMap'")!;
+        expect(action).toBeDefined();
+        const edit = action.edit!.changes![Object.keys(action.edit!.changes!)[0]][0];
+        // after the existing `use` on line 0
+        expect(edit.range.start.line).toBe(1);
+    });
+
+    test('offers nothing for an unresolved class with no known FQN', async () => {
+        const { actions, linking } = await codeActionsFor('x! = new Foobar()\n');
+        expect(linking.length).toBeGreaterThanOrEqual(1);
+        expect(actions).toHaveLength(0);
+    });
+
+    test('offers nothing when there are no linking diagnostics', async () => {
+        const doc = await parse('use java.util.HashMap\nhm! = new HashMap()\n', { documentUri: 'file:///ca-clean.bbj', validation: true });
+        const params: CodeActionParams = {
+            textDocument: { uri: doc.textDocument.uri },
+            range: { start: { line: 1, character: 0 }, end: { line: 1, character: 5 } },
+            context: { diagnostics: [] }
+        };
+        const result = await bbj.lsp.CodeActionProvider!.getCodeActions(doc, params);
+        expect(result ?? []).toHaveLength(0);
+    });
+});

--- a/bbj-vscode/test/completion-test.test.ts
+++ b/bbj-vscode/test/completion-test.test.ts
@@ -507,4 +507,28 @@ y = 2
             }
         });
     });
+
+    describe('auto-import only fires in type positions - issue #447', () => {
+        const hasAutoImport = (completions: { items: { label: string, additionalTextEdits?: unknown }[] }) =>
+            completions.items.some(i => i.label === 'TreeMap' && i.additionalTextEdits);
+
+        function autoImportCase(name: string, text: string, expected: boolean) {
+            test(name, async () => {
+                interopSeam.seedCompleteClassIndex(['java.util.TreeMap']);
+                try {
+                    await completion({ text, index: 0, assert: (c) => expect(hasAutoImport(c)).toBe(expected) });
+                } finally {
+                    interopSeam.resetCompleteClassIndex();
+                }
+            });
+        }
+
+        // Type positions — auto-import is helpful.
+        autoImportCase('after new', `x! = new TreeM<|>`, true);
+        autoImportCase('declared type', `declare TreeM<|> x!`, true);
+        // Expression positions — offering a bare class would nest a class where a value is expected
+        // (e.g. accepting here then typing '(' yields `new TreeMap(TreeMap())`).
+        autoImportCase('constructor argument', `tm! = new HashMap(Tree<|>)`, false);
+        autoImportCase('assignment value', `x! = Tree<|>`, false);
+    });
 });

--- a/bbj-vscode/test/completion-test.test.ts
+++ b/bbj-vscode/test/completion-test.test.ts
@@ -472,4 +472,39 @@ y = 2
         const list = await fieldCompletion(text);
         expect(list?.items ?? []).toHaveLength(0);
     });
+
+    const interopSeam = bbjServices.java.JavaInteropService as unknown as {
+        seedCompleteClassIndex(f: string[]): void; resetCompleteClassIndex(): void;
+    };
+
+    test('auto-import completion offers an unimported class with a use edit (augmented server) - issue #447', async () => {
+        interopSeam.seedCompleteClassIndex(['java.util.TreeMap']);
+        try {
+            await completion({
+                text: `x! = new TreeM<|>`,
+                index: 0,
+                assert: (completions) => {
+                    const item = completions.items.find(i => i.label === 'TreeMap');
+                    expect(item).toBeDefined();
+                    expect(item!.kind).toBe(7); // CompletionItemKind.Class
+                    expect(item!.additionalTextEdits?.[0].newText).toBe('use java.util.TreeMap\n');
+                }
+            });
+        } finally {
+            interopSeam.resetCompleteClassIndex();
+        }
+    });
+
+    test('auto-import completion falls back to already-resolved classes (old server) - issue #447', async () => {
+        // No complete index seeded: HashMap is in the fake classpath, so the fallback still offers it.
+        await completion({
+            text: `x! = new HashM<|>`,
+            index: 0,
+            assert: (completions) => {
+                const item = completions.items.find(i => i.label === 'HashMap' && i.additionalTextEdits);
+                expect(item).toBeDefined();
+                expect(item!.additionalTextEdits?.[0].newText).toBe('use java.util.HashMap\n');
+            }
+        });
+    });
 });

--- a/bbj-vscode/test/completion-test.test.ts
+++ b/bbj-vscode/test/completion-test.test.ts
@@ -182,6 +182,31 @@ w! = new MyWidget(<|>)
         });
     });
 
+    test('no-arg constructor completion inserts nothing, not the label - issue #447', async () => {
+        // Regression: a no-arg constructor item had an empty insertText, which is falsy, so the
+        // client falls back to the label `MyWidget()` and nests it as `new MyWidget(MyWidget())`.
+        // It must use a textEdit that inserts nothing instead.
+        const text = `
+class public MyWidget
+    method public void create()
+    methodend
+classend
+declare MyWidget w!
+w! = new MyWidget(<|>)
+        `
+        await completion({
+            text,
+            index: 0,
+            assert: (completions) => {
+                const ctor = completions.items.find(i => i.kind === 4 && i.label === 'MyWidget()');
+                expect(ctor).toBeDefined();
+                expect(ctor!.insertText).toBeUndefined();
+                expect(ctor!.textEdit).toBeDefined();
+                expect((ctor!.textEdit as { newText: string }).newText).toBe('');
+            }
+        });
+    });
+
     test('class-reference completion after `new` does not crash (issue: Langium 4.3 synthetic node)', async () => {
         // Regression: getScope read container.simpleClass.$refText on a synthetic
         // completion node where simpleClass is undefined, throwing a TypeError that

--- a/bbj-vscode/test/functional/issue447-real-interop.test.ts
+++ b/bbj-vscode/test/functional/issue447-real-interop.test.ts
@@ -1,0 +1,54 @@
+import { DocumentValidator, LangiumDocument } from 'langium';
+import { NodeFileSystem } from 'langium/node';
+import { parseHelper } from 'langium/test';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { CodeAction, CodeActionParams } from 'vscode-languageserver';
+import { Model } from '../../src/language/generated/ast.js';
+import { createBBjServices } from '../../src/language/bbj-module.js';
+import { JavadocProvider } from '../../src/language/java-javadoc.js';
+import { initializeWorkspace, shouldRunBBjTests } from '../test-helper.js';
+
+/**
+ * End-to-end verification for issue #447 against the LIVE java-interop service on :5008.
+ * `java.util.HashMap` is not an implicit import, so the missing-`use` quick-fix depends on
+ * the targeted candidate probe (resolveClassCandidatesBySimpleName) actually resolving
+ * `java.util.HashMap` from the real classpath. Skipped unless interop is reachable.
+ */
+describe('Issue #447 - suggest missing use statements (real interop)', async () => {
+    const run = await shouldRunBBjTests();
+
+    const services = createBBjServices(NodeFileSystem);
+    const validate = (content: string) => parseHelper<Model>(services.BBj)(content, { validation: true });
+
+    beforeAll(async () => {
+        if (!run) return;
+        if (!JavadocProvider.getInstance().isInitialized()) {
+            JavadocProvider.getInstance().initialize([], services.shared.workspace.FileSystemProvider);
+        }
+        services.BBj.java.JavaInteropService.setConnectionConfig('127.0.0.1', 5008);
+        await initializeWorkspace(services.shared);
+    }, 120000);
+
+    function linkingErrors(document: LangiumDocument) {
+        return document.diagnostics?.filter(err => err.data?.code === DocumentValidator.LinkingError) ?? [];
+    }
+
+    test.runIf(run)('probe resolves HashMap to java.util.HashMap from the real classpath', async () => {
+        const candidates = await services.BBj.java.JavaInteropService.resolveClassCandidatesBySimpleName('HashMap');
+        expect(candidates).toContain('java.util.HashMap');
+    }, 60000);
+
+    test.runIf(run)("offers 'use java.util.HashMap' for an unresolved HashMap reference", async () => {
+        const doc = await validate('hm! = new HashMap()\n');
+        const linking = linkingErrors(doc);
+        expect(linking.some(d => d.message.includes('HashMap'))).toBe(true);
+
+        const params: CodeActionParams = {
+            textDocument: { uri: doc.textDocument.uri },
+            range: linking[0].range,
+            context: { diagnostics: linking }
+        };
+        const actions = (await services.BBj.lsp.CodeActionProvider!.getCodeActions(doc, params) ?? []) as CodeAction[];
+        expect(actions.map(a => a.title)).toContain("Add 'use java.util.HashMap'");
+    }, 60000);
+});

--- a/bbj-vscode/test/functional/issue447-real-interop.test.ts
+++ b/bbj-vscode/test/functional/issue447-real-interop.test.ts
@@ -33,8 +33,13 @@ describe('Issue #447 - suggest missing use statements (real interop)', async () 
         return document.diagnostics?.filter(err => err.data?.code === DocumentValidator.LinkingError) ?? [];
     }
 
-    test.runIf(run)('probe resolves HashMap to java.util.HashMap from the real classpath', async () => {
-        const candidates = await services.BBj.java.JavaInteropService.resolveClassCandidatesBySimpleName('HashMap');
+    test.runIf(run)('capability detection: current server lacks getAllClassNames and degrades gracefully', async () => {
+        const interop = services.BBj.java.JavaInteropService;
+        // The deployed server predates the augmented endpoint, so no complete index is built...
+        expect(await interop.ensureCompleteClassIndex()).toBe(false);
+        expect(interop.hasCompleteClassIndex()).toBe(false);
+        // ...yet suggestions still work via the fallback probe.
+        const candidates = await interop.resolveClassCandidatesBySimpleName('HashMap');
         expect(candidates).toContain('java.util.HashMap');
     }, 60000);
 

--- a/bbj-vscode/test/functional/lsp-features.test.ts
+++ b/bbj-vscode/test/functional/lsp-features.test.ts
@@ -105,7 +105,11 @@ describe('LSP Feature Verification Tests', async () => {
                     Hash<|>
                 `,
                 index: 0,
-                expectedItems: ['HashMap']
+                // The imported class is proposed; auto-import (#447) may add further unimported
+                // `Hash*` classes with a `use` edit, so assert presence rather than an exact set.
+                assert: (completions) => {
+                    expect(completions.items.map(i => i.label)).toContain('HashMap');
+                }
             });
         });
     });


### PR DESCRIPTION
Closes #447.

Java-IDE-style assistance for missing `use` statements, in two forms — both work in **VS Code and IntelliJ** through the shared language server.

## Features

1. **Quick-fix** — an unresolved class reference offers *"Add 'use <fqn>'"*. Covers:
   - constructor calls (`hm! = new HashMap()`),
   - declared/cast/extends types,
   - **static/factory receivers** (`dr! = DataRow.fromJson(x$)`).
   The top candidate is `isPreferred`, so VS Code's Auto-Fix (Ctrl/Cmd+.) applies it directly.
2. **Completion auto-import** — typing a class prefix in a type position (`new TreeM`, `declare TreeM`) proposes unimported classes; accepting one inserts the class name **and** the `use` statement in one step (`additionalTextEdits`).

## Hybrid design: augmented server when present, graceful fallback otherwise

Suggestions are backed by a `simpleName → FQN` index whose completeness depends on the connected `bbj-ls`:

- **Augmented `bbj-ls`** (companion change: adds a `getAllClassNames` endpoint) → the LS fetches the full class list once (classpath jars **and** JDK modules), so every class is suggestable, including cold JDK types like `TreeMap`.
- **Existing `bbj-ls`** (no endpoint) → the call returns `MethodNotFound`, which the LS latches and falls back to today's behaviour: an on-demand `pkg.SimpleName` probe for the quick-fix, and classes already resolved this session for completion.

Capability detection follows the existing `getTopLevelPackages` precedent. Why the endpoint is needed: `getClassInfos("java.util")` returns 0 against the live service — JDK classes live in JVM modules, invisible to Guava `ClassPath` — so there is no runtime way to enumerate them for prefix completion. The endpoint adds a `ModuleFinder.ofSystem()` walk (~15k JDK classes).

## Correctness details handled

- **Auto-import only in type positions.** A bare class name is also a valid BBj expression, so auto-import is gated to type-reference nodes or a `new`-prefixed token — otherwise it fired in argument/assignment positions and nested a class where a value belongs (`new TreeMap(Tree|)` → `new TreeMap(TreeMap())`).
- **No-arg constructor completion.** Constructor items now use a `textEdit` (zero-width insert) rather than an empty `insertText`, which the client would otherwise replace with the label — the other source of `new TreeMap(TreeMap())`.

## Implementation

- `JavaInteropService`: `ensureCompleteClassIndex()` (capability probe), `resolveClassCandidatesBySimpleName()` (quick-fix), `findClassCandidatesByPrefix()` (completion).
- `BBjCodeActionProvider`: quick-fix on unresolved-class / member-access-receiver linking diagnostics; ranks `java.*`/`javax.*`/`com.basis.*` first; inserts after existing `use` lines.
- `BBjCompletionProvider.completionForCrossReference`: prefix auto-import at type positions, deduped against in-scope classes.
- Shared `useInsertPosition()` helper.

## Tests & CI

- Fake-classpath unit tests for the quick-fix, completion (augmented + fallback + type-position gating), and the no-arg constructor edit; a live-interop functional test (gated on :5008) confirming graceful degradation.
- The interop test double is hermetic (no socket I/O), fixing a pre-existing flaky-CI teardown crash caused by async `ECONNREFUSED` logs racing with vitest worker shutdown.
- Full suite: 665 passed, 0 failures.

## Companion change (separate repo)
`bbj-ls` gains `getAllClassNames()` (classpath + JDK modules). This PR is independent — it ships value immediately via the fallback and lights up fully once the augmented server is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
