### PR TITLE
Fix #173: warn on unresolvable RUN/CALL file targets

### DIFF
--- a/bbj-vscode/src/language/bbj-validator.ts
+++ b/bbj-vscode/src/language/bbj-validator.ts
@@ -4,11 +4,11 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstNode, AstUtils, CompositeCstNode, CstNode, DiagnosticInfo, IndexManager, LangiumDocuments, LeafCstNode, Properties, Reference, RootCstNode, URI, UriUtils, ValidationAcceptor, ValidationChecks, isCompositeCstNode, isLeafCstNode } from 'langium';
+import { AstNode, AstUtils, CompositeCstNode, CstNode, DiagnosticInfo, FileSystemProvider, IndexManager, LangiumDocuments, LeafCstNode, Properties, Reference, RootCstNode, URI, UriUtils, ValidationAcceptor, ValidationChecks, isCompositeCstNode, isLeafCstNode } from 'langium';
 import { basename, dirname, isAbsolute, normalize, relative, resolve } from 'path';
 import type { BBjServices } from './bbj-module.js';
 import { TypeInferer } from './bbj-type-inferer.js';
-import { BBjAstType, BbjClass, BeginStatement, CastExpression, Class, CommentStatement, DefFunction, EraseStatement, FieldDecl, InitFileStatement, JavaField, JavaMethod, KeyedFileStatement, LabelDecl, MemberCall, MethodDecl, OpenStatement, Option, SwitchCase, SymbolicLabelRef, Use, VariableDecl, isArrayElement, isBBjClassMember, isBBjTypeRef, isBbjClass, isClass, isCompoundStatement, isKeywordStatement, isLabelDecl, isOption, isSimpleTypeRef, isSwitchStatement, isSymbolRef } from './generated/ast.js';
+import { BBjAstType, BbjClass, BeginStatement, CallStatement, CastExpression, Class, CommentStatement, DefFunction, EraseStatement, FieldDecl, InitFileStatement, JavaField, JavaMethod, KeyedFileStatement, LabelDecl, MemberCall, MethodDecl, OpenStatement, Option, RunStatement, SwitchCase, SymbolicLabelRef, Use, VariableDecl, isArrayElement, isBBjClassMember, isBBjTypeRef, isBbjClass, isClass, isCompoundStatement, isKeywordStatement, isLabelDecl, isOption, isSimpleTypeRef, isStringLiteral, isSwitchStatement, isSymbolRef } from './generated/ast.js';
 import { JavaInteropService } from './java-interop.js';
 import { BBjPathPattern } from './bbj-scope.js';
 import { BBjWorkspaceManager } from './bbj-ws-manager.js';
@@ -38,6 +38,8 @@ export function registerValidationChecks(services: BBjServices) {
         AstNode: checkLineBreaks,
         LabelDecl: validator.checkLabelDecl,
         Use: validator.checkUsedClassExists,
+        RunStatement: validator.checkRunCallFileResolves,
+        CallStatement: validator.checkRunCallFileResolves,
         OpenStatement: validator.checkOpenStatementOptions,
         InitFileStatement: validator.checkInitFileStatementOptions,
         EraseStatement: validator.checkEraseStatementOptions,
@@ -66,6 +68,7 @@ export class BBjValidator {
     protected readonly indexManager: IndexManager;
     protected readonly langiumDocuments: LangiumDocuments;
     protected readonly workspaceManager: BBjWorkspaceManager;
+    protected readonly fileSystemProvider: FileSystemProvider;
     protected readonly typeInferer: TypeInferer;
     checkExceptClause(node: BeginStatement, accept: ValidationAcceptor): void {
         const wrongs = node.except.filter(e => !(isSymbolRef(e) || (isArrayElement(e) && e.all)))
@@ -149,6 +152,7 @@ export class BBjValidator {
         this.indexManager = services.shared.workspace.IndexManager;
         this.langiumDocuments = services.shared.workspace.LangiumDocuments;
         this.workspaceManager = services.shared.workspace.WorkspaceManager as BBjWorkspaceManager;
+        this.fileSystemProvider = services.shared.workspace.FileSystemProvider;
         this.typeInferer = services.types.Inferer;
     }
 
@@ -370,6 +374,64 @@ export class BBjValidator {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Flags a `RUN` or `CALL` whose target program file cannot be resolved on disk, when that
+     * target is given as a static string literal (issue #173). Resolution mirrors the USE/scope
+     * resolvers: the filename is searched relative to the current file's directory, each
+     * workspace/project root, and each PREFIX directory.
+     *
+     * Only plain string literals are checked. A dynamic target — a variable or a concatenation such
+     * as `RUN "./"+A$` — has an unknown value until runtime, so it is skipped to avoid false
+     * positives. The check is also skipped entirely when no project context is configured (no
+     * workspace folders and no PREFIX), since a bare single file has nowhere meaningful to resolve
+     * against.
+     */
+    checkRunCallFileResolves(node: RunStatement | CallStatement, accept: ValidationAcceptor): void {
+        if (!typeResolutionWarningsEnabled) return;
+
+        const fileid = node.fileid;
+        // Only static string literals carry a knowable path; skip variables/concatenations.
+        if (!isStringLiteral(fileid)) return;
+        // StringLiteral.value also covers HEX_STRING (`$0A$`); those are byte sequences, not paths.
+        if (!fileid.$cstNode?.text?.startsWith('"')) return;
+
+        // BBj accepts a `program::label` entry point in CALL; only the program part is a file path.
+        let cleanPath = fileid.value;
+        const labelIndex = cleanPath.indexOf('::');
+        if (labelIndex >= 0) {
+            cleanPath = cleanPath.substring(0, labelIndex);
+        }
+        cleanPath = cleanPath.trim();
+        if (cleanPath.length === 0) return;
+
+        const currentDocUri = AstUtils.getDocument(node).uri;
+        // parseSettings yields a single empty-string prefix when none is configured; drop those so
+        // they neither gate the check nor resolve against the process working directory.
+        const prefixes = (this.workspaceManager.getSettings()?.prefixes ?? []).filter(prefix => prefix.length > 0);
+        const workspaceRoots = this.workspaceManager.getWorkspaceFolderUris();
+        // Without any project context there is nothing authoritative to resolve against, so skip
+        // rather than warn on every RUN/CALL in a stand-alone file.
+        if (workspaceRoots.length === 0 && prefixes.length === 0) return;
+
+        const candidateUris = [
+            UriUtils.resolvePath(UriUtils.dirname(currentDocUri), cleanPath)
+        ]
+            .concat(workspaceRoots.map(root => UriUtils.resolvePath(root, cleanPath)))
+            .concat(prefixes.map(prefixPath => URI.file(resolve(prefixPath, cleanPath))));
+
+        // A target resolves if it is an already-indexed workspace document (project files loaded
+        // into the workspace) or exists on disk (PREFIX programs are not eagerly loaded).
+        const resolved = candidateUris.some(uri =>
+            this.langiumDocuments.hasDocument(uri) || this.fileSystemProvider.existsSync(uri)
+        );
+        if (!resolved) {
+            accept('warning', `File '${cleanPath}' could not be resolved in the project directory or any PREFIX.`, {
+                node,
+                property: 'fileid'
+            });
         }
     }
 

--- a/bbj-vscode/test/run-call-file-resolution.test.ts
+++ b/bbj-vscode/test/run-call-file-resolution.test.ts
@@ -1,0 +1,97 @@
+import { EmptyFileSystem, URI, LangiumDocument } from 'langium';
+import { WorkspaceFolder } from 'vscode-languageserver';
+import { parseHelper } from 'langium/test';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { createBBjServices } from '../src/language/bbj-module';
+import { BBjWorkspaceManager } from '../src/language/bbj-ws-manager';
+import { Model } from '../src/language/generated/ast';
+
+/**
+ * Issue #173: filenames in RUN and CALL that are given as static string literals should be flagged
+ * when they cannot be resolved relative to the current file's directory, a workspace/project root,
+ * or a PREFIX directory. Dynamic targets (concatenations/variables) must not be flagged.
+ */
+
+function fileNotResolvedWarnings(doc: LangiumDocument) {
+    return (doc.diagnostics ?? []).filter(d => d.message.includes('could not be resolved in the project directory'));
+}
+
+describe('RUN/CALL file resolution (#173)', () => {
+    const services = createBBjServices(EmptyFileSystem);
+    const parse = parseHelper<Model>(services.BBj);
+
+    beforeAll(async () => {
+        await services.shared.workspace.WorkspaceManager.initializeWorkspace([]);
+        // Simulate an open workspace rooted at /root.
+        const wsManager = services.shared.workspace.WorkspaceManager as BBjWorkspaceManager;
+        const folders: WorkspaceFolder[] = [{ uri: URI.file('/root').toString(), name: 'root' }];
+        (wsManager as unknown as { folders: WorkspaceFolder[] }).folders = folders;
+
+        // Target programs indexed into the workspace so `hasDocument` resolves them.
+        await parse(`print "sub"`, { documentUri: URI.file('/root/lib/sub.bbj').toString(), validation: false });
+        await parse(`print "helper"`, { documentUri: URI.file('/root/app/helper.bbj').toString(), validation: false });
+    });
+
+    test('RUN target resolving against the project root produces no warning', async () => {
+        const doc = await parse(`RUN "lib/sub.bbj"`, {
+            documentUri: URI.file('/root/app/main-root.bbj').toString(),
+            validation: true,
+        });
+        expect(fileNotResolvedWarnings(doc).map(d => d.message).join('\n')).toBe('');
+    });
+
+    test('CALL target resolving against the current file directory produces no warning', async () => {
+        const doc = await parse(`CALL "helper.bbj"`, {
+            documentUri: URI.file('/root/app/main-samedir.bbj').toString(),
+            validation: true,
+        });
+        expect(fileNotResolvedWarnings(doc).map(d => d.message).join('\n')).toBe('');
+    });
+
+    test('unresolvable RUN target is flagged as a warning', async () => {
+        const doc = await parse(`RUN "does-not-exist.bbj"`, {
+            documentUri: URI.file('/root/app/main-missing.bbj').toString(),
+            validation: true,
+        });
+        const warnings = fileNotResolvedWarnings(doc);
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toContain("'does-not-exist.bbj'");
+    });
+
+    test('the "program::label" entry point is stripped before resolution', async () => {
+        const doc = await parse(`CALL "missing.bbj::setUp", A$`, {
+            documentUri: URI.file('/root/app/main-label.bbj').toString(),
+            validation: true,
+        });
+        const warnings = fileNotResolvedWarnings(doc);
+        expect(warnings).toHaveLength(1);
+        // The label part must not appear in the reported path.
+        expect(warnings[0].message).toContain("'missing.bbj'");
+        expect(warnings[0].message).not.toContain('::setUp');
+    });
+
+    test('dynamic RUN target (concatenation) is not flagged', async () => {
+        const doc = await parse(`A$ = "does-not-exist.bbj"\nRUN "./"+A$`, {
+            documentUri: URI.file('/root/app/main-dynamic.bbj').toString(),
+            validation: true,
+        });
+        expect(fileNotResolvedWarnings(doc).map(d => d.message).join('\n')).toBe('');
+    });
+});
+
+describe('RUN/CALL file resolution is inert without project context', () => {
+    const services = createBBjServices(EmptyFileSystem);
+    const parse = parseHelper<Model>(services.BBj);
+
+    beforeAll(async () => {
+        await services.shared.workspace.WorkspaceManager.initializeWorkspace([]);
+    });
+
+    test('no warning when there is no workspace folder or PREFIX', async () => {
+        const doc = await parse(`RUN "does-not-exist.bbj"`, {
+            documentUri: URI.file('/loose/main.bbj').toString(),
+            validation: true,
+        });
+        expect(fileNotResolvedWarnings(doc).map(d => d.message).join('\n')).toBe('');
+    });
+});


### PR DESCRIPTION
## Summary

Closes #173.

Adds a validation that flags filenames in `RUN` and `CALL` statements that are given as **static string literals** when the target file cannot be resolved. Resolution searches, in line with the existing USE/scope resolvers:

- the current file's directory,
- each workspace / project root, and
- each `PREFIX` directory.

**Dynamic targets are skipped.** Anything that is not a plain string literal — a variable or a concatenation such as `RUN "./"+A$` (a `BinaryExpression`) — is left alone, since its value is unknown until runtime.

### Details

- A single `checkRunCallFileResolves` method serves both `RunStatement` and `CallStatement` (both expose `fileid: Expression`).
- Emits a **warning**, not an error (per the issue).
- Skips hex-string literals (`$0A$`), which aren't paths.
- Strips the `program::label` entry point so `CALL "missing.bbj::setUp"` reports `missing.bbj`, not the label.
- A target counts as resolved if it is an indexed workspace document **or** exists on disk (`FileSystemProvider.existsSync`) — the latter covers `PREFIX` programs that aren't eagerly loaded.
- The check is **inert without project context** (no workspace roots and no real PREFIX), so stand-alone files aren't nagged. The empty-string prefix that `parseSettings` yields when none is configured is filtered out.

## Testing

- New `test/run-call-file-resolution.test.ts` — 6 tests: project-root resolution, same-dir resolution, unresolvable warning, `::label` stripping, dynamic-concatenation skip, and the no-project-context inert case. All pass.
- `tsc --noEmit`, ESLint, and the parser / validation / use-project-root suites all pass.
- The pre-existing Java-interop linking failures in the full suite are unrelated (they need java-interop on :5008 and fail identically without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)