### PR TITLE
Fix #455: '#' completion offers methods, this! and super! (not just fields)

### DIFF
--- a/bbj-vscode/src/language/bbj-completion-provider.ts
+++ b/bbj-vscode/src/language/bbj-completion-provider.ts
@@ -214,23 +214,66 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
             return undefined;
         }
 
-        // Collect fields from the class and its inheritance hierarchy
-        const fields = this.collectFields(klass);
+        const items = this.buildInstanceMemberItems(klass);
+        return { items, isIncomplete: false };
+    }
 
-        // Convert to completion items
-        const items: CompletionItem[] = fields.map(field => {
-            const fieldClass = getClass(field.type);
-            const fieldType = fieldClass?.name ?? 'Object';
-            return {
+    /**
+     * Builds the completion items offered after a `#` inside a class method (issue #455):
+     * the class's fields and methods (own = all visibilities; inherited = public/protected),
+     * plus the pseudo-members `this!` and `super!`. All insert their bare name without the
+     * leading `#` (which the user has already typed), matching the `#name!` / `#name` syntax.
+     */
+    protected buildInstanceMemberItems(klass: BbjClass): CompletionItem[] {
+        const items: CompletionItem[] = [];
+
+        // Fields (own: all visibilities; inherited: public/protected)
+        for (const field of this.collectFields(klass)) {
+            const fieldType = getClass(field.type)?.name ?? 'Object';
+            items.push({
                 label: field.name,
                 kind: CompletionItemKind.Variable,
                 detail: `${fieldType} field`,
                 insertText: field.name,  // Insert field name without #
                 sortText: field.name
-            };
-        });
+            });
+        }
 
-        return { items, isIncomplete: false };
+        // Methods (own: all visibilities; inherited: public/protected)
+        for (const methodMember of this.collectMethods(klass)) {
+            const paramList = methodMember.params.map(p => p.name).join(', ');
+            const returnType = methodMember.voidReturn || !methodMember.returnType
+                ? 'void'
+                : (getClass(methodMember.returnType)?.name ?? 'Object');
+            items.push({
+                label: methodMember.name,
+                kind: CompletionItemKind.Method,
+                detail: `${methodMember.name}(${paramList}): ${returnType} method`,
+                insertText: methodMember.name,  // Insert method name without #
+                sortText: methodMember.name
+            });
+        }
+
+        // Pseudo-members `this!` and `super!` — valid as `#this!` / `#super!` in BBj.
+        // `super!` only exists when the class actually extends a superclass.
+        items.push({
+            label: 'this!',
+            kind: CompletionItemKind.Keyword,
+            detail: 'Current instance',
+            insertText: 'this!',
+            sortText: 'this!'
+        });
+        if (klass.extends.length > 0) {
+            items.push({
+                label: 'super!',
+                kind: CompletionItemKind.Keyword,
+                detail: 'Superclass instance',
+                insertText: 'super!',
+                sortText: 'super!'
+            });
+        }
+
+        return items;
     }
 
     /**
@@ -385,6 +428,57 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
 
             // Recursively get superclass hierarchy
             this.collectInheritedFields(superClass, fields, visited, depth + 1, maxDepth);
+        }
+    }
+
+    protected collectMethods(klass: BbjClass): MethodDecl[] {
+        const methods: MethodDecl[] = [];
+        const visited = new Set<BbjClass>();
+        const maxDepth = 20;
+
+        // Add methods from current class (all visibilities)
+        methods.push(...klass.members.filter(isMethodDecl));
+
+        // Add inherited methods (protected and public only)
+        this.collectInheritedMethods(klass, methods, visited, 0, maxDepth);
+
+        return methods;
+    }
+
+    protected collectInheritedMethods(
+        klass: BbjClass,
+        methods: MethodDecl[],
+        visited: Set<BbjClass>,
+        depth: number,
+        maxDepth: number
+    ): void {
+        // Cycle protection
+        if (visited.has(klass) || depth >= maxDepth) {
+            return;
+        }
+        visited.add(klass);
+
+        // Walk superclass chain
+        for (const extendsQualifiedClass of klass.extends) {
+            const superClass = getClass(extendsQualifiedClass);
+
+            // Skip unresolved superclass references or non-BBj classes
+            if (!superClass || !isBbjClass(superClass)) {
+                continue;
+            }
+
+            // Collect inherited methods (protected and public only, not private)
+            const inheritedMethods = superClass.members
+                .filter(isMethodDecl)
+                .filter(m => {
+                    const visibility = m.visibility?.toUpperCase() ?? 'PUBLIC';
+                    return visibility === 'PUBLIC' || visibility === 'PROTECTED';
+                });
+
+            methods.push(...inheritedMethods);
+
+            // Recursively get superclass hierarchy
+            this.collectInheritedMethods(superClass, methods, visited, depth + 1, maxDepth);
         }
     }
 

--- a/bbj-vscode/test/completion-test.test.ts
+++ b/bbj-vscode/test/completion-test.test.ts
@@ -1,7 +1,7 @@
 
 import { AstUtils, EMPTY_SCOPE, EmptyFileSystem } from 'langium';
 import { expectCompletion, parseHelper } from 'langium/test';
-import { CompletionParams, CompletionTriggerKind } from 'vscode-languageserver';
+import { CompletionItemKind, CompletionParams, CompletionTriggerKind } from 'vscode-languageserver';
 import { describe, expect, test, vi } from 'vitest';
 import { createBBjTestServices } from './bbj-test-module';
 import { isBbjClass, isSymbolRef, Model } from '../src/language/generated/ast.js';
@@ -496,6 +496,90 @@ y = 2
 `;
         const list = await fieldCompletion(text);
         expect(list?.items ?? []).toHaveLength(0);
+    });
+
+    test('# in a class method offers methods, this! and super! alongside fields - issue #455', async () => {
+        // The '#' trigger must offer the full instance member set, not just fields:
+        // own fields (any visibility), own/inherited methods (public/protected), and
+        // the pseudo-members this! and super!.
+        // A valid symbol (`name!`) follows the cursor so the enclosing class does NOT
+        // collapse (see issue #445): the built document then resolves `extends`, which the
+        // throwaway recovery reparse cannot, so inherited members are available here.
+        const text = `class public Base
+    method public void inheritedPublic()
+    methodend
+    method private void inheritedPrivate()
+    methodend
+classend
+class public Derived extends Base
+    field public String name!
+    field private String secret!
+    method public void doIt()
+    methodend
+    method private void helper()
+    methodend
+    method public void run()
+        #<|>name!
+    methodend
+classend
+`;
+        const list = await fieldCompletion(text);
+        const labels = list?.items.map(i => i.label) ?? [];
+        // own fields, all visibilities
+        expect(labels).toContain('name!');
+        expect(labels).toContain('secret!');
+        // own methods, all visibilities
+        expect(labels).toContain('doIt');
+        expect(labels).toContain('helper');
+        expect(labels).toContain('run');
+        // inherited method: public only
+        expect(labels).toContain('inheritedPublic');
+        expect(labels).not.toContain('inheritedPrivate');
+        // pseudo-members
+        expect(labels).toContain('this!');
+        expect(labels).toContain('super!');
+        // methods must carry the Method kind and insert without the leading #
+        const doIt = list?.items.find(i => i.label === 'doIt');
+        expect(doIt?.kind).toBe(CompletionItemKind.Method);
+        expect(doIt?.insertText).toBe('doIt');
+    });
+
+    test('# in a class method without a superclass omits super! - issue #455', async () => {
+        // super! only exists when the class actually extends a superclass.
+        const text = `class public C
+    field public String name!
+    method public void doIt()
+    methodend
+    method public void run()
+        #<|>
+    methodend
+classend
+`;
+        const list = await fieldCompletion(text);
+        const labels = list?.items.map(i => i.label) ?? [];
+        expect(labels).toContain('name!');
+        expect(labels).toContain('doIt');
+        expect(labels).toContain('this!');
+        expect(labels).not.toContain('super!');
+    });
+
+    test('dangling # recovery also offers methods and this! - issue #455 / #445', async () => {
+        // The collapsed-class recovery path (a bare '#' unwinds the class) must offer
+        // the same member set: methods and this!, not only fields.
+        const text = `class public C
+    field public HashMap map!
+    method public void doIt()
+    methodend
+    method public void m()
+        #<|>
+    methodend
+classend
+`;
+        const list = await fieldCompletion(text);
+        const labels = list?.items.map(i => i.label) ?? [];
+        expect(labels).toContain('map!');
+        expect(labels).toContain('doIt');
+        expect(labels).toContain('this!');
     });
 
     const interopSeam = bbjServices.java.JavaInteropService as unknown as {


### PR DESCRIPTION
Fixes #455.

## Problem
Typing `#` inside a class method auto-triggers completion served by `getFieldCompletion`, which collected **fields only**. Because the list is returned with `isIncomplete: false`, the client kept filtering that field-only list — so methods, `this!` and `super!` never appeared on the `#` path (even though the `#name!<Ctrl+Space>` scope path already offered methods).

## Fix
`getFieldCompletion` now delegates to a new `buildInstanceMemberItems(klass)` helper (the single entry point shared by the normal path **and** the issue-#445 dangling-`#` recovery path), which offers:
- **fields** — unchanged (own: all visibilities; inherited: public/protected);
- **methods** — new `collectMethods`/`collectInheritedMethods`, mirroring the field collectors with the same visibility/inheritance rules; items use `Method` kind and insert the bare method name;
- **`this!`**, and **`super!`** only when the class extends a superclass.

All items insert their bare name (no leading `#`, which the user already typed) — matching real BBj syntax `#this!` / `#super!` (verified in `test/test-data/class-def.bbj`).

## Tests
Added 3 tests to `test/completion-test.test.ts`. Suite: 29 passed, 1 skipped. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)