### PR TITLE
Fix #457: add REPEAT..UNTIL snippet

### DIFF
--- a/bbj-vscode/snippets/bbj.json
+++ b/bbj-vscode/snippets/bbj.json
@@ -675,5 +675,16 @@
 			"WEND"
 		],
 		"description": "While Statement"
+	},
+	"RepeatUntil": {
+		"prefix": [
+			"repeat-until"
+		],
+		"body": [
+			"REPEAT",
+			"\t$0",
+			"UNTIL ${1:condition}"
+		],
+		"description": "REPEAT .. UNTIL loop"
 	}
 }


### PR DESCRIPTION
Fixes #457.

Adds the one BDT code template that had no extension equivalent: a `REPEAT .. UNTIL` block snippet.

New entry in `snippets/bbj.json`:
- prefix: `repeat-until`
- body: `REPEAT` / `<tab>$0` / `UNTIL ${1:condition}`

Keywords are uppercased to match the existing snippet convention (`WHILE`/`WEND`, `SWITCH`/`SWEND`, …). `REPEAT`/`UNTIL` are confirmed BBj keywords in `bbj.langium`, and `package.json` already contributes `./snippets/bbj.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)