### PR TITLE
Fix #453: offer package/class completion after a dot in USE statements

### DIFF
--- a/bbj-vscode/src/language/bbj-completion-provider.ts
+++ b/bbj-vscode/src/language/bbj-completion-provider.ts
@@ -108,8 +108,9 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
     }
 
     protected override completionFor(context: CompletionContext, next: NextFeature, acceptor: CompletionAcceptor): MaybePromise<void> {
-        if (this.dotTriggerActive && !this.isMemberReference(next.feature)) {
-            // Suppress everything except the `member` cross-reference of a MemberCall.
+        if (this.dotTriggerActive && !this.isMemberReference(next.feature) && !this.isJavaSymbolReference(next.feature)) {
+            // Suppress everything except the `member` cross-reference of a MemberCall and the
+            // `symbol` cross-reference of a JavaSymbol (the package/class parts of a `use` path).
             return;
         }
         return super.completionFor(context, next, acceptor);
@@ -122,6 +123,24 @@ export class BBjCompletionProvider extends DefaultCompletionProvider {
         }
         const assignment = GrammarAST.isAssignment(feature.$container) ? feature.$container : undefined;
         return assignment?.feature === 'member';
+    }
+
+    /**
+     * True if `feature` is the `symbol=[JavaPackageLike:ID]` cross-reference of the JavaSymbol rule,
+     * i.e. a package/class part of a `use` path (`use java.util.HashMap`). Checked so the '.' trigger
+     * still offers package/class suggestions after a dot in a USE statement (issue #453). The rule
+     * check keeps this precise so an unrelated `symbol` assignment cannot slip through.
+     */
+    protected isJavaSymbolReference(feature: GrammarAST.AbstractElement): boolean {
+        if (!GrammarAST.isCrossReference(feature)) {
+            return false;
+        }
+        const assignment = GrammarAST.isAssignment(feature.$container) ? feature.$container : undefined;
+        if (assignment?.feature !== 'symbol') {
+            return false;
+        }
+        const rule = GrammarAST.isParserRule(assignment.$container) ? assignment.$container : undefined;
+        return rule?.name === 'JavaSymbol';
     }
 
     override async getCompletion(document: LangiumDocument, params: CompletionParams, cancelToken?: CancellationToken): Promise<CompletionList | undefined> {

--- a/bbj-vscode/src/language/bbj-scope.ts
+++ b/bbj-vscode/src/language/bbj-scope.ts
@@ -52,7 +52,6 @@ import { BBjWorkspaceManager } from './bbj-ws-manager.js';
 import { normalize, resolve } from 'path';
 import { assertType } from './utils.js';
 import { getClass } from './bbj-nodedescription-provider.js';
-import { assertTrue } from './assertions.js';
 
 const BBjClassNamePattern = /^::(.*)::([_a-zA-Z][\w_]*@?)$/;
 export const BBjPathPattern = /^::(.*)::$/;
@@ -110,11 +109,18 @@ export class BbjScopeProvider extends DefaultScopeProvider {
                 const property = context.property as CrossReferencesOfAstNodeType<typeof container>;
                 if (property === 'symbol') {
                     if (isJavaTypeRef(container.$container)) {
-                        assertTrue(container.$containerIndex !== undefined);
-                        if (container.$containerIndex === 0) {
+                        // During completion after a '.' in a `use` statement (issue #453) Langium
+                        // synthesizes a new JavaSymbol node with no $containerIndex. In that case the
+                        // new part is appended after the last already-parsed part, so treat the last
+                        // existing pathPart as the previous one.
+                        const pathParts = container.$container.pathParts;
+                        const previousIndex = container.$containerIndex !== undefined
+                            ? container.$containerIndex - 1
+                            : pathParts.length - 1;
+                        if (previousIndex < 0) {
                             return this.createScopeForNodes(this.javaInterop.getChildrenOf());
                         } else {
-                            const previousPart = container.$container.pathParts[container.$containerIndex - 1].symbol.ref;
+                            const previousPart = pathParts[previousIndex]?.symbol.ref;
                             if (previousPart) {
                                 let outerScope: Scope | undefined = undefined;
                                 if (isJavaClass(previousPart)) {

--- a/bbj-vscode/src/language/bbj-scope.ts
+++ b/bbj-vscode/src/language/bbj-scope.ts
@@ -34,7 +34,9 @@ import {
     isClasspath, isCompoundStatement,
     isJavaClass, isJavaField, isJavaMethod, isJavaMethodParameter,
     isJavaPackage,
+    isJavaSymbol,
     isJavaTypeRef,
+    JavaTypeRef,
     isLibFunction,
     isMemberCall,
     isMethodCall,
@@ -108,15 +110,31 @@ export class BbjScopeProvider extends DefaultScopeProvider {
                 assertType<JavaSymbol>(container);
                 const property = context.property as CrossReferencesOfAstNodeType<typeof container>;
                 if (property === 'symbol') {
-                    if (isJavaTypeRef(container.$container)) {
-                        // During completion after a '.' in a `use` statement (issue #453) Langium
-                        // synthesizes a new JavaSymbol node with no $containerIndex. In that case the
-                        // new part is appended after the last already-parsed part, so treat the last
-                        // existing pathPart as the previous one.
-                        const pathParts = container.$container.pathParts;
-                        const previousIndex = container.$containerIndex !== undefined
-                            ? container.$containerIndex - 1
-                            : pathParts.length - 1;
+                    // Resolve which JavaTypeRef path we are in and the index of the segment being
+                    // completed, across the three shapes the scope is queried with (issue #453):
+                    //  1. linking / a real parsed part:  container.$container is the JavaTypeRef and
+                    //     container.$containerIndex is the part's position;
+                    //  2. completion right after a '.':  Langium synthesizes a new JavaSymbol whose
+                    //     $container is the JavaTypeRef and whose $containerIndex is undefined — a new
+                    //     part appended after the last parsed one (`use java.|`);
+                    //  3. completion on a partially-typed part (`use java.ut|`): the synthetic
+                    //     JavaSymbol's $container is the EXISTING part node, so the JavaTypeRef is one
+                    //     level up and the completed part's index is that existing node's index.
+                    // Typed as AstNode: the generated AST fixes JavaSymbol.$container to JavaTypeRef,
+                    // but Langium's synthetic completion node (case 3) makes it a JavaSymbol at runtime.
+                    const parent = container.$container as AstNode | undefined;
+                    let typeRef: JavaTypeRef | undefined = undefined;
+                    let completingIndex = -1;
+                    if (isJavaTypeRef(parent)) {
+                        typeRef = parent;
+                        completingIndex = container.$containerIndex ?? typeRef.pathParts.length;
+                    } else if (isJavaSymbol(parent) && isJavaTypeRef(parent.$container)) {
+                        typeRef = parent.$container;
+                        completingIndex = parent.$containerIndex ?? typeRef.pathParts.length;
+                    }
+                    if (typeRef) {
+                        const pathParts = typeRef.pathParts;
+                        const previousIndex = completingIndex - 1;
                         if (previousIndex < 0) {
                             return this.createScopeForNodes(this.javaInterop.getChildrenOf());
                         } else {

--- a/bbj-vscode/test/completion-test.test.ts
+++ b/bbj-vscode/test/completion-test.test.ts
@@ -49,6 +49,33 @@ describe('BBJ completion provider', async () => {
         return (list?.items ?? []).map(i => i.label);
     }
 
+    // Plain (Invoked) completion driver — models VS Code re-querying as the user keeps typing a
+    // segment. The '.' list is returned `isIncomplete`, so the client re-queries; that re-query
+    // must return the narrowed candidates rather than an empty list (issue #460).
+    async function useInvokedCompletion(text: string): Promise<string[]> {
+        const offset = text.indexOf('<|>');
+        const clean = text.replace('<|>', '');
+        const doc = await parseHelper<Model>(bbjServices)(
+            clean, { documentUri: `file:///use-invoked-completion-${dotCompletionCounter++}.bbj` });
+        const params: CompletionParams = {
+            textDocument: { uri: doc.textDocument.uri },
+            position: doc.textDocument.positionAt(offset),
+            context: { triggerKind: CompletionTriggerKind.Invoked }
+        };
+        const list = await bbjServices.lsp.CompletionProvider!.getCompletion(doc, params);
+        return (list?.items ?? []).map(i => i.label);
+    }
+
+    test("partially typed subpackage after `use java.` still narrows - issue #460", async () => {
+        const labels = await useInvokedCompletion('use java.u<|>\n');
+        expect(labels).toContain('util');
+    });
+
+    test("partially typed class after `use java.util.` still narrows - issue #460", async () => {
+        const labels = await useInvokedCompletion('use java.util.Hash<|>\n');
+        expect(labels).toContain('HashMap');
+    });
+
     test("'.' after `use java` offers subpackages - issue #453", async () => {
         const labels = await useDotCompletion('use java.<|>\n');
         expect(labels).toContain('util');

--- a/bbj-vscode/test/completion-test.test.ts
+++ b/bbj-vscode/test/completion-test.test.ts
@@ -30,6 +30,55 @@ describe('BBJ completion provider', async () => {
         return bbjServices.lsp.CompletionProvider!.getCompletion(doc, params);
     }
 
+    // Drive the completion provider with a '.' trigger context at the '<|>' marker.
+    // expectCompletion() does not let us set a trigger character, and USE-path package/class
+    // completion after a dot is only reachable via the '.' trigger, so this drives the request
+    // directly (mirrors fieldCompletion above). Returns the offered item labels.
+    let dotCompletionCounter = 0;
+    async function useDotCompletion(text: string): Promise<string[]> {
+        const offset = text.indexOf('<|>');
+        const clean = text.replace('<|>', '');
+        const doc = await parseHelper<Model>(bbjServices)(
+            clean, { documentUri: `file:///use-dot-completion-${dotCompletionCounter++}.bbj` });
+        const params: CompletionParams = {
+            textDocument: { uri: doc.textDocument.uri },
+            position: doc.textDocument.positionAt(offset),
+            context: { triggerKind: CompletionTriggerKind.TriggerCharacter, triggerCharacter: '.' }
+        };
+        const list = await bbjServices.lsp.CompletionProvider!.getCompletion(doc, params);
+        return (list?.items ?? []).map(i => i.label);
+    }
+
+    test("'.' after `use java` offers subpackages - issue #453", async () => {
+        const labels = await useDotCompletion('use java.<|>\n');
+        expect(labels).toContain('util');
+        expect(labels).toContain('lang');
+    });
+
+    test("'.' after `use java.util` offers classes - issue #453", async () => {
+        const labels = await useDotCompletion('use java.util.<|>\n');
+        expect(labels).toContain('HashMap');
+    });
+
+    test("'.' after `use java.lang` offers classes - issue #453", async () => {
+        const labels = await useDotCompletion('use java.lang.<|>\n');
+        expect(labels).toContain('String');
+        expect(labels).toContain('Class');
+    });
+
+    test("Ctrl+Space after `use java.` offers subpackages - issue #453", async () => {
+        // The plain (no trigger character) path must also offer package/class suggestions after a dot.
+        await completion({
+            text: 'use java.<|>\n',
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('util');
+                expect(labels).toContain('lang');
+            }
+        });
+    });
+
     test('Should propose imported java class', async () => {
         const text = `
         use java.util.HashMap


### PR DESCRIPTION
Fixes #453.

## Problem
`use ja<Ctrl+Space>` offered the `java` root package, but as soon as a `.` was typed (`use java.`, `use java.util.`) completion went silent — 0 items, on both the `.` auto-trigger and the plain Ctrl+Space paths.

## Root cause (two layers)
1. **Dot-trigger suppression** — while `dotTriggerActive` is set, `completionFor()` suppressed every predicted feature except the MemberCall `member` cross-reference, filtering out the `JavaSymbol.symbol` reference the USE path completes.
2. **Scope-provider crash on the synthetic completion node** — during cross-reference completion Langium synthesizes a `JavaSymbol` with `$container = JavaTypeRef` but **no `$containerIndex`**. The `case 'JavaSymbol'` scope code asserted `$containerIndex !== undefined` and threw; `completionForCrossReference` swallows that as a `console.error` and yields nothing. This broke the Ctrl+Space path too (it never reached the dot filter).

## Fix
- `bbj-completion-provider.ts`: added `isJavaSymbolReference(feature)` (mirrors `isMemberReference`, and also confirms the containing parser rule is `JavaSymbol`) and allow it through the dot-trigger guard.
- `bbj-scope.ts`: when `$containerIndex` is undefined (synthetic completion node), treat the new part as appended after the last already-parsed part (`previousIndex = pathParts.length - 1`); `previousIndex < 0` returns the Java roots. Behavior is unchanged for real parsed nodes.

## Tests
Added a `useDotCompletion()` helper (drives `triggerCharacter: '.'`) and tests: `use java.` → `util`/`lang`; `use java.util.` → `HashMap`; `use java.lang.` → `String`/`Class`; plus a Ctrl+Space case. `completion-test.test.ts`: 30 passed, 1 skipped. The 11 pre-existing `linking.test.ts` interop failures are identical on `main` (no new regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)