### PR TITLE
feat(snippets): add REPEAT..UNTIL loop snippet

### DIFF
--- a/bbj-vscode/snippets/bbj.json
+++ b/bbj-vscode/snippets/bbj.json
@@ -675,5 +675,16 @@
 			"WEND"
 		],
 		"description": "While Statement"
+	},
+	"RepeatUntil": {
+		"prefix": [
+			"repeat-until"
+		],
+		"body": [
+			"REPEAT",
+			"\t$0",
+			"UNTIL ${1:condition}"
+		],
+		"description": "REPEAT .. UNTIL loop"
 	}
 }


### PR DESCRIPTION
## Summary

Adds a `REPEAT..UNTIL` block snippet — the only BDT code template that had no equivalent in the extension.

The issue author's own audit of the BDT template list vs `bbj.json` identified this as the sole gap (see #457).

## Change

**File:** `bbj-vscode/snippets/bbj.json`

New snippet added at the end of the file:

```json
"RepeatUntil": {
    "prefix": ["repeat-until"],
    "body": ["REPEAT", "\t$0", "UNTIL ${1:condition}"],
    "description": "REPEAT .. UNTIL loop"
}
```

- Prefix: `repeat-until` — consistent with existing loop prefixes (`for-next`, `while`)
- Body: cursor lands inside the loop body (`$0`); condition is tab-stoppable (`${1:condition}`)
- No other files changed

Closes #457