### PR TITLE
Fix #454: offer class/interface completion after EXTENDS and IMPLEMENTS

### DIFF
--- a/bbj-vscode/src/language/bbj-scope.ts
+++ b/bbj-vscode/src/language/bbj-scope.ts
@@ -307,10 +307,12 @@ export class BbjScopeProvider extends DefaultScopeProvider {
     }
 
     private resolveClassScopeByName(context: ReferenceInfo, qualifiedClassName: string): Scope {
-        if (!qualifiedClassName) {
-            return EMPTY_SCOPE;
-        }
-        const match = qualifiedClassName.match(BBjClassNamePattern);
+        // `qualifiedClassName` is empty during completion (Ctrl+Space): Langium asks for the scope
+        // with an empty `$refText` and then fuzzy-filters the candidates by the typed prefix itself.
+        // So an empty name must still yield the full class scope (local BBj classes, imports and the
+        // global Java index) — returning EMPTY_SCOPE here left extends/implements/declare completion
+        // with no candidates (#454). Only the `::file::Class` form needs the name up front.
+        const match = qualifiedClassName ? qualifiedClassName.match(BBjClassNamePattern) : null;
         if (match) {
             const relativeFilePath = match[1];
             return this.getBBjClassesFromFile(context.container, relativeFilePath, false);

--- a/bbj-vscode/test/completion-test.test.ts
+++ b/bbj-vscode/test/completion-test.test.ts
@@ -152,6 +152,38 @@ DEF fnIsText(_f$,_t$)=_f$+<|>
         });
     });
 
+    test('completion after EXTENDS offers visible BBj classes - issue #454', async () => {
+        const text = `
+class public Animal
+classend
+class public Dog extends An<|>
+classend
+`
+        await completion({
+            text,
+            index: 0,
+            expectedItems: [
+                'Animal'
+            ]
+        });
+    });
+
+    test('completion after IMPLEMENTS offers visible interfaces - issue #454', async () => {
+        const text = `
+interface public Walker
+interfaceend
+class public Dog implements Wa<|>
+classend
+`
+        await completion({
+            text,
+            index: 0,
+            expectedItems: [
+                'Walker'
+            ]
+        });
+    });
+
     test('BBj class constructor completion returns items or empty list (no crash)', async () => {
         const text = `
 class public MyWidget


### PR DESCRIPTION
Fixes #454.

## Problem
Completion after `extends` / `implements` returned nothing, even with a typed prefix and the target class defined in the same file — while the same names *were* offered in `declare` position.

## Root cause
Completion candidates come from `getScope(refInfo).getAllElements()`. On Ctrl+Space, Langium builds a synthetic `ReferenceInfo` with an **empty `$refText`** and then fuzzy-filters candidates by the typed prefix itself. But `resolveClassScopeByName` started with:
```ts
if (!qualifiedClassName) { return EMPTY_SCOPE; }
```
Since the name is always empty during completion, this returned no candidates. Java classes still appeared only because of the separate auto-import fallback in the completion provider — in-scope BBj classes/interfaces had no such fallback, so they never showed up (this latently affected `declare` for local BBj classes too).

## Fix
`bbj-scope.ts`: for an empty or simple name, fall through to the full class scope (local BBj classes + imports + global Java index). Only the `::file::Class` form still needs the name up front. Linking of real references is unaffected — a present reference never has an empty `$refText`, and an empty one resolves to nothing either way.

Also fixes local-BBj-class completion in `declare`. The `extends`/`implements` keywords after the class name were already offered (verified) — no change needed.

## Tests
Two new `completion-test.test.ts` tests (extends → local class; implements → interface) that fail before the fix and pass after. `completion-test.test.ts`: 28 passed, 1 skipped. Battery of completion/classes/variable-scoping/linking: only the 11 pre-existing interop `linking.test.ts` failures (identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)