### PR TITLE
Fix #437: validate method return value against Java/non-BBj return types

### DIFF
--- a/bbj-vscode/src/language/bbj-validator.ts
+++ b/bbj-vscode/src/language/bbj-validator.ts
@@ -26,6 +26,10 @@ export function setTypeResolutionWarnings(enabled: boolean): void {
     typeResolutionWarningsEnabled = enabled;
 }
 
+export function isTypeResolutionWarningsEnabled(): boolean {
+    return typeResolutionWarningsEnabled;
+}
+
 /** Prefix of the diagnostic message emitted for unresolvable USE file paths. Used by document builder to identify and reconcile these diagnostics after PREFIX docs are loaded. */
 export const USE_FILE_NOT_RESOLVED_PREFIX = "File '";
 
@@ -56,7 +60,7 @@ export function registerValidationChecks(services: BBjServices) {
         SwitchCase: validator.checkSwitchCaseInSwitch,
     };
     registry.register(checks, validator);
-    registerClassChecks(registry);
+    registerClassChecks(registry, services);
     registerVariableScopingChecks(registry);
     registerFunctionCallChecks(registry);
 }

--- a/bbj-vscode/src/language/validations/check-classes.ts
+++ b/bbj-vscode/src/language/validations/check-classes.ts
@@ -1,10 +1,13 @@
 import { AstNode, AstUtils, DiagnosticInfo, ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
 import { basename, dirname, isAbsolute, relative } from 'path';
+import type { BBjServices } from '../bbj-module.js';
+import { TypeInferer } from '../bbj-type-inferer.js';
+import { isTypeResolutionWarningsEnabled } from '../bbj-validator.js';
 import { getClass, getClassRef } from '../bbj-nodedescription-provider.js';
-import { BBjAstType, BbjClass, ConstructorCall, Expression, FieldDecl, isBbjClass, isMethodDecl, isMethodReturnStatement, isNumberLiteral, isStringLiteral, MethodDecl, QualifiedClass } from '../generated/ast.js';
+import { BBjAstType, BbjClass, Class, ConstructorCall, Expression, FieldDecl, isBbjClass, isClass, isJavaClass, isMethodDecl, isMethodReturnStatement, isNumberLiteral, isStringLiteral, JavaClass, MethodDecl, QualifiedClass } from '../generated/ast.js';
 
-export function registerClassChecks(registry: ValidationRegistry) {
-    const validator = new ClassValidator();
+export function registerClassChecks(registry: ValidationRegistry, services: BBjServices) {
+    const validator = new ClassValidator(services.types.Inferer);
     const classChecks: ValidationChecks<BBjAstType> = {
         Use: (use, accept) => {
             if(!use.bbjClass) {
@@ -77,6 +80,9 @@ export function registerClassChecks(registry: ValidationRegistry) {
 }
 
 class ClassValidator {
+    constructor(private readonly inferer: TypeInferer) {
+    }
+
     private isSubFolderOf(folder: string, parentFolder: string) {
         if(parentFolder === folder) {
             return true;
@@ -192,8 +198,156 @@ class ClassValidator {
                     node: ret,
                     property: 'return'
                 });
+                continue; // already reported by the literal check — don't double-report
+            }
+            // Deeper check against Java / non-BBj return types via type inference (issue #437).
+            this.checkReturnTypeAssignable(meth, ret.return!, {
+                node: ret,
+                property: 'return'
+            }, accept);
+        }
+    }
+
+    // BBj scalar return types are handled by the literal check above and are otherwise loosely
+    // typed (BBj coerces), so the inference-based Java-type check below skips them to stay
+    // false-positive-free. Compared case-insensitively.
+    private static readonly BBJ_SCALAR_RETURN_TYPES = new Set(['bbjstring', 'bbjnumber', 'bbjint']);
+
+    /**
+     * The complete set of assignable target types for well-known FINAL Java types, keyed by the
+     * returned type's fully-qualified name (all lower-cased). Because these classes are `final`,
+     * their supertype closure is fixed and fully known here — so if the declared return type's FQN
+     * is NOT in the set, the returned value is *provably* not assignable and can be flagged with no
+     * risk of missing a subtype relationship. Non-final Java types are never flagged (see below),
+     * since their hierarchy is not walkable from the AST (a JavaClass carries no supertype info).
+     */
+    private static readonly FINAL_TYPE_ASSIGNABLE_TO: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+        ['java.lang.string', new Set(['java.lang.string', 'java.lang.charsequence', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])],
+        ['java.lang.integer', new Set(['java.lang.integer', 'java.lang.number', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])],
+        ['java.lang.long', new Set(['java.lang.long', 'java.lang.number', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])],
+        ['java.lang.short', new Set(['java.lang.short', 'java.lang.number', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])],
+        ['java.lang.byte', new Set(['java.lang.byte', 'java.lang.number', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])],
+        ['java.lang.double', new Set(['java.lang.double', 'java.lang.number', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])],
+        ['java.lang.float', new Set(['java.lang.float', 'java.lang.number', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])],
+        ['java.lang.boolean', new Set(['java.lang.boolean', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])],
+        ['java.lang.character', new Set(['java.lang.character', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])],
+        ['java.math.bigdecimal', new Set(['java.math.bigdecimal', 'java.lang.number', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])],
+        ['java.math.biginteger', new Set(['java.math.biginteger', 'java.lang.number', 'java.lang.comparable', 'java.io.serializable', 'java.lang.object'])]
+    ]);
+
+    /**
+     * Validates a single returned expression against a method's declared (Java / non-BBj) return
+     * type using type inference (issue #437, follow-up to #372/#436). Gated behind the
+     * `typeResolutionWarnings` flag, exactly like the CAST-resolvability check.
+     *
+     * Deliberately conservative to avoid false positives on BBj's loose typing:
+     *  - fires ONLY when both the declared and the inferred returned type FULLY resolve to a Class;
+     *  - skips BBj scalar declared types (owned by the literal check, and loosely coerced);
+     *  - `java.lang.Object` (the top type) is always assignable;
+     *  - only reports when the returned value's type is *provably* not assignable — currently when
+     *    the returned type is a well-known FINAL Java type whose complete supertype set is known and
+     *    does not contain the declared type. Non-final returned types and BBj-class returns are left
+     *    unflagged because the Java class hierarchy is not walkable from the AST here.
+     */
+    private checkReturnTypeAssignable<N extends AstNode>(meth: MethodDecl, returned: Expression, info: DiagnosticInfo<N>, accept: ValidationAcceptor): void {
+        if (!isTypeResolutionWarningsEnabled() || meth.array) {
+            return;
+        }
+        // BBj scalar declared types are handled elsewhere / loosely typed — never flag them here.
+        const declaredName = this.simpleTypeName(meth.returnType!);
+        if (declaredName && ClassValidator.BBJ_SCALAR_RETURN_TYPES.has(declaredName.toLowerCase())) {
+            return;
+        }
+        const declaredClass = getClass(meth.returnType);
+        if (!declaredClass) {
+            return; // declared type does not fully resolve — skip silently
+        }
+        const inferred = this.inferer.getType(returned);
+        if (!inferred || !isClass(inferred)) {
+            return; // returned type does not resolve to a Class — skip silently
+        }
+        if (this.isAssignable(declaredClass, inferred) === false) {
+            accept('error', `Method '${meth.name}' declares return type '${this.classDisplayName(declaredClass)}' but returns a value of incompatible type '${this.classDisplayName(inferred)}'.`, info);
+        }
+    }
+
+    /**
+     * Three-valued assignability of a returned value of type `returned` to the declared type
+     * `declared`: `true` = provably assignable, `false` = provably NOT assignable, `undefined` =
+     * unknown (must be treated as assignable, i.e. not flagged). Only definitive answers are used
+     * to emit a diagnostic.
+     */
+    private isAssignable(declared: Class, returned: Class): boolean | undefined {
+        if (declared === returned) {
+            return true;
+        }
+        const declaredFqn = this.classFqn(declared).toLowerCase();
+        const returnedFqn = this.classFqn(returned).toLowerCase();
+        if (declaredFqn === returnedFqn) {
+            return true;
+        }
+        // java.lang.Object is the top type: every reference type is assignable to it.
+        if (declaredFqn === 'java.lang.object') {
+            return true;
+        }
+        // A returned BBj class whose resolvable supertype chain reaches the declared class is
+        // assignable; otherwise we cannot be certain (the chain may reach Java types we cannot
+        // walk), so we defer rather than risk a false positive.
+        if (isBbjClass(returned)) {
+            return this.bbjSupertypesReach(returned, declared) ? true : undefined;
+        }
+        // A returned well-known FINAL Java type has a fully-known supertype set: decide definitively.
+        if (isJavaClass(returned)) {
+            const assignableTo = ClassValidator.FINAL_TYPE_ASSIGNABLE_TO.get(returnedFqn);
+            if (assignableTo) {
+                return assignableTo.has(declaredFqn);
             }
         }
+        return undefined; // hierarchy not walkable / unknown — do not flag
+    }
+
+    /** True if walking the BBj class's resolvable extends/implements chain reaches `target`. */
+    private bbjSupertypesReach(klass: BbjClass, target: Class): boolean {
+        const visited = new Set<Class>();
+        const queue: BbjClass[] = [klass];
+        while (queue.length > 0) {
+            const current = queue.pop()!;
+            if (visited.has(current)) {
+                continue;
+            }
+            visited.add(current);
+            for (const ref of [...current.extends, ...current.implements]) {
+                const superType = getClass(ref);
+                if (!superType) {
+                    continue;
+                }
+                if (superType === target) {
+                    return true;
+                }
+                if (isBbjClass(superType)) {
+                    queue.push(superType);
+                }
+            }
+        }
+        return false;
+    }
+
+    /** Fully-qualified name of a resolved class (JavaClass carries a package; BBj classes do not). */
+    private classFqn(klass: Class): string {
+        if (isJavaClass(klass)) {
+            const name = (klass as JavaClass).name;
+            if (name.includes('.')) {
+                return name;
+            }
+            const pkg = (klass as JavaClass).packageName;
+            return pkg ? `${pkg}.${name}` : name;
+        }
+        return klass.name;
+    }
+
+    /** Human-readable class name for diagnostics (FQN for Java types, simple name for BBj types). */
+    private classDisplayName(klass: Class): string {
+        return isJavaClass(klass) ? this.classFqn(klass) : klass.name;
     }
 
     /**

--- a/bbj-vscode/test/method-return-java-type.test.ts
+++ b/bbj-vscode/test/method-return-java-type.test.ts
@@ -1,0 +1,174 @@
+import { EmptyFileSystem } from 'langium';
+import { beforeAll, afterEach, describe, expect, test } from 'vitest';
+import { validationHelper } from 'langium/test';
+import { createBBjTestServices } from './bbj-test-module.js';
+import { initializeWorkspace } from './test-helper.js';
+import { Program } from '../src/language/generated/ast.js';
+import { setTypeResolutionWarnings } from '../src/language/bbj-validator.js';
+
+// Uses the test module's FAKE Java classes (java.util.HashMap, java.lang.String,
+// java.lang.Class, BBjAPI) so declared/returned types actually resolve. See bbj-test-module.ts.
+const { shared, BBj } = createBBjTestServices(EmptyFileSystem);
+const validate = validationHelper<Program>(BBj);
+
+// The diagnostic emitted by the #437 return-type check. Assertions target this message
+// specifically — incidental "Could not resolve reference to ..." linking diagnostics appear
+// whenever a type isn't in the fake classpath and are irrelevant here.
+const INCOMPATIBLE = 'returns a value of incompatible type';
+
+async function returnTypeDiagnostics(code: string): Promise<string[]> {
+    const result = await validate(code);
+    return result.diagnostics
+        .filter(d => d.message.includes(INCOMPATIBLE))
+        .map(d => d.message);
+}
+
+describe('#437 validate returned value against a Java / non-BBj return type', () => {
+    beforeAll(async () => { await initializeWorkspace(shared); });
+    afterEach(() => setTypeResolutionWarnings(true));
+
+    test('string returned for a java.util.HashMap return type is flagged', async () => {
+        const diagnostics = await returnTypeDiagnostics(`
+use java.util.HashMap
+class public Test
+  method public java.util.HashMap doSomething()
+    methodret ""
+  methodend
+classend
+`);
+        expect(diagnostics).toEqual([
+            `Method 'doSomething' declares return type 'java.util.HashMap' but returns a value of incompatible type 'java.lang.String'.`
+        ]);
+    });
+
+    test('the incompatibility is reported as an error', async () => {
+        const result = await validate(`
+use java.util.HashMap
+class public Test
+  method public java.util.HashMap doSomething()
+    methodret ""
+  methodend
+classend
+`);
+        const diag = result.diagnostics.find(d => d.message.includes(INCOMPATIBLE));
+        expect(diag).toBeDefined();
+        expect(diag!.severity).toBe(1); // 1 = Error
+    });
+
+    describe('no false positives', () => {
+        test('exact type match: string returned for a java.lang.String return type', async () => {
+            const diagnostics = await returnTypeDiagnostics(`
+class public Test
+  method public java.lang.String doSomething()
+    methodret ""
+  methodend
+classend
+`);
+            expect(diagnostics).toHaveLength(0);
+        });
+
+        test('BBjString scalar return type is left to the loose literal check', async () => {
+            const diagnostics = await returnTypeDiagnostics(`
+class public Test
+  method public BBjString doSomething()
+    methodret ""
+  methodend
+classend
+`);
+            expect(diagnostics).toHaveLength(0);
+        });
+
+        test('java.lang.Object return type accepts any returned value (top type)', async () => {
+            // Object is not in the fake classpath, so the declared type does not resolve and the
+            // check skips silently — never a false positive. When Object does resolve it is treated
+            // as the top type by isAssignable().
+            const diagnostics = await returnTypeDiagnostics(`
+class public Test
+  method public java.lang.Object doSomething()
+    methodret ""
+  methodend
+classend
+`);
+            expect(diagnostics).toHaveLength(0);
+        });
+
+        test('a supertype (CharSequence) return type accepts a String value', async () => {
+            const diagnostics = await returnTypeDiagnostics(`
+class public Test
+  method public java.lang.CharSequence doSomething()
+    methodret ""
+  methodend
+classend
+`);
+            expect(diagnostics).toHaveLength(0);
+        });
+
+        test('an unresolved declared return type is not flagged', async () => {
+            const diagnostics = await returnTypeDiagnostics(`
+class public Test
+  method public com.example.Unknown doSomething()
+    methodret ""
+  methodend
+classend
+`);
+            expect(diagnostics).toHaveLength(0);
+        });
+
+        test('a returned value whose type does not resolve is not flagged', async () => {
+            const diagnostics = await returnTypeDiagnostics(`
+use java.util.HashMap
+class public Test
+  method public java.util.HashMap doSomething()
+    methodret unknownVar!
+  methodend
+classend
+`);
+            expect(diagnostics).toHaveLength(0);
+        });
+
+        test('a non-final returned Java type is not flagged (hierarchy not walkable)', async () => {
+            // Returning a HashMap where a String is declared is a genuine mismatch, but HashMap is
+            // not a known final type, so its supertype set is unknown and we deliberately defer
+            // rather than risk a false positive on a legitimate subtype return.
+            const diagnostics = await returnTypeDiagnostics(`
+use java.util.HashMap
+class public Test
+  method public java.lang.String doSomething()
+    methodret new java.util.HashMap()
+  methodend
+classend
+`);
+            expect(diagnostics).toHaveLength(0);
+        });
+
+        test('a BBj subtype instance returned for a BBj supertype is not flagged', async () => {
+            const diagnostics = await returnTypeDiagnostics(`
+class public Animal
+classend
+class public Dog extends Animal
+classend
+class public Test
+  method public Animal make()
+    declare Dog d!
+    d! = new Dog()
+    methodret d!
+  methodend
+classend
+`);
+            expect(diagnostics).toHaveLength(0);
+        });
+    });
+
+    test('the check is silent when typeResolutionWarnings is disabled', async () => {
+        setTypeResolutionWarnings(false);
+        const diagnostics = await returnTypeDiagnostics(`
+use java.util.HashMap
+class public Test
+  method public java.util.HashMap doSomething()
+    methodret ""
+  methodend
+classend
+`);
+        expect(diagnostics).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Fixes #437. Follow-up to #372 / #436.

## What
Extends the conservative `checkMethodReturn` (which so far only checked returned *literals* against BBj scalar / BBj-class return types) to also catch a returned value whose inferred type is incompatible with a declared **Java / non-BBj** return type, e.g.:
```bbj
method public java.util.HashMap doSomething()
    methodret ""     rem String is not assignable to HashMap → flagged
methodend
```

## Key finding → conservative design
The issue's suggested approach assumed a `JavaClass` exposes walkable `extends`/`implements`. **In this AST it does not** — `JavaClass` carries only `packageName`/`fields`/`methods`/`classes`/`constructors`, no supertype info. A general "resolve both + compare" would therefore false-positive on every legal subtype return (e.g. `HashMap` for a declared `Map`).

So the check is narrowed to what is **provably** decidable with zero false-positive risk (three-valued assignability — only a definitive *not-assignable* emits):
- fires only when both declared and inferred returned types fully resolve to a `Class`; skips otherwise;
- skips BBj scalar declared types (`BBjString`/`BBjNumber`/`BBjInt` — owned by the literal check, loosely coerced);
- `java.lang.Object` is the top type (always assignable);
- flags only when the **returned** type is a well-known **final** Java type (`String`, boxed numerics, `BigDecimal`/`BigInteger`) whose complete supertype closure is known and does not contain the declared type;
- BBj-class returns walk the resolvable `extends`/`implements` chain only to *confirm* assignability — never to emit a false negative;
- never double-reports with the existing literal check (`continue` after a literal match).

Gated behind `typeResolutionWarnings` (like the CAST-resolvability check); severity `error` to match the sibling method-return diagnostics.

## Plumbing
`registerClassChecks(registry)` → `registerClassChecks(registry, services)` to thread `services.types.Inferer` into `ClassValidator`; added exported `isTypeResolutionWarningsEnabled()` getter (single caller).

## Tests
New `test/method-return-java-type.test.ts` (11 tests): mismatch flagged; **no** false positives on exact-match / `Object` / `CharSequence` / BBj-scalar / unresolved returns; silent when `typeResolutionWarnings` disabled. Validation battery (`method-return-java-type` + `class-validations-issues` + `classes` + `validation`): 107/107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)