### PR TITLE
Fix #438: flag unresolvable type identifiers

### DIFF
--- a/bbj-vscode/src/language/bbj-validator.ts
+++ b/bbj-vscode/src/language/bbj-validator.ts
@@ -26,6 +26,10 @@ export function setTypeResolutionWarnings(enabled: boolean): void {
     typeResolutionWarningsEnabled = enabled;
 }
 
+export function isTypeResolutionWarningsEnabled(): boolean {
+    return typeResolutionWarningsEnabled;
+}
+
 /** Prefix of the diagnostic message emitted for unresolvable USE file paths. Used by document builder to identify and reconcile these diagnostics after PREFIX docs are loaded. */
 export const USE_FILE_NOT_RESOLVED_PREFIX = "File '";
 
@@ -56,7 +60,7 @@ export function registerValidationChecks(services: BBjServices) {
         SwitchCase: validator.checkSwitchCaseInSwitch,
     };
     registry.register(checks, validator);
-    registerClassChecks(registry);
+    registerClassChecks(registry, services.java.JavaInteropService);
     registerVariableScopingChecks(registry);
     registerFunctionCallChecks(registry);
 }

--- a/bbj-vscode/src/language/java-interop.ts
+++ b/bbj-vscode/src/language/java-interop.ts
@@ -75,6 +75,17 @@ export class JavaInteropService {
     }
 
     /**
+     * True once the java-interop classpath has actually been populated with at least one resolved
+     * class (via {@link loadImplicitImports}/{@link loadClasspath}, or preloaded in the test double).
+     * Used to gate "type cannot be resolved" diagnostics: when no class is available the interop
+     * service is effectively down (e.g. CI without a running service, or EmptyFileSystem without a
+     * reachable :5008), so an unresolved reference means "interop unavailable", not "invalid type".
+     */
+    public isClasspathAvailable(): boolean {
+        return this._resolvedClasses.size > 0;
+    }
+
+    /**
      * Establishes connection to the Java backend service
      */
     protected async connect(): Promise<MessageConnection> {

--- a/bbj-vscode/src/language/validations/check-classes.ts
+++ b/bbj-vscode/src/language/validations/check-classes.ts
@@ -1,10 +1,12 @@
 import { AstNode, AstUtils, DiagnosticInfo, ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
 import { basename, dirname, isAbsolute, relative } from 'path';
-import { getClass, getClassRef } from '../bbj-nodedescription-provider.js';
+import { getClass, getFQNFullname } from '../bbj-nodedescription-provider.js';
 import { BBjAstType, BbjClass, ConstructorCall, Expression, FieldDecl, isBbjClass, isMethodDecl, isMethodReturnStatement, isNumberLiteral, isStringLiteral, MethodDecl, QualifiedClass } from '../generated/ast.js';
+import { JavaInteropService } from '../java-interop.js';
+import { isTypeResolutionWarningsEnabled } from '../bbj-validator.js';
 
-export function registerClassChecks(registry: ValidationRegistry) {
-    const validator = new ClassValidator();
+export function registerClassChecks(registry: ValidationRegistry, javaInterop?: JavaInteropService) {
+    const validator = new ClassValidator(javaInterop);
     const classChecks: ValidationChecks<BBjAstType> = {
         Use: (use, accept) => {
             if(!use.bbjClass) {
@@ -63,7 +65,13 @@ export function registerClassChecks(registry: ValidationRegistry) {
             });
             validator.checkMethodReturn(meth, accept);
         },
-        FieldDecl: (field, accept) => validator.checkFieldInit(field, accept),
+        FieldDecl: (field, accept) => {
+            validator.checkClassReference(accept, field.type, {
+                node: field,
+                property: 'type'
+            });
+            validator.checkFieldInit(field, accept);
+        },
         ParameterDecl: (param, accept) => validator.checkClassReference(accept, param.type, {
             node: param,
             property: 'type'
@@ -77,6 +85,20 @@ export function registerClassChecks(registry: ValidationRegistry) {
 }
 
 class ClassValidator {
+
+    /**
+     * Type names (case-insensitive, simple name) that must never be flagged as unresolvable even
+     * when java-interop has not resolved them. These are BBj's built-in scalar types: they are
+     * backed by real `com.basis.startup.type.*` classes that resolve once the classpath is loaded,
+     * but they are so fundamental to typed FIELD/METHOD/DECLARE declarations that a
+     * partially-loaded classpath (or a test double that does not preload them) must not produce a
+     * false positive.
+     */
+    private static readonly KNOWN_BBJ_SCALAR_TYPES = new Set(['bbjnumber', 'bbjstring', 'bbjint']);
+
+    constructor(private readonly javaInterop?: JavaInteropService) {
+    }
+
     private isSubFolderOf(folder: string, parentFolder: string) {
         if(parentFolder === folder) {
             return true;
@@ -86,19 +108,48 @@ class ClassValidator {
     }
 
     public checkClassReference<N extends AstNode>(accept: ValidationAcceptor, qclass: QualifiedClass|undefined, info: DiagnosticInfo<N>): void {
-        const ref = qclass ? getClassRef(qclass) : undefined;
-        if(!ref) {
+        if(!qclass) {
             return;
         }
-        const uriOfUsage = AstUtils.getDocument(ref.$refNode!.root.astNode).uri.fsPath;
-        if(!ref.ref) {
+        const klass = getClass(qclass);
+        if(!klass) {
+            // The type reference resolved to nothing. Flag it as unresolvable (#438), but only when
+            // it is safe to conclude the name is genuinely invalid rather than "interop is down".
+            this.warnUnresolvableType(accept, qclass, info);
             return;
         }
-        const klass = ref.ref;
-        const uriOfDeclaration = AstUtils.getDocument(ref.ref).uri.fsPath;
+        const uriOfUsage = AstUtils.getDocument(qclass).uri.fsPath;
         if(isBbjClass(klass) && klass.visibility) {
+            const uriOfDeclaration = AstUtils.getDocument(klass).uri.fsPath;
             return this.checkBBjClass<N>(klass, uriOfDeclaration, uriOfUsage, accept, info);
         }
+    }
+
+    /**
+     * Emits a warning that a {@link QualifiedClass} type reference cannot be resolved (#438), gated
+     * so it never floods environments where java-interop is unavailable:
+     *  - only when the `typeResolutionWarnings` flag is enabled, and
+     *  - only when the java-interop classpath is actually available (at least one class resolved) —
+     *    otherwise an unresolved reference just means the interop service is down, not that the
+     *    type is invalid; and
+     *  - never for the built-in BBj scalar types (see {@link KNOWN_BBJ_SCALAR_TYPES}).
+     */
+    private warnUnresolvableType<N extends AstNode>(accept: ValidationAcceptor, qclass: QualifiedClass, info: DiagnosticInfo<N>): void {
+        if(!isTypeResolutionWarningsEnabled()) {
+            return;
+        }
+        if(!this.javaInterop?.isClasspathAvailable()) {
+            return;
+        }
+        const name = getFQNFullname(qclass);
+        if(!name) {
+            return;
+        }
+        const simpleName = name.substring(name.lastIndexOf('.') + 1).toLowerCase();
+        if(ClassValidator.KNOWN_BBJ_SCALAR_TYPES.has(simpleName)) {
+            return;
+        }
+        accept('warning', `Type '${name}' cannot be resolved.`, info);
     }
 
     public checkBBjClass<N extends AstNode>(klass: BbjClass, uriOfDeclaration: string, uriOfUsage: string, accept: ValidationAcceptor, info: DiagnosticInfo<N>) {

--- a/bbj-vscode/test/unresolvable-type.test.ts
+++ b/bbj-vscode/test/unresolvable-type.test.ts
@@ -1,0 +1,139 @@
+import { EmptyFileSystem } from 'langium';
+import { ParseHelperOptions, validationHelper } from 'langium/test';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { createBBjTestServices } from './bbj-test-module.js';
+import { Program } from '../src/language/generated/ast.js';
+import { setTypeResolutionWarnings } from '../src/language/bbj-validator.js';
+import { initializeWorkspace } from './test-helper.js';
+
+/**
+ * Issue #438: a QualifiedClass type reference that resolves to nothing must be flagged.
+ * These tests use the test double (createBBjTestServices), whose fake java-interop preloads a
+ * handful of classes, so `isClasspathAvailable()` is true and genuinely-invalid names warn —
+ * while EmptyFileSystem-with-real-interop-down stays quiet.
+ */
+describe('Unresolvable type references (#438)', () => {
+    const services = createBBjTestServices(EmptyFileSystem);
+    let validate: ReturnType<typeof validationHelper<Program>>;
+    const disposables: (() => Promise<void>)[] = [];
+
+    beforeAll(async () => {
+        await initializeWorkspace(services.shared);
+        const validateInternal = validationHelper<Program>(services.BBj);
+        validate = async (input: string, options?: ParseHelperOptions) => {
+            const result = await validateInternal(input, options);
+            disposables.push(result.dispose);
+            return result;
+        };
+    });
+
+    afterAll(async () => {
+        for (const dispose of disposables) {
+            await dispose();
+        }
+    });
+
+    function unresolvableWarnings(diagnostics: { message: string }[], name: string) {
+        return diagnostics.filter(d => d.message === `Type '${name}' cannot be resolved.`);
+    }
+
+    test('unresolvable return type warns', async () => {
+        const { diagnostics } = await validate(`
+            class public Foo
+                method public SomeInvalidType testmethod()
+                    methodret new SomeInvalidType()
+                methodend
+            classend
+        `);
+        expect(unresolvableWarnings(diagnostics, 'SomeInvalidType').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('unresolvable parameter type warns', async () => {
+        const { diagnostics } = await validate(`
+            class public Foo
+                method public void testmethod(SomeInvalidType p!)
+                methodend
+            classend
+        `);
+        expect(unresolvableWarnings(diagnostics, 'SomeInvalidType').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('unresolvable field type warns', async () => {
+        const { diagnostics } = await validate(`
+            class public Foo
+                field public SomeInvalidType f!
+            classend
+        `);
+        expect(unresolvableWarnings(diagnostics, 'SomeInvalidType').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('unresolvable DECLARE variable type warns', async () => {
+        const { diagnostics } = await validate(`
+            declare SomeInvalidType x!
+        `);
+        expect(unresolvableWarnings(diagnostics, 'SomeInvalidType').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('unresolvable extends target warns', async () => {
+        const { diagnostics } = await validate(`
+            class public Foo extends SomeInvalidType
+            classend
+        `);
+        expect(unresolvableWarnings(diagnostics, 'SomeInvalidType').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('resolvable BBj class in the same file does NOT warn', async () => {
+        const { diagnostics } = await validate(`
+            class public Bar
+            classend
+
+            class public Foo
+                field public Bar b!
+                method public Bar getBar()
+                    methodret new Bar()
+                methodend
+            classend
+        `);
+        expect(diagnostics.filter(d => /cannot be resolved/.test(d.message))).toHaveLength(0);
+    });
+
+    test('resolvable Java fake (java.util.HashMap) does NOT warn', async () => {
+        const { diagnostics } = await validate(`
+            use java.util.HashMap
+
+            class public Foo
+                field public java.util.HashMap m!
+            classend
+        `);
+        expect(diagnostics.filter(d => /cannot be resolved/.test(d.message))).toHaveLength(0);
+    });
+
+    test('built-in BBj scalar types (BBjString, BBjNumber) do NOT warn', async () => {
+        const { diagnostics } = await validate(`
+            class public Foo
+                field public BBjString s$
+                field public BBjNumber n%
+                method public BBjString getS()
+                    methodret ""
+                methodend
+            classend
+        `);
+        expect(diagnostics.filter(d => /cannot be resolved/.test(d.message))).toHaveLength(0);
+    });
+
+    test('with type-resolution warnings disabled there is NO warning', async () => {
+        setTypeResolutionWarnings(false);
+        try {
+            const { diagnostics } = await validate(`
+                class public Foo
+                    method public SomeInvalidType testmethod()
+                        methodret new SomeInvalidType()
+                    methodend
+                classend
+            `);
+            expect(diagnostics.filter(d => /cannot be resolved/.test(d.message))).toHaveLength(0);
+        } finally {
+            setTypeResolutionWarnings(true);
+        }
+    });
+});


### PR DESCRIPTION
Fixes #438. Surfaced during #372 / #436 review.

## What
A `QualifiedClass` type reference that resolves to nothing is now reported. This applies consistently everywhere a type is referenced, all of which already route through `ClassValidator.checkClassReference`: method return types, parameter types, **field types** (newly wired — `FieldDecl` previously only ran `checkFieldInit`), variable/`DECLARE` types, and `extends`/`implements`.

```bbj
method public SomeInvalidType testmethod()   rem → warning: Type 'SomeInvalidType' cannot be resolved.
```

## Fix
`checkClassReference` now resolves via `getClass(qclass)` (covers all three `QualifiedClass` forms) and, on non-resolution, calls `warnUnresolvableType` → `warning: "Type '<name>' cannot be resolved."` (matching the existing CAST-resolvability warning).

## Gating (to avoid flooding — the warning fires only when ALL hold)
1. `isTypeResolutionWarningsEnabled()` — new exported getter over the existing `typeResolutionWarnings` flag.
2. `javaInterop.isClasspathAvailable()` — new signal (`_resolvedClasses.size > 0`). When no class has resolved, interop is effectively down (CI without `:5008`, cold service), so an unresolved reference means "interop unavailable", not "invalid type" → stays silent. This is what keeps the many `EmptyFileSystem` validation tests quiet on CI.
3. The type's simple name is not a built-in BBj scalar (`BBjNumber`/`BBjString`/`BBjInt`) — so a partially-loaded classpath or the test double (which doesn't preload them) never false-positives.

`JavaInteropService` is threaded into `ClassValidator` via `registerClassChecks(registry, services.java.JavaInteropService)`.

## Tests
New `test/unresolvable-type.test.ts` (9 tests, via `createBBjTestServices` whose fake interop preloads classes so it's deterministic regardless of `:5008`): `SomeInvalidType` as return/param/field/var/extends → warning; resolvable BBj/Java types → none; silent when `typeResolutionWarnings` disabled. Full `npm test`: **zero new failures** (the 11 `linking.test.ts` interop failures are identical on `main`).

## Reviewer note
Because the check keys off live interop resolution, a genuinely-valid Java type that hasn't been lazily resolved yet at validation time could momentarily warn in the running IDE. This is gated behind `typeResolutionWarnings` (user-disablable) and matches the issue's stated constraints; worth a look if lazy-prefix loading proves noisy in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)