### PR TITLE
Parameter name inlay hints (Phase 1+2 of #108)

### DIFF
--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -552,6 +552,17 @@
           "description": "Path to config.bbx file. When not set, defaults to {bbj.home}/cfg/config.bbx. Set this to use a custom config.bbx location for PREFIX resolution.",
           "scope": "window"
         },
+        "bbj.inlayHints.parameterNames.enabled": {
+          "type": "string",
+          "enum": [
+            "none",
+            "literals",
+            "all"
+          ],
+          "default": "literals",
+          "description": "Show parameter name inlay hints at call sites. 'literals' (default) shows hints only for literal arguments like msgbox(\"Hi\"), 'all' shows them for every argument, 'none' disables them.",
+          "scope": "window"
+        },
         "bbj.interop.host": {
           "type": "string",
           "default": "localhost",

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -871,7 +871,8 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
             interopPort: vscode.workspace.getConfiguration("bbj").get("interop.port", 5008),
             suppressCascading: vscode.workspace.getConfiguration("bbj").get("diagnostics.suppressCascading", true),
             maxErrors: vscode.workspace.getConfiguration("bbj").get("diagnostics.maxErrors", 20),
-            compilerTrigger: vscode.workspace.getConfiguration("bbj").get("compiler.trigger", "debounced")
+            compilerTrigger: vscode.workspace.getConfiguration("bbj").get("compiler.trigger", "debounced"),
+            inlayHintsParameterNames: vscode.workspace.getConfiguration("bbj").get("inlayHints.parameterNames.enabled", "literals")
         }
     };
 

--- a/bbj-vscode/src/language/bbj-inlay-hint-provider.ts
+++ b/bbj-vscode/src/language/bbj-inlay-hint-provider.ts
@@ -1,0 +1,125 @@
+import { AstNode, Reference } from 'langium';
+import { AbstractInlayHintProvider, InlayHintAcceptor } from 'langium/lsp';
+import { InlayHintKind } from 'vscode-languageserver';
+import { isFunctionNodeDescription } from './bbj-nodedescription-provider.js';
+import { Expression, MethodCall, NamedElement, isMemberCall, isMethodCall, isNumberLiteral, isPrefixExpression, isStringLiteral, isSymbolRef } from './generated/ast.js';
+
+export type ParameterHintMode = 'none' | 'literals' | 'all';
+
+let parameterHintMode: ParameterHintMode = 'literals';
+
+export function setParameterHintMode(mode: unknown): void {
+    if (mode === 'none' || mode === 'literals' || mode === 'all') {
+        parameterHintMode = mode;
+    }
+}
+
+export function getParameterHintMode(): ParameterHintMode {
+    return parameterHintMode;
+}
+
+/**
+ * Names the JDK invents when a jar was compiled without -parameters (arg0, arg1, ...).
+ * Showing them as hints is worse than showing nothing.
+ */
+const SYNTHETIC_NAME = /^(arg|param|p)\d+$/i;
+
+/**
+ * Parameter name inlay hints at call sites (issue #108). Resolves the callee the same
+ * way signature help does: through the reference's FunctionNodeDescription, which
+ * normalizes BBj class methods, DEF FN functions, builtin library functions and Java
+ * methods (with the Javadoc-backed realName fallback) into one parameter list.
+ */
+export class BBjInlayHintProvider extends AbstractInlayHintProvider {
+
+    override computeInlayHint(node: AstNode, acceptor: InlayHintAcceptor): void {
+        if (parameterHintMode === 'none') {
+            return;
+        }
+        if (!isMethodCall(node) || node.args.length === 0) {
+            return;
+        }
+        const ref = this.getFunctionReference(node);
+        // Access .ref so lazily linked references are resolved before reading the description
+        if (!ref?.ref) {
+            return;
+        }
+        const description = ref.$nodeDescription;
+        if (!isFunctionNodeDescription(description)) {
+            return;
+        }
+        const calleeName = description.name.toLowerCase();
+        // Extra arguments beyond the declared parameters (varargs, arity errors) get no hint
+        const count = Math.min(node.args.length, description.parameters.length);
+        for (let i = 0; i < count; i++) {
+            const cst = node.args[i].$cstNode;
+            if (!cst) {
+                continue;
+            }
+            const parameter = description.parameters[i];
+            const name = (parameter.realName ?? parameter.name)?.trim();
+            if (!name || SYNTHETIC_NAME.test(stripTypeSuffix(name))) {
+                continue;
+            }
+            if (parameterHintMode === 'literals' && !isLiteralArgument(node.args[i].expression)) {
+                continue;
+            }
+            if (matchesParameterName(cst.text, name) || isSelfDescribing(calleeName, name)) {
+                continue;
+            }
+            acceptor({
+                position: cst.range.start,
+                label: `${name}:`,
+                kind: InlayHintKind.Parameter,
+                paddingRight: true
+            });
+        }
+    }
+
+    protected getFunctionReference(callNode: MethodCall): Reference<NamedElement> | undefined {
+        const method = callNode.method;
+        if (isSymbolRef(method)) {
+            return method.symbol;
+        } else if (isMemberCall(method)) {
+            return method.member;
+        }
+        return undefined;
+    }
+}
+
+/**
+ * True for arguments whose value carries no name of its own: string/number literals,
+ * optionally behind a numeric sign (-1, +0.5). Everything else (variables, calls,
+ * arithmetic) is considered self-describing in 'literals' mode.
+ */
+export function isLiteralArgument(expression: Expression): boolean {
+    if (isPrefixExpression(expression) && (expression.operator === '-' || expression.operator === '+')) {
+        return isLiteralArgument(expression.expression);
+    }
+    return isNumberLiteral(expression) || isStringLiteral(expression);
+}
+
+/** BBj variable names carry type suffixes (name$, obj!, i%) that must not defeat name comparisons. */
+function stripTypeSuffix(name: string): string {
+    return name.replace(/[!$%]$/, '');
+}
+
+/**
+ * A hint is redundant when the argument is a plain identifier already spelling the
+ * parameter name: foo(count) for foo(count). Case-insensitive (BBj), ignoring type
+ * suffixes and instance access: foo(#count!) matches parameter "count".
+ */
+export function matchesParameterName(argumentText: string, parameterName: string): boolean {
+    const identifier = /^#?([a-zA-Z_][a-zA-Z0-9_]*)[!$%]?$/.exec(argumentText.trim());
+    return identifier !== null
+        && identifier[1].toLowerCase() === stripTypeSuffix(parameterName).toLowerCase();
+}
+
+/**
+ * setName(x$) style: the callee name already contains the parameter name, so a hint
+ * adds nothing. Only applied to names of 3+ characters to avoid accidental substrings.
+ */
+export function isSelfDescribing(calleeName: string, parameterName: string): boolean {
+    const bare = stripTypeSuffix(parameterName).toLowerCase();
+    return bare.length >= 3 && calleeName.includes(bare);
+}

--- a/bbj-vscode/src/language/bbj-module.ts
+++ b/bbj-vscode/src/language/bbj-module.ts
@@ -23,6 +23,7 @@ import { BBjDocumentSymbolProvider } from './bbj-document-symbol-provider.js';
 import { BBjDocumentValidator } from './bbj-document-validator.js';
 import { BBjHoverProvider } from './bbj-hover.js';
 import { BBjIndexManager } from './bbj-index-manager.js';
+import { BBjInlayHintProvider } from './bbj-inlay-hint-provider.js';
 import { BbjLexer } from './bbj-lexer.js';
 import { BbjLinker } from './bbj-linker.js';
 import { BBjNodeKindProvider } from './bbj-node-kind.js';
@@ -101,6 +102,7 @@ export const BBjModule: Module<BBjServices, PartialLangiumServices & BBjAddedSer
         CompletionProvider: (services) => new BBjCompletionProvider(services),
         SemanticTokenProvider: (services) => new BBjSemanticTokenProvider(services),
         SignatureHelp: () => new BBjSignatureHelpProvider(),
+        InlayHintProvider: () => new BBjInlayHintProvider(),
         CodeActionProvider: (services) => new BBjCodeActionProvider(services),
     },
     parser: {

--- a/bbj-vscode/src/language/bbj-nodedescription-provider.ts
+++ b/bbj-vscode/src/language/bbj-nodedescription-provider.ts
@@ -1,5 +1,5 @@
 import { AstNode, AstNodeDescription, AstUtils, CstNode, DefaultAstNodeDescriptionProvider, LangiumDocument, Reference, assertUnreachable, isAstNodeDescription } from "langium";
-import { Class, JavaClass, JavaMethod, LibEventType, LibFunction, MethodDecl, QualifiedClass } from "./generated/ast.js";
+import { Class, DefFunction, JavaClass, JavaMethod, LibEventType, LibFunction, MethodDecl, QualifiedClass } from "./generated/ast.js";
 import { documentationHeader } from "./bbj-hover.js";
 
 export class BBjAstNodeDescriptionProvider extends DefaultAstNodeDescriptionProvider {
@@ -17,6 +17,7 @@ export class BBjAstNodeDescriptionProvider extends DefaultAstNodeDescriptionProv
         const descr = super.createDescription(node, name, document);
         switch (node.$type) {
             case MethodDecl.$type: return enhanceFunctionDescription(descr, toMethodData(node as MethodDecl))
+            case DefFunction.$type: return enhanceFunctionDescription(descr, toDefFunctionData(node as DefFunction));
             case LibFunction.$type: return enhanceFunctionDescription(descr, node as LibFunction);
             case JavaMethod.$type: return enhanceFunctionDescription(descr, node as JavaMethod);
             case LibEventType.$type: return { ...descr, docu: documentationHeader(node)! } as AstNodeDescription;
@@ -36,6 +37,24 @@ export function toMethodData(methDecl: MethodDecl): MethodData {
         name: methDecl.name,
         parameters: methDecl.params.map(p => { return { name: p.name, type: getFQNFullname(p.type) } }),
         returnType: getFQNFullname(methDecl.returnType)
+    }
+}
+
+export function toDefFunctionData(def: DefFunction): MethodData {
+    return {
+        name: def.name,
+        parameters: def.parameters.map(p => { return { name: p.name, type: suffixType(p.name) } }),
+        returnType: suffixType(def.name)
+    }
+}
+
+/** DEF FN parameters and names are untyped; the BBj name suffix defines the type. */
+function suffixType(name: string): string {
+    switch (name?.charAt(name.length - 1)) {
+        case '$': return 'string';
+        case '!': return 'object';
+        case '%': return 'int';
+        default: return 'num';
     }
 }
 

--- a/bbj-vscode/src/language/bbj-ws-manager.ts
+++ b/bbj-vscode/src/language/bbj-ws-manager.ts
@@ -20,6 +20,7 @@ import * as path from 'path';
 import { builtinEvents } from "./lib/events.js";
 import { setTypeResolutionWarnings } from "./bbj-validator.js";
 import { setSuppressCascading, setMaxErrors, setCompilerTrigger } from "./bbj-document-validator.js";
+import { setParameterHintMode } from "./bbj-inlay-hint-provider.js";
 
 export class BBjWorkspaceManager extends DefaultWorkspaceManager {
 
@@ -92,6 +93,9 @@ export class BBjWorkspaceManager extends DefaultWorkspaceManager {
                 } else {
                     setCompilerTrigger('debounced');
                 }
+
+                // Set parameter name inlay hint mode (invalid/missing values keep the default)
+                setParameterHintMode(params.initializationOptions.inlayHintsParameterNames);
             }
         });
         this.documentFactory = services.workspace.LangiumDocumentFactory;

--- a/bbj-vscode/src/language/main.ts
+++ b/bbj-vscode/src/language/main.ts
@@ -12,6 +12,7 @@ import { createBBjServices } from './bbj-module.js';
 import { BBjWorkspaceManager } from './bbj-ws-manager.js';
 import { logger, LogLevel } from './logger.js';
 import { setSuppressCascading, setMaxErrors, setCompilerTrigger } from './bbj-document-validator.js';
+import { setParameterHintMode } from './bbj-inlay-hint-provider.js';
 import { initNotifications } from './bbj-notifications.js';
 import { registerComposerRequests } from './composer-commands.js';
 
@@ -58,6 +59,7 @@ connection.onRequest('bbj/refreshJavaClasses', async () => {
         if (docUris.length > 0) {
             await shared.workspace.DocumentBuilder.update(docUris, []);
         }
+        refreshInlayHints();
 
         // Step 5: Send notification
         connection.window.showInformationMessage('Java classes refreshed');
@@ -73,11 +75,18 @@ connection.onRequest('bbj/refreshJavaClasses', async () => {
 // Start the language server with the shared services
 startLanguageServer(shared);
 
+// Ask the client to re-request inlay hints, e.g. after Java classes (and the Javadoc-based
+// parameter names) arrived asynchronously. Clients without refresh support just ignore us.
+function refreshInlayHints() {
+    connection.languages.inlayHint.refresh().catch(() => { /* client does not support refresh */ });
+}
+
 // Guard: skip Java class reload until initial workspace build is complete
 let workspaceInitialized = false;
 shared.workspace.DocumentBuilder.onBuildPhase(DocumentState.Validated, () => {
     if (!workspaceInitialized) {
         workspaceInitialized = true;
+        refreshInlayHints();
     }
 });
 
@@ -119,6 +128,12 @@ connection.onDidChangeConfiguration(async (change) => {
         if (trigger === 'debounced' || trigger === 'on-save' || trigger === 'off') {
             setCompilerTrigger(trigger);
         }
+    }
+
+    // Apply inlay hint mode (no startup gate — apply immediately) and repaint open editors
+    if (config.inlayHints?.parameterNames?.enabled !== undefined) {
+        setParameterHintMode(config.inlayHints.parameterNames.enabled);
+        refreshInlayHints();
     }
 
     // Skip Java class reload during initial startup — initializeWorkspace handles it
@@ -165,6 +180,7 @@ connection.onDidChangeConfiguration(async (change) => {
         if (docUris.length > 0) {
             await shared.workspace.DocumentBuilder.update(docUris, []);
         }
+        refreshInlayHints();
 
         connection.window.showInformationMessage('Java classes refreshed');
     } catch (error) {

--- a/bbj-vscode/test/inlay-hints.test.ts
+++ b/bbj-vscode/test/inlay-hints.test.ts
@@ -1,0 +1,187 @@
+import { AstUtils, EmptyFileSystem, LangiumDocument } from 'langium';
+import { parseHelper } from 'langium/test';
+import { afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { InlayHint, Range } from 'vscode-languageserver';
+import { isLiteralArgument, isSelfDescribing, matchesParameterName, setParameterHintMode } from '../src/language/bbj-inlay-hint-provider.js';
+import { Model, isParameterCall } from '../src/language/generated/ast.js';
+import { createBBjTestServices } from './bbj-test-module.js';
+import { initializeWorkspace } from './test-helper.js';
+
+const services = createBBjTestServices(EmptyFileSystem);
+const parse = (content: string) => parseHelper<Model>(services.BBj)(content);
+
+describe('Inlay hints', () => {
+
+    beforeAll(async () => {
+        await initializeWorkspace(services.shared);
+    });
+
+    afterEach(() => {
+        setParameterHintMode('literals');
+    });
+
+    async function getHints(content: string): Promise<{ document: LangiumDocument, hints: InlayHint[] }> {
+        const document = await parse(content);
+        expect(document.parseResult.lexerErrors).toHaveLength(0);
+        expect(document.parseResult.parserErrors).toHaveLength(0);
+        const provider = services.BBj.lsp.InlayHintProvider!;
+        const hints = await provider.getInlayHints(document, {
+            textDocument: { uri: document.uri.toString() },
+            range: Range.create(0, 0, document.textDocument.lineCount, 0)
+        }) ?? [];
+        return { document, hints };
+    }
+
+    function positionOf(document: LangiumDocument, snippet: string) {
+        const offset = document.textDocument.getText().indexOf(snippet);
+        expect(offset, `expected to find "${snippet}" in the test source`).toBeGreaterThanOrEqual(0);
+        return document.textDocument.positionAt(offset);
+    }
+
+    test('BBj class method call shows parameter name hints for literal arguments', async () => {
+        const { document, hints } = await getHints(`
+            class public Person
+                method public resize(BBjNumber width, BBjNumber height)
+                methodend
+            classend
+
+            declare Person p!
+            p!.resize(100, 200)
+        `);
+        expect(hints.map(h => h.label)).toEqual(['width:', 'height:']);
+        expect(hints[0].kind).toBe(2); // InlayHintKind.Parameter
+        expect(hints[0].position).toEqual(positionOf(document, '100'));
+        expect(hints[1].position).toEqual(positionOf(document, '200'));
+    });
+
+    test('DEF FN call shows parameter name hints', async () => {
+        const { document, hints } = await getHints(`
+            DEF FNAREA(W,H)=W*H
+            X = FNAREA(3,4)
+        `);
+        expect(hints.map(h => h.label)).toEqual(['W:', 'H:']);
+        expect(hints[0].position).toEqual(positionOf(document, '3,4)'));
+    });
+
+    test('builtin library function call shows parameter name hints', async () => {
+        const { hints } = await getHints(`
+            A$ = CHR(65)
+        `);
+        expect(hints.map(h => h.label)).toEqual(['num:']);
+    });
+
+    test('literals mode skips non-literal arguments', async () => {
+        const { hints } = await getHints(`
+            DEF FNAREA(W,H)=W*H
+            SIZE = 3
+            X = FNAREA(SIZE,4)
+        `);
+        expect(hints.map(h => h.label)).toEqual(['H:']);
+    });
+
+    test('negative and positive number literals still count as literals', async () => {
+        const { hints } = await getHints(`
+            DEF FNAREA(W,H)=W*H
+            X = FNAREA(-3,+4)
+        `);
+        expect(hints.map(h => h.label)).toEqual(['W:', 'H:']);
+    });
+
+    test('mode "all" hints variable arguments but not those spelling the parameter name', async () => {
+        setParameterHintMode('all');
+        const { hints } = await getHints(`
+            DEF FNAREA(W,H)=W*H
+            w = 3
+            SIZE = 4
+            X = FNAREA(w,SIZE)
+        `);
+        // w matches parameter W (case-insensitive), SIZE does not match H
+        expect(hints.map(h => h.label)).toEqual(['H:']);
+    });
+
+    test('mode "none" disables all hints', async () => {
+        setParameterHintMode('none');
+        const { hints } = await getHints(`
+            DEF FNAREA(W,H)=W*H
+            X = FNAREA(3,4)
+        `);
+        expect(hints).toHaveLength(0);
+    });
+
+    test('setter-like methods whose name contains the parameter name get no hint', async () => {
+        const { hints } = await getHints(`
+            class public Person
+                method public setAge(BBjNumber age)
+                methodend
+            classend
+
+            declare Person p!
+            p!.setAge(30)
+        `);
+        expect(hints).toHaveLength(0);
+    });
+
+    test('synthetic parameter names (arg0, arg1) are suppressed', async () => {
+        const { hints } = await getHints(`
+            class public Legacy
+                method public compute(BBjNumber arg0, BBjNumber arg1)
+                methodend
+            classend
+
+            declare Legacy l!
+            l!.compute(1, 2)
+        `);
+        expect(hints).toHaveLength(0);
+    });
+
+    test('extra arguments beyond the declared parameters get no hint', async () => {
+        const { hints } = await getHints(`
+            DEF FNTWICE(N)=N*2
+            X = FNTWICE(3,4)
+        `);
+        expect(hints.map(h => h.label)).toEqual(['N:']);
+    });
+});
+
+describe('Inlay hint heuristics', () => {
+
+    test('matchesParameterName is case-insensitive and ignores BBj suffixes', () => {
+        expect(matchesParameterName('count', 'count')).toBe(true);
+        expect(matchesParameterName('COUNT', 'count')).toBe(true);
+        expect(matchesParameterName('count!', 'count')).toBe(true);
+        expect(matchesParameterName('name$', 'NAME$')).toBe(true);
+        expect(matchesParameterName('#count', 'count')).toBe(true);
+        expect(matchesParameterName('total', 'count')).toBe(false);
+        expect(matchesParameterName('getCount()', 'count')).toBe(false);
+    });
+
+    test('isSelfDescribing detects setter-like callee names', () => {
+        expect(isSelfDescribing('setage', 'age')).toBe(true);
+        expect(isSelfDescribing('settitle', 'title$')).toBe(true);
+        expect(isSelfDescribing('resize', 'width')).toBe(false);
+        // short names never trigger the substring rule
+        expect(isSelfDescribing('sin', 'n')).toBe(false);
+    });
+
+    test('isLiteralArgument accepts literals and signed literals only', async () => {
+        const document = await parse(`
+            DEF FNID(N)=N
+            A = FNID(1)
+            B = FNID(-1)
+            C = FNID("s")
+            D = FNID(A)
+            E = FNID(1+2)
+        `);
+        const args = AstUtils.streamAllContents(document.parseResult.value)
+            .filter(isParameterCall)
+            .map(p => p.expression)
+            .toArray();
+        expect(args).toHaveLength(5);
+        const [literal, signed, str, variable, binary] = args;
+        expect(isLiteralArgument(literal)).toBe(true);
+        expect(isLiteralArgument(signed)).toBe(true);
+        expect(isLiteralArgument(str)).toBe(true);
+        expect(isLiteralArgument(variable)).toBe(false);
+        expect(isLiteralArgument(binary)).toBe(false);
+    });
+});


### PR DESCRIPTION
Implements Phase 1 + 2 of the strategy in #108: parameter name inlay hints computed entirely inside the language server.

## What it does

Call sites show the callee's parameter names as inline hints:

- **BBj class methods** (`method ... endmethod`) — names from the AST
- **DEF FN functions** — descriptions are now enriched into `FunctionNodeDescription`, which also gives DEF FN working signature help and parameter snippets in completion
- **Builtin library functions** (functions.bbl)
- **Java methods** — via the existing Javadoc-backed `realName`; methods with only reflection-synthetic names show nothing

## Noise control (JDT LS / IntelliJ conventions)

- Synthetic Java names (`arg0`, `param1`, …) are never rendered
- Arguments already spelling the parameter name are skipped (case-insensitive, ignoring BBj type suffixes `$ ! %` and `#` instance access)
- Setter-like callees (`setAge(30)`) are skipped
- Extra arguments beyond the declared parameter list get no hint

## Setting

`bbj.inlayHints.parameterNames.enabled`: `none` | `literals` (default — only literal arguments get hints) | `all`. Applied live via `onDidChangeConfiguration`; the server sends `workspace/inlayHint/refresh` when the mode changes or Java class data arrives late. Registration via Langium's DI advertises the LSP 3.17 capability automatically, so IntelliJ/LSP4IJ picks this up with no plugin change.

## Testing

- 13 new tests in `test/inlay-hints.test.ts` (hint positions/labels for all callee kinds, all three modes, every suppression heuristic)
- Wire-level smoke test against the bundled `out/language/main.cjs` returned correct hints over real LSP
- Full suite green except the 11 pre-existing live-interop `linking.test.ts` failures (reproduced identically on a clean checkout)

Phase 3 (better Java parameter names in bbj-ls via `MethodParameters`/`LocalVariableTable`) and Phase 4 (sources jars) remain follow-ups per the issue plan.

Part of #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)