### PR TITLE
Fix incorrect return/parameter types in builtin function library (MSGBOX and others)

### DIFF
--- a/bbj-vscode/src/language/lib/functions.bbl
+++ b/bbj-vscode/src/language/lib/functions.bbl
@@ -591,7 +591,7 @@ MOD(numA: num, numB: num, ERR?!: lineref): num
 
 The MSGBOX() function creates a message dialog box and returns a value that identifies the user-selected button.
 @/
-MSGBOX(str1: string, expr?: num, str2?: string, button1?: string, button2?: string, button3?: string, MODE?!: string, TIM?!: int, ERR?!: lineref): string
+MSGBOX(str1: string, expr?: num, str2?: string, button1?: string, button2?: string, button3?: string, MODE?!: string, TIM?!: int, ERR?!: lineref): int
 
 /@@
 \`NEVAL(str{,ERR=lineref})\`
@@ -659,7 +659,7 @@ NUM(str: string, ERR?!: lineref): num
 
 The PAD() function pads a specified string.
 @/
-PAD(str: string, len: int, padtype?: int, padchr?: char, ERR?!: lineref): string
+PAD(str: string, len: int, padtype?: string, padchr?: char, ERR?!: lineref): string
 
 /@@
 \`PCK(num1,num2{,ERR=lineref})\`
@@ -732,7 +732,7 @@ RESINFO(handle: res_handle, resource: string, ERR?!: lineref): string
 
 The RESNEXT() function returns a string assigning the next valid resource in the resource file to the template defined by RESFIRST().
 @/
-RESNEXT(handle: res_handle, res_id: int, ERR?!: lineref): string
+RESNEXT(handle: res_handle, res_id: string, ERR?!: lineref): string
 
 /@@
 \`RESOPEN(filename{,ERR=lineref})\`
@@ -894,7 +894,7 @@ TBL(str: string, TBL?!:lineref, ERR?!:lineref): string
 
 The TCB() function returns information on the current state of the application.
 @/
-TCB(funcnum: int, ERR?!:lineref): string
+TCB(funcnum: int, ERR?!:lineref): num
 
 /@@
 \`TIME(str1{,str2}{,str3}{,ERR=lineref})\`
@@ -937,14 +937,14 @@ UPK(str: string, ERR?!:lineref): num
 
 The WINFIRST() function returns a window context ID that can be used by the WININFO() function to obtain information about the referenced window.
 @/
-WINFIRST(sysguichan: sysgui, ERR?!:lineref): int
+WINFIRST(sysguichan: sysgui, ERR?!:lineref): string
 
 /@@
 \`WININFO(sysgui,contextid{,ERR=lineref}{,END=lineref})\`
 
 The WININFO() function returns a string that contains information about the contents of a SYSGUI window.
 @/
-WININFO(sysguichan: sysgui, contextid: int, ERR?!:lineref, END?!:lineref): string
+WININFO(sysguichan: sysgui, contextid: string, ERR?!:lineref, END?!:lineref): string
 
 /@@
 \`WINNEXT(sysgui,context{,ERR=lineref})\`
@@ -952,7 +952,7 @@ WININFO(sysguichan: sysgui, contextid: int, ERR?!:lineref, END?!:lineref): strin
 The WINNEXT() function returns the next context ID of each of the top-level windows in sequence by way of a templated 
 string obtained either from the WINFIRST() function or from a previous use of the WINNEXT() function.
 @/
-WINNEXT(sysguichan: sysgui, context: int, ERR?!:lineref): int
+WINNEXT(sysguichan: sysgui, context: string, ERR?!:lineref): string
 
 /@@
 \`XFID(channelno{,ERR=lineref})\`
@@ -967,7 +967,7 @@ XFID(channelno: int, ERR?!:lineref): string
 
 The XFIN() function returns an 8-byte file length.
 @/
-XFIN(channelno: int, ERR?!:lineref): num
+XFIN(channelno: int, ERR?!:lineref): string
 
 /@@
 \`XKGEN(str1,str2,int{,ERR=lineref})\`

--- a/bbj-vscode/src/language/lib/functions.ts
+++ b/bbj-vscode/src/language/lib/functions.ts
@@ -592,7 +592,7 @@ MOD(numA: num, numB: num, ERR?!: lineref): num
 
 The MSGBOX() function creates a message dialog box and returns a value that identifies the user-selected button.
 @/
-MSGBOX(str1: string, expr?: num, str2?: string, button1?: string, button2?: string, button3?: string, MODE?!: string, TIM?!: int, ERR?!: lineref): string
+MSGBOX(str1: string, expr?: num, str2?: string, button1?: string, button2?: string, button3?: string, MODE?!: string, TIM?!: int, ERR?!: lineref): int
 
 /@@
 \`NEVAL(str{,ERR=lineref})\`
@@ -660,7 +660,7 @@ NUM(str: string, ERR?!: lineref): num
 
 The PAD() function pads a specified string.
 @/
-PAD(str: string, len: int, padtype?: int, padchr?: char, ERR?!: lineref): string
+PAD(str: string, len: int, padtype?: string, padchr?: char, ERR?!: lineref): string
 
 /@@
 \`PCK(num1,num2{,ERR=lineref})\`
@@ -733,7 +733,7 @@ RESINFO(handle: res_handle, resource: string, ERR?!: lineref): string
 
 The RESNEXT() function returns a string assigning the next valid resource in the resource file to the template defined by RESFIRST().
 @/
-RESNEXT(handle: res_handle, res_id: int, ERR?!: lineref): string
+RESNEXT(handle: res_handle, res_id: string, ERR?!: lineref): string
 
 /@@
 \`RESOPEN(filename{,ERR=lineref})\`
@@ -895,7 +895,7 @@ TBL(str: string, TBL?!:lineref, ERR?!:lineref): string
 
 The TCB() function returns information on the current state of the application.
 @/
-TCB(funcnum: int, ERR?!:lineref): string
+TCB(funcnum: int, ERR?!:lineref): num
 
 /@@
 \`TIME(str1{,str2}{,str3}{,ERR=lineref})\`
@@ -938,14 +938,14 @@ UPK(str: string, ERR?!:lineref): num
 
 The WINFIRST() function returns a window context ID that can be used by the WININFO() function to obtain information about the referenced window.
 @/
-WINFIRST(sysguichan: sysgui, ERR?!:lineref): int
+WINFIRST(sysguichan: sysgui, ERR?!:lineref): string
 
 /@@
 \`WININFO(sysgui,contextid{,ERR=lineref}{,END=lineref})\`
 
 The WININFO() function returns a string that contains information about the contents of a SYSGUI window.
 @/
-WININFO(sysguichan: sysgui, contextid: int, ERR?!:lineref, END?!:lineref): string
+WININFO(sysguichan: sysgui, contextid: string, ERR?!:lineref, END?!:lineref): string
 
 /@@
 \`WINNEXT(sysgui,context{,ERR=lineref})\`
@@ -953,7 +953,7 @@ WININFO(sysguichan: sysgui, contextid: int, ERR?!:lineref, END?!:lineref): strin
 The WINNEXT() function returns the next context ID of each of the top-level windows in sequence by way of a templated 
 string obtained either from the WINFIRST() function or from a previous use of the WINNEXT() function.
 @/
-WINNEXT(sysguichan: sysgui, context: int, ERR?!:lineref): int
+WINNEXT(sysguichan: sysgui, context: string, ERR?!:lineref): string
 
 /@@
 \`XFID(channelno{,ERR=lineref})\`
@@ -968,7 +968,7 @@ XFID(channelno: int, ERR?!:lineref): string
 
 The XFIN() function returns an 8-byte file length.
 @/
-XFIN(channelno: int, ERR?!:lineref): num
+XFIN(channelno: int, ERR?!:lineref): string
 
 /@@
 \`XKGEN(str1,str2,int{,ERR=lineref})\`

--- a/bbj-vscode/test/validation-function-calls.test.ts
+++ b/bbj-vscode/test/validation-function-calls.test.ts
@@ -68,6 +68,9 @@ describe('builtin function call validation (#451)', () => {
         'A%=DIR("x")',     // DIR returns string -> numeric A%
         'B$=ABS(2)',       // ABS returns num -> string B$
         'N=DSK("0")',      // DSK returns string -> numeric N
+        'B$=MSGBOX("hi")', // MSGBOX returns numeric (selected-button id) -> string B$
+        'S$=TCB(1)',       // TCB returns numeric -> string S$
+        'N=XFIN(1)',       // XFIN returns string -> numeric N
     ])('flags return/target mismatch: %j', async (code) => {
         expect(await callIssues(code)).not.toEqual([]);
     });
@@ -78,6 +81,9 @@ describe('builtin function call validation (#451)', () => {
         'N%=LEN("hi")',    // int return -> numeric target
         'X!=NULL()',       // object return -> object target (not judged)
         'A=IFF(1,2,3)',    // any return -> not judged
+        'N=MSGBOX("hi")',  // MSGBOX returns numeric (selected-button id) -> numeric N
+        'N=TCB(1)',        // TCB returns numeric -> numeric N
+        'S$=XFIN(1)',      // XFIN returns string -> string S$
     ])('accepts return/target: %j', async (code) => {
         expect(await callIssues(code)).toEqual([]);
     });
@@ -99,6 +105,7 @@ describe('builtin function call validation (#451)', () => {
         's$="x"\n? HTA(s$)',   // string variable -> HTA string parameter
         'n=5\n? ABS(n)',       // numeric variable -> ABS numeric parameter
         '? STR(n)',            // STR objexpr is `any` -> not judged
+        '? PAD("x",5,"C")',    // PAD padtype is the string keyword "L"/"C"/"R"
     ])('accepts inferred argument: %j', async (code) => {
         expect(await callIssues(code)).toEqual([]);
     });


### PR DESCRIPTION
## Summary

Fixes the `MSGBOX()` return-type bug and eight related type defects in the builtin function library, surfaced now that the #451 function-call type warnings are active.

`MSGBOX()` was declared `: string`, but the [docs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/msgbox_function.htm) say it *"returns a value that identifies the user-selected button"* — an integer. As a result `X = MSGBOX(...)` (numeric target) was wrongly warned and `X$ = MSGBOX(...)` wrongly accepted.

While there, I audited **all ~130 builtin functions** against the official [Alphabetical Functions](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/Alphabetical_Functions.htm) docs (see #468 for the full write-up). Nine numeric-vs-string bucket defects were confirmed and corrected.

## Changes

Corrected in both `functions.ts` (runtime source) and its `functions.bbl` mirror, in lockstep:

| Function | Field | Before | After |
|---|---|---|---|
| `MSGBOX` | return | `string` | `int` |
| `TCB` | return | `string` | `num` |
| `XFIN` | return | `num` | `string` |
| `WINFIRST` | return | `int` | `string` |
| `WINNEXT` | return | `int` | `string` |
| `WINNEXT` | `context` param | `int` | `string` |
| `WININFO` | `contextid` param | `int` | `string` |
| `RESNEXT` | `res_id` param | `int` | `string` |
| `PAD` | `padtype` param | `int` | `string` |

Each change is backed by a documentation quote in #468.

## Tests

Added regression cases to `test/validation-function-calls.test.ts`:
- `MSGBOX`/`TCB` numeric return → flags string target, accepts numeric target
- `XFIN` string return → flags numeric target, accepts string target
- `PAD("x",5,"C")` — string `padtype` keyword now accepted

`npx vitest run test/validation-function-calls.test.ts` → **41 passed**. `npm run build` clean. (The 11 pre-existing failures in `test/linking.test.ts` require the java-interop service on :5008 and are unrelated to this change — they fail identically on `main`.)

## Not changed (documented as follow-ups in #468)

Overloaded/ambiguous params that aren't numeric-vs-string bucket bugs: `DSK`/`DIR` `disk` (string|int overload), `DIMS` `arrayname` (array ref), `PCK` `num2` (int vs num), `CVT` `unit_value`, and `FILEOPT` (unverifiable from its doc page).

Fixes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
