### PR TITLE
fix: restore dedicated highlighting for config.bbx / config.min (#381)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,7 @@ jobs:
       shell: bash
       run: |
         cd bbj-vscode
-        npm i -g @vscode/vsce@^2.32
-        vsce package
+        npx vsce package
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4 
       with: 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: documentation/package-lock.json
 

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -26,7 +26,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq
-          npm install -g @vscode/vsce semver
+          npm install -g semver
+          # vsce comes from bbj-vscode devDependencies (npm ci) — `npx vsce` resolves the pinned version
 
       - name: Install dependencies
         working-directory: bbj-vscode

--- a/.github/workflows/pr-vsix.yml
+++ b/.github/workflows/pr-vsix.yml
@@ -54,12 +54,11 @@ jobs:
         id: pkg
         working-directory: bbj-vscode
         run: |
-          npm i -g @vscode/vsce@^2.32
           NAME=$(node -p "require('./package.json').name")
           VERSION=$(node -p "require('./package.json').version")
           SHA=$(git rev-parse --short HEAD)
           OUT="${NAME}-${VERSION}-pr${{ github.event.pull_request.number }}-${SHA}.vsix"
-          vsce package --out "$OUT"
+          npx vsce package --out "$OUT"
           echo "vsix=$OUT" >> "$GITHUB_OUTPUT"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq
-          npm install -g @vscode/vsce
+          # vsce comes from bbj-vscode devDependencies (npm ci) — `npx vsce` resolves the pinned version
 
       - name: Install deps and build
         working-directory: bbj-vscode

--- a/bbj-intellij/src/main/resources/textmate/bbj-bundle/package.json
+++ b/bbj-intellij/src/main/resources/textmate/bbj-bundle/package.json
@@ -6,6 +6,11 @@
         "id": "BBj",
         "extensions": [".bbj", ".bbl", ".bbjt", ".src", ".bbx"],
         "configuration": "./bbj-language-configuration.json"
+      },
+      {
+        "id": "BBx Config",
+        "filenames": ["config.bbx", "Config.bbx", "config.min", "Config.min"],
+        "configuration": "./bbx-language-configuration.json"
       }
     ],
     "grammars": [
@@ -13,6 +18,11 @@
         "language": "BBj",
         "scopeName": "source.bbj",
         "path": "./syntaxes/bbj.tmLanguage.json"
+      },
+      {
+        "language": "BBx Config",
+        "scopeName": "source.bbx",
+        "path": "./syntaxes/bbx.tmLanguage.json"
       }
     ]
   }

--- a/bbj-vscode/package-lock.json
+++ b/bbj-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bbj-lang",
-  "version": "0.8.32",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bbj-lang",
-      "version": "0.8.32",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/vsce": "^3.7.1",

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -601,10 +601,6 @@
       }
     },
     "configurationDefaults": {
-      "files.associations": {
-        "config.bbx": "plaintext",
-        "config.min": "plaintext"
-      },
       "[bbj]": {
         "editor.wordSeparators": "`~^&*()-=+[{]}\\|;:'\",.<>/?"
       }

--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -38,6 +38,24 @@
           "dark": "./images/bbj-file-dark.svg"
         },
         "configuration": "./bbj-language-configuration.json"
+      },
+      {
+        "id": "bbx-config",
+        "aliases": [
+          "BBx Config",
+          "bbx-config"
+        ],
+        "filenames": [
+          "config.bbx",
+          "Config.bbx",
+          "config.min",
+          "Config.min"
+        ],
+        "icon": {
+          "light": "./images/bbj-config-light.svg",
+          "dark": "./images/bbj-config-dark.svg"
+        },
+        "configuration": "./bbx-language-configuration.json"
       }
     ],
     "grammars": [
@@ -45,6 +63,11 @@
         "language": "bbj",
         "scopeName": "source.bbj",
         "path": "./syntaxes/bbj.tmLanguage.json"
+      },
+      {
+        "language": "bbx-config",
+        "scopeName": "source.bbx",
+        "path": "./syntaxes/bbx.tmLanguage.json"
       }
     ],
     "snippets": [

--- a/bbj-vscode/syntaxes/bbx.tmLanguage.json
+++ b/bbj-vscode/syntaxes/bbx.tmLanguage.json
@@ -1,73 +1,179 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "BBx",
+  "name": "BBx Config",
   "scopeName": "source.bbx",
   "patterns": [
     {
-      "include": "#keywords"
+      "include": "#comments"
     },
     {
-      "include": "#comments"
+      "include": "#alias-directive"
+    },
+    {
+      "include": "#setopts-directive"
+    },
+    {
+      "include": "#dsksyn-directive"
+    },
+    {
+      "include": "#use-directive"
+    },
+    {
+      "include": "#directives"
+    },
+    {
+      "include": "#limit-setting"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#option-flags"
+    },
+    {
+      "include": "#option-assignment"
+    },
+    {
+      "include": "#java-class"
     },
     {
       "include": "#numbers"
     },
     {
-      "include": "#strings"
+      "include": "#generic-setting"
     }
   ],
   "repository": {
-    "keywords": {
-      "patterns": [
-        {
-          "name": "keyword.operator.new",
-          "match": "(?i)(?<=\\s|^|=|\\()(new)(?=\\s)"
-        },
-        {
-          "name": "keyword.bbj",
-          "match": "(?i)(?<=\\s|^|,|\\(|\\)|\\+)(set|alias|dsksyn|setopts|prefix)(?=\\(|\\s|$)"
-        }
-      ]
-    },
     "comments": {
       "patterns": [
         {
-          "name": "comment.line.bbj",
-          "match": "(?i)(?<=^|\\s)(#|;)(?=\\s).*"
+          "name": "comment.line.number-sign.bbx",
+          "match": "(?:^|\\s)#.*$"
+        },
+        {
+          "name": "comment.line.semicolon.bbx",
+          "match": "(?:^|\\s);.*$"
+        },
+        {
+          "name": "comment.line.rem.bbx",
+          "match": "(?i)^\\s*REM(\\s.*)?$"
         }
       ]
     },
-    "numbers": {
-      "patterns": [
-        {
-          "match": "(?x)\n\\b(?<!\\$)\n0(x|X)\n(\n  (?<!\\.)[0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?[Ll]?(?!\\.)\n  |\n  (\n    [0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?\\.?\n    |\n    ([0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?)?\\.[0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?\n  )\n  [Pp][+-]?[0-9]([0-9_]*[0-9])?[FfDd]?\n)\n\\b(?!\\$)",
-          "name": "constant.numeric.hex.bbj"
+    "alias-directive": {
+      "comment": "ALIAS <name> <device | java.class.Name> [\"description\"] [options]",
+      "match": "(?i)^\\s*(ALIAS)\\s+(\\S+)(?:\\s+(SYSGUI|SYSWINDOW|SYSPRINT|SYSPLOT|SYSMEM|SYSCLIP|MINI|NIO|TCP|SSL|UDP|COM\\d+|LPT\\d+))?",
+      "captures": {
+        "1": {
+          "name": "keyword.control.directive.alias.bbx"
         },
-        {
-          "match": "\\b(?<!\\$)0(b|B)[01]([01_]*[01])?[Ll]?\\b(?!\\$)",
-          "name": "constant.numeric.binary.bbj"
+        "2": {
+          "name": "entity.name.function.alias.bbx"
         },
-        {
-          "match": "\\b(?<!\\$)0[0-7]([0-7_]*[0-7])?[Ll]?\\b(?!\\$)",
-          "name": "constant.numeric.octal.bbj"
-        },
-        {
-          "match": "(?x)\n(?<!\\$)\n(\n  \\b[0-9]([0-9_]*[0-9])?\\.\\B(?!\\.)\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([Ee][+-]?[0-9]([0-9_]*[0-9])?)[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([0-9]([0-9_]*[0-9])?)([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]?\\b\n  |\n  (?<!\\.)\\B\\.[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]\\b\n  |\n  \\b(0|[1-9]([0-9_]*[0-9])?)(?!\\.)[Ll]?\\b\n)\n(?!\\$)",
-          "name": "constant.numeric.decimal.bbj"
+        "3": {
+          "name": "support.class.device.bbx"
         }
-      ]
+      }
+    },
+    "setopts-directive": {
+      "comment": "SETOPTS <hex byte string>",
+      "match": "(?i)^\\s*(SETOPTS)\\s+([0-9A-Fa-f]+)\\s*$",
+      "captures": {
+        "1": {
+          "name": "keyword.control.directive.bbx"
+        },
+        "2": {
+          "name": "constant.numeric.hex.bbx"
+        }
+      }
+    },
+    "dsksyn-directive": {
+      "comment": "DSKSYN A: — disk drive synonym",
+      "match": "(?i)^\\s*(DSKSYN)\\s+([A-Za-z]:?)",
+      "captures": {
+        "1": {
+          "name": "keyword.control.directive.bbx"
+        },
+        "2": {
+          "name": "constant.other.drive.bbx"
+        }
+      }
+    },
+    "use-directive": {
+      "comment": "USE java.class.Name or USE ::file.bbj::ClassName (BBj 17+)",
+      "match": "(?i)^\\s*(USE)\\s+((?:::[^:]+::\\S+)|\\S+)",
+      "captures": {
+        "1": {
+          "name": "keyword.control.directive.bbx"
+        },
+        "2": {
+          "name": "entity.name.type.class.bbx"
+        }
+      }
+    },
+    "directives": {
+      "comment": "Structured directives at line start",
+      "match": "(?i)^\\s*(ALIAS|PREFIX|DSKSYN|SET|SETOPTS|SETDEV|SETDAY|SETTIME|SETTRACE|USE|KEYMAP|CHARMAP)\\b",
+      "name": "keyword.control.directive.bbx"
+    },
+    "limit-setting": {
+      "comment": "Generic OPTION[=]value limit/function settings at line start, e.g. FCBS=128, PRECISION=2, SQL=/path",
+      "match": "(?i)^\\s*([A-Z][A-Z0-9_]*)\\s*(=)",
+      "captures": {
+        "1": {
+          "name": "keyword.other.setting.bbx"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.bbx"
+        }
+      }
     },
     "strings": {
       "patterns": [
         {
-          "name": "string.quoted.single.bbj",
-          "match": "(?i)'([^'])*'"
+          "name": "string.quoted.double.bbx",
+          "match": "\"[^\"]*\""
         },
         {
-          "name": "string.quoted.double.bbj",
-          "match": "(?i)\\\"([^\"])*\\\""
+          "name": "string.quoted.single.bbx",
+          "match": "'[^']*'"
         }
       ]
+    },
+    "option-flags": {
+      "comment": "Bare option flags in ALIAS/device lines (with optional leading - to negate)",
+      "match": "(?i)(?<=[\\s,])-?(VISIBLE|INVISIBLE|FLOAT|PREVIEW|NODELAY|XON/XOFF|XON|XOFF|DSR|CTS|TERM)\\b",
+      "name": "entity.other.attribute-name.flag.bbx"
+    },
+    "option-assignment": {
+      "comment": "key=value options within a line, e.g. TITLE=, FONT=, ROWS=, BAUD=, MODE=, !COMPAT=",
+      "match": "(?i)(?<=[\\s,])(!?[A-Z_][A-Z0-9_]*)(=)",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name.option.bbx"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.bbx"
+        }
+      }
+    },
+    "java-class": {
+      "comment": "Fully qualified Java class names, e.g. in ALIAS plugin definitions",
+      "match": "\\b(?:[a-z][a-zA-Z0-9_]*\\.){2,}[A-Z][A-Za-z0-9_$]*\\b",
+      "name": "entity.name.type.class.bbx"
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.decimal.bbx",
+          "match": "\\b\\d+\\b"
+        }
+      ]
+    },
+    "generic-setting": {
+      "comment": "Fallback: any OPTION at line start (settings allow the = to be omitted, e.g. PRECISION 2,16)",
+      "match": "(?i)^\\s*([A-Z][A-Z0-9_]*)\\b",
+      "name": "keyword.other.setting.bbx"
     }
   }
 }

--- a/bbj-vscode/test/textmate-bbx-highlighting.test.ts
+++ b/bbj-vscode/test/textmate-bbx-highlighting.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'fs';
+import { beforeAll, describe, expect, test } from 'vitest';
+import * as oniguruma from 'vscode-oniguruma';
+import { INITIAL, IGrammar, Registry, StateStack, parseRawGrammar } from 'vscode-textmate';
+
+/**
+ * TextMate tokenization test for the BBx config grammar (config.bbx / config.min).
+ * Regression for #381: config.bbx must get dedicated config highlighting instead of
+ * being rendered as plain text (or mis-highlighted as BBj source).
+ */
+
+let grammar: IGrammar;
+
+beforeAll(async () => {
+    await oniguruma.loadWASM(readFileSync('node_modules/vscode-oniguruma/release/onig.wasm'));
+    const registry = new Registry({
+        onigLib: Promise.resolve({
+            createOnigScanner: (patterns: string[]) => new oniguruma.OnigScanner(patterns),
+            createOnigString: (s: string) => new oniguruma.OnigString(s),
+        }),
+        loadGrammar: async (scopeName: string) => {
+            if (scopeName === 'source.bbx') {
+                const content = readFileSync('syntaxes/bbx.tmLanguage.json', 'utf8');
+                return parseRawGrammar(content, 'bbx.tmLanguage.json');
+            }
+            return null;
+        },
+    });
+    const loaded = await registry.loadGrammar('source.bbx');
+    if (!loaded) throw new Error('failed to load source.bbx grammar');
+    grammar = loaded;
+});
+
+function tokenize(line: string): Array<{ text: string; scopes: string[] }> {
+    const ruleStack: StateStack = INITIAL;
+    const result = grammar.tokenizeLine(line, ruleStack);
+    return result.tokens.map(t => ({ text: line.substring(t.startIndex, t.endIndex), scopes: t.scopes }));
+}
+
+function scopesOf(line: string, text: string): string[] {
+    const token = tokenize(line).find(t => t.text.trim() === text || t.text.includes(text));
+    expect(token, `token "${text}" present in "${line}"`).toBeDefined();
+    return token!.scopes;
+}
+
+describe('BBx config TextMate highlighting (#381)', () => {
+    test('ALIAS directive: keyword, alias name and device are scoped', () => {
+        const line = 'ALIAS T1 SYSWINDOW "" TITLE="Extra Window"';
+        expect(scopesOf(line, 'ALIAS')).toContain('keyword.control.directive.alias.bbx');
+        expect(scopesOf(line, 'T1')).toContain('entity.name.function.alias.bbx');
+        expect(scopesOf(line, 'SYSWINDOW')).toContain('support.class.device.bbx');
+        expect(scopesOf(line, 'TITLE')).toContain('entity.other.attribute-name.option.bbx');
+        expect(scopesOf(line, 'Extra Window')).toContain('string.quoted.double.bbx');
+    });
+
+    test('ALIAS with Java plugin class is scoped as class name', () => {
+        const line = 'ALIAS J0 com.basis.bbj.bridge.BBjBridgeOpenPlugin';
+        expect(scopesOf(line, 'com.basis.bbj.bridge.BBjBridgeOpenPlugin')).toContain('entity.name.type.class.bbx');
+    });
+
+    test('ALIAS option flags are scoped', () => {
+        const line = 'ALIAS TMINI MINI "BUI Mini Console" INVISIBLE,FLOAT,ROWS=24,COLS=80';
+        expect(scopesOf(line, 'INVISIBLE')).toContain('entity.other.attribute-name.flag.bbx');
+        expect(scopesOf(line, 'FLOAT')).toContain('entity.other.attribute-name.flag.bbx');
+        expect(scopesOf(line, 'ROWS')).toContain('entity.other.attribute-name.option.bbx');
+        expect(scopesOf(line, '24')).toContain('constant.numeric.decimal.bbx');
+    });
+
+    test('PREFIX directive with quoted directories', () => {
+        const line = 'PREFIX "/usr/basis/bbj/utils/" "/usr/basis/bbj/plugins/"';
+        expect(scopesOf(line, 'PREFIX')).toContain('keyword.control.directive.bbx');
+        expect(scopesOf(line, '/usr/basis/bbj/utils/')).toContain('string.quoted.double.bbx');
+    });
+
+    test('SETOPTS hex value is numeric', () => {
+        const line = 'SETOPTS 08004020000000';
+        expect(scopesOf(line, 'SETOPTS')).toContain('keyword.control.directive.bbx');
+        expect(scopesOf(line, '08004020000000')).toContain('constant.numeric.hex.bbx');
+    });
+
+    test('DSKSYN directive', () => {
+        const line = 'DSKSYN A:';
+        expect(scopesOf(line, 'DSKSYN')).toContain('keyword.control.directive.bbx');
+        expect(scopesOf(line, 'A:')).toContain('constant.other.drive.bbx');
+    });
+
+    test('limit settings (KEY=value) are scoped', () => {
+        expect(scopesOf('FCBS=128', 'FCBS')).toContain('keyword.other.setting.bbx');
+        expect(scopesOf('FCBS=128', '128')).toContain('constant.numeric.decimal.bbx');
+        expect(scopesOf('SQL=/usr/basis/bbj/cfg/sql.ini', 'SQL')).toContain('keyword.other.setting.bbx');
+    });
+
+    test('settings with omitted = still highlight the option name', () => {
+        expect(scopesOf('PRECISION 2,16', 'PRECISION')).toContain('keyword.other.setting.bbx');
+    });
+
+    test('SET directive with !COMPAT option', () => {
+        const line = 'SET !COMPAT=LISTBUTTON_DESELECT=TRUE';
+        expect(scopesOf(line, 'SET')).toContain('keyword.control.directive.bbx');
+        expect(scopesOf(line, '!COMPAT')).toContain('entity.other.attribute-name.option.bbx');
+    });
+
+    test('comment lines are comment-scoped', () => {
+        const line = '# For BUI debugging, change the INVISIBLE mode to VISIBLE';
+        const tokens = tokenize(line);
+        expect(tokens.every(t => t.scopes.includes('comment.line.number-sign.bbx'))).toBe(true);
+    });
+
+    test('every line of examples/config.bbx and examples/config.min tokenizes without dropping to plain text on directive lines', () => {
+        for (const file of ['../examples/config.bbx', '../examples/config.min']) {
+            const lines = readFileSync(file, 'utf8').split('\n').filter(l => l.trim().length > 0);
+            for (const line of lines) {
+                const tokens = tokenize(line);
+                // The first non-whitespace token of each directive line must carry
+                // some scope beyond the base source.bbx scope.
+                const first = tokens.find(t => t.text.trim().length > 0);
+                expect(first, `tokens for "${line}"`).toBeDefined();
+                expect(first!.scopes.length, `"${line.substring(0, 40)}..." first token should be scoped (got only ${first!.scopes.join(', ')})`).toBeGreaterThan(1);
+            }
+        }
+    });
+});

--- a/documentation/docs/vscode/features.md
+++ b/documentation/docs/vscode/features.md
@@ -141,7 +141,8 @@ The extension supports multiple BBj file types:
 | `.bbj` | BBj source files |
 | `.bbjt` | BBj template files |
 | `.src` | BBj source files (legacy) |
-| `.bbx` | BBx configuration files |
+| `.bbx` | BBx program files |
+| `config.bbx`, `config.min` | BBj/BBx configuration files (dedicated config syntax highlighting) |
 
 > **Note:** `.bbl` (BBj library) files are not supported by the extension. They are excluded from workspace indexing and do not receive language features.
 

--- a/examples/config.min
+++ b/examples/config.min
@@ -1,0 +1,11 @@
+# Minimal BBj configuration (config.min) — same syntax as config.bbx
+ALIASES=15
+FCBS=128
+CIBS=128
+STBLEN=4096
+SETOPTS 08004020000000
+ALIAS X0 SYSGUI
+ALIAS T0 SYSWINDOW
+ALIAS LP SYSPRINT "" FONT="Courier",COLS=80,ROWS=62
+ALIAS N0 TCP "" NODELAY
+PREFIX "/usr/basis/bbj/utils/"


### PR DESCRIPTION
Fixes #381 — Phase 1 of the plan in https://github.com/BBx-Kitchen/bbj-language-server/issues/381#issuecomment-5012561684.

## Root cause

185e9b0 merged `.bbx` into the BBj language so `.bbx` *program* files get full language support, but as a side effect `config.bbx` lost its dedicated config highlighting (rendered as plain text) and was sent to the Langium BBj parser, producing spurious diagnostics.

## What this PR does

- **Re-adds a config language** (id `bbx-config`) in the VS Code extension, registered by exact **filenames** — `config.bbx`, `Config.bbx`, `config.min`, `Config.min` — instead of the `.bbx` extension. Filename matches take precedence over extension matches, so config files get config highlighting while all other `.bbx` files keep full BBj language support (the intent of 185e9b0 is preserved). BBj ships both `cfg/config.bbx` and `cfg/config.min` with the same syntax, so both are covered.
- **Keeps the LS away from config files**: `bbx-config` is deliberately not in the language client's `documentSelector`, so the Langium BBj parser no longer produces bogus diagnostics on them.
- **Rewrites `syntaxes/bbx.tmLanguage.json`** against the BASIS docs ([config.bbx – BBj](https://documentation.basis.cloud/BASISHelp/WebHelp/sysadmin/config/the_config_bbx_configuration_file_bbj_spec.htm)): `ALIAS` lines (alias name, device types `SYSGUI`/`SYSWINDOW`/`SYSPRINT`/`TCP`/`SSL`/`MINI`/…, option flags `INVISIBLE`/`FLOAT`/`NODELAY`/…, `key=value` options incl. `!COMPAT`), `PREFIX`, `DSKSYN`, `SETOPTS` hex, `USE` (incl. `::file::Class`), `KEY=value` limit settings (with optional `=`, e.g. `PRECISION 2,16`), Java plugin class names, strings, `#`/`;` comments.
- **IntelliJ**: registers the `BBx Config` language in the TextMate bundle by the same filenames; the grammar files are already copied from `bbj-vscode` at build time, so both IDEs share one grammar.
- **Test**: new `test/textmate-bbx-highlighting.test.ts` (mirrors the #107 TextMate test) with 11 cases covering directive lines plus every line of `examples/config.bbx` and the new `examples/config.min` fixture — no directive line may fall through as plain text.
- **Docs**: `features.md` file-type table now distinguishes `.bbx` program files from `config.bbx`/`config.min`.

## Verification

- New grammar test: 11/11 pass; existing BBj TextMate test still passes; ESLint clean; `npm run build` succeeds.
- The 11 failures in `test/linking.test.ts` are pre-existing on `main` (they require the java-interop service on :5008) — verified via stash.
- ⚠️ IntelliJ caveat: the native `BbjFileType` claims the `bbx` extension; exact-filename TextMate associations should take priority, but this needs a manual check in a running IDE.

## Out of scope (tracked in the issue plan)

- Phase 2: Langium grammar for validation/completion/hover in the existing server.
- Phase 3: user-registered custom config filenames via setting + dedicated view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)