### PR TITLE
Visual SETOPTS composer for the bbx-config editor (#474)

### DIFF
--- a/bbj-vscode/package.json
+++ b/bbj-vscode/package.json
@@ -190,6 +190,11 @@
         "category": "BBj",
         "command": "bbj.composeAddChildWindow",
         "title": "Compose addChildWindow (visual)…"
+      },
+      {
+        "category": "BBj",
+        "command": "bbj.composeConfigSetopts",
+        "title": "Compose config.bbx SETOPTS (visual)…"
       }
     ],
     "keybindings": [
@@ -259,6 +264,11 @@
         {
           "command": "bbj.composeAddChildWindow",
           "when": "editorLangId == bbj",
+          "group": "1_modification"
+        },
+        {
+          "command": "bbj.composeConfigSetopts",
+          "when": "editorLangId == bbx-config",
           "group": "1_modification"
         }
       ],
@@ -634,7 +644,9 @@
     "onCommand:bbj.composeMsgbox",
     "onCommand:bbj.composeMsgboxVisual",
     "onCommand:bbj.composeAddWindow",
-    "onCommand:bbj.composeAddChildWindow"
+    "onCommand:bbj.composeAddChildWindow",
+    "onCommand:bbj.composeConfigSetopts",
+    "onLanguage:bbx-config"
   ],
   "main": "./out/extension.cjs",
   "scripts": {

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -18,6 +18,7 @@ import { isLineNumberedSource } from './line-numbering.js';
 import { registerMsgboxComposer } from './msgbox-composer-ui.js';
 import { registerAddWindowComposer } from './addwindow-composer-ui.js';
 import { registerAddChildWindowComposer } from './addchildwindow-composer-ui.js';
+import { registerSetOptsComposer } from './setopts-composer-ui.js';
 import {
     OPTION_GROUP_ORDER,
     getOptionsGrouped,
@@ -583,6 +584,7 @@ export function activate(context: vscode.ExtensionContext): void {
     registerMsgboxComposer(context); // spike: visual MSGBOX composer (#426)
     registerAddWindowComposer(context); // spike: visual addWindow flags/event-mask composer (#430)
     registerAddChildWindowComposer(context); // visual addChildWindow flags/event-mask composer (#473)
+    registerSetOptsComposer(context); // visual SETOPTS composer for config.bbx (#474)
     secretStorage = context.secrets;
     client = startLanguageClient(context);
     outputChannel = client.outputChannel;

--- a/bbj-vscode/src/setopts-catalog.ts
+++ b/bbj-vscode/src/setopts-catalog.ts
@@ -1,0 +1,335 @@
+/**
+ * Editor-agnostic catalog + vector logic for the config.bbx SETOPTS composer (#474).
+ *
+ * A `SETOPTS` line in config.bbx is a bare hex string — `SETOPTS 08004020000000` — encoding up
+ * to 16 bytes of independent bit options (see
+ * https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setopts_verb.htm and the
+ * BBj-specific notes in
+ * https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/setopts_verb_bbj.htm).
+ * Unlike the SETOPTS verb in BBj code, the config.bbx string is absolute and stateless — no OPTS
+ * query, no IOR/AND — so a composer can round-trip it losslessly: parse to bytes, flip individual
+ * bits, re-emit. Bytes 5–6 are data (mask replacement characters), bytes 10–16 are reserved /
+ * application use and pass through as raw hex.
+ *
+ * This module owns the byte/bit catalog and the vector <-> hex <-> line conversions with NO
+ * `vscode` dependency, so it is unit-testable and reusable by the IntelliJ client and by the
+ * BBj-code SETOPTS composer (#475) later.
+ */
+
+export interface SetOptsBit {
+    /** 1-based option byte this bit lives in (1–4, 7–9). */
+    byte: number;
+    /** The single bit within the byte, e.g. 0x80. */
+    mask: number;
+    label: string;
+    detail?: string;
+    /** 'ignored' = PRO/5-only, has no effect in BBj. 'bbj-specific' = meaningless in PRO/5. */
+    bbj?: 'ignored' | 'bbj-specific';
+    /** Why the bit is ignored in BBj / what BBj does differently. */
+    bbjDetail?: string;
+    /** Version gate, e.g. 'BBj 15.00+'. */
+    since?: string;
+}
+
+/** UI group heading per option byte (bytes 5–6 and 10–16 are handled as data, not flags). */
+export const BYTE_GROUPS: Record<number, string> = {
+    1: 'Errors, console & listing',
+    2: 'Printing & numeric behavior',
+    3: 'Program loading & file locking',
+    4: 'File access & number formatting',
+    7: 'Large files, licensing & GUI',
+    8: 'Compatibility',
+    9: 'Input & parsing restrictions',
+};
+
+/** Byte 5 replaces ',' and byte 6 replaces '.' in masks — only when byte 3 $02$ is set. */
+export const MASK_COMMA_BYTE = 5;
+export const MASK_DOT_BYTE = 6;
+/** The bit that enables the byte 5/6 mask replacement characters. */
+export const MASK_REPLACEMENT_BIT = { byte: 3, mask: 0x02 } as const;
+/** Bytes 10–16 are reserved / application use — the composer passes them through as raw hex. */
+export const FIRST_RAW_BYTE = 10;
+export const MAX_BYTES = 16;
+
+/**
+ * The documented option bits, in byte/descending-bit order. PRO/5 wording condensed; `bbj`
+ * annotates the delta from the BBj-specific SETOPTS page so the UI can de-emphasize no-ops.
+ */
+export const SETOPTS_BITS: SetOptsBit[] = [
+    // Byte 1 — errors, console & listing
+    { byte: 1, mask: 0x80, label: 'Error 63 on unassigned variables', detail: 'Issue !ERROR=63 when a variable is referenced before being assigned a value.' },
+    { byte: 1, mask: 0x40, label: 'Disable all error traps', detail: 'Turns off all error traps; useful when debugging an application.' },
+    { byte: 1, mask: 0x20, label: 'Insert mode for EDIT/INPUTE', detail: 'Places EDIT windows and INPUTE fields in insert mode (toggles with CTL-T).' },
+    { byte: 1, mask: 0x10, label: 'No pause in LIST/DUMP', detail: 'Disables the "pause" feature of LIST and DUMP.' },
+    { byte: 1, mask: 0x08, label: 'Console mode in public programs', detail: 'Enables console mode and debugging in public programs.' },
+    { byte: 1, mask: 0x04, label: 'Old SAVEP algorithm', detail: 'Use the pre-2.20 PRO/5 SAVEP algorithm.', bbj: 'ignored' },
+    { byte: 1, mask: 0x02, label: 'List variables in lowercase', detail: 'Show variable names in lowercase in LIST/LST() output.', bbj: 'ignored' },
+    { byte: 1, mask: 0x01, label: 'List keywords in lowercase', detail: 'Show commands and keywords in lowercase in LIST/LST() output.', bbj: 'ignored' },
+    // Byte 2 — printing & numeric behavior
+    { byte: 2, mask: 0x80, label: 'Nondestructive @(x) cursor advance', detail: 'Nondestructive cursor advance for the @(X) column positioning mnemonic.' },
+    { byte: 2, mask: 0x40, label: 'Linefeed on PRINT without IOLIST', bbj: 'ignored', bbjDetail: 'BBj always outputs a linefeed on a PRINT statement that has no IOLIST.' },
+    { byte: 2, mask: 0x20, label: 'Round intermediate math results', detail: 'Numerically round intermediate results after multiplication, division and exponentiation (may reduce performance).' },
+    { byte: 2, mask: 0x10, label: 'NUM() strips embedded spaces', detail: 'Strip embedded spaces from the string argument to NUM().' },
+    { byte: 2, mask: 0x08, label: 'Ignore mask overflow', detail: 'Ignore mask overflows in PRINT, WRITE and STR() instead of issuing !ERROR=43.' },
+    { byte: 2, mask: 0x04, label: 'Reject keyless WRITEs', detail: 'Reject WRITEs to a DIRECT/MKEYED file or unextracted record when no key is specified.' },
+    { byte: 2, mask: 0x02, label: 'Disable math coprocessor', detail: 'Skip the math coprocessor for SIN(), COS(), ATN(), SQR(), LOG() and exponentiation.', bbj: 'ignored' },
+    { byte: 2, mask: 0x01, label: 'Update MS-DOS file length per write', detail: 'Force MS-DOS to update dynamic file length after each addition (reduces write performance).', bbj: 'ignored' },
+    // Byte 3 — program loading & file locking
+    { byte: 3, mask: 0x80, label: 'RUN/LOAD from public program space', bbj: 'ignored', bbjDetail: 'BBj automatically loads and runs programs from the program cache.' },
+    { byte: 3, mask: 0x40, label: 'Advisory locking in data files', detail: 'EXTRACT blocks EXTRACT/REMOVE while READ can still access extracted data.' },
+    { byte: 3, mask: 0x20, label: 'Multiple readers on key region', detail: 'Allow multiple read processes on the key region of a keyed file while blocking writers.', bbj: 'ignored' },
+    { byte: 3, mask: 0x10, label: 'WRITE through EXTRACT', detail: 'Allow WRITE on extracted records; requires advisory locking (byte 3 $40$).' },
+    { byte: 3, mask: 0x08, label: 'Skip program hash check on load', detail: 'Disable the corruption hash check of a program upon loading.' },
+    { byte: 3, mask: 0x04, label: 'Block files with nonzero access count', detail: 'Refuse to access files whose header access count is nonzero (post-crash utility use).', bbj: 'ignored' },
+    { byte: 3, mask: 0x02, label: 'Enable mask replacement characters', detail: 'Replace the "," and "." mask characters with the characters in bytes 5 and 6 (also affects CVS()).' },
+    { byte: 3, mask: 0x01, label: 'Novell network flag', detail: 'Set by PRO/5 itself when running under MS-DOS on a Novell network.', bbj: 'ignored' },
+    // Byte 4 — file access & number formatting
+    { byte: 4, mask: 0x80, label: 'Limit OPEN file search', detail: 'Scan the PREFIX list only once and search the current disk only.' },
+    { byte: 4, mask: 0x40, label: 'Network lock bit', detail: 'Slower locking scheme so non-PRO/5 processes can access files across the network.' },
+    { byte: 4, mask: 0x20, label: 'Enable Data Server access', detail: 'Allow access to the PRO/5 Data Server software.' },
+    { byte: 4, mask: 0x10, label: 'Recognize C-ISAM files', bbj: 'ignored', bbjDetail: 'BBj does not support C-ISAM files.' },
+    { byte: 4, mask: 0x08, label: '14-digit business math', detail: 'Force templates and keys to 14-digit precision for earlier-version compatibility.', bbj: 'ignored', bbjDetail: 'Business math fields always use 16-digit precision in BBj.' },
+    { byte: 4, mask: 0x04, label: 'STR() fills trailing # with zeros', detail: 'Fill trailing "#" mask positions with zeros instead of spaces in STR().' },
+    { byte: 4, mask: 0x02, label: 'Adjust leading spaces in EP mode', detail: 'Adjust the number of leading spaces for lines printed in expanded ("EP") mode.' },
+    { byte: 4, mask: 0x01, label: 'Leading zero in E notation', detail: 'Express E-notation numbers with a leading zero, e.g. "0.1E+01" instead of ".1E+01".' },
+    // Byte 7 — large files, licensing & GUI
+    { byte: 7, mask: 0x80, label: 'Check filesystem for large files', detail: 'Check whether the filesystem supports 4GB (PRO/5 2.x) or 64-bit (3.x+) files.' },
+    { byte: 7, mask: 0x20, label: 'Recoverable MKEYED files', detail: 'Format MKEYED files for corruption recovery.', bbjDetail: 'BBj also formats XKEYED files for corruption recovery.' },
+    { byte: 7, mask: 0x10, label: 'Exit instead of license nag mode', detail: 'Disable "nag" messages and exit when a license cannot be obtained.' },
+    { byte: 7, mask: 0x08, label: 'Visual PRO/5 2.0x grid controls', detail: 'Run 2.0x-style Grid controls under 2.10+; affects RESOURCE, GRID, FONT and control sizing.' },
+    { byte: 7, mask: 0x04, label: 'SYSGUI defaults to system font', detail: 'Use the system font as SYSGUI default (cannot be changed with a SYSGUI device open).' },
+    { byte: 7, mask: 0x02, label: 'Keep SYSGUI channels across BEGIN', detail: 'Do not close SYSGUI channels during a BEGIN statement.' },
+    { byte: 7, mask: 0x01, label: 'Allow same file via different paths', detail: 'No !ERROR=0 on duplicate opens through different paths; enables "./" prefix support.' },
+    // Byte 8 — compatibility
+    { byte: 8, mask: 0x80, label: 'FID() reports MKEYED as type $06$', detail: 'Recoverable/64-bit MKEYED files report as standard MKEYED (PRO/5 2.23+).' },
+    { byte: 8, mask: 0x40, label: 'MKEYED verb creates XKEYED files', bbj: 'bbj-specific' },
+    { byte: 8, mask: 0x20, label: 'FID() returns name as OPENed', detail: 'PRO/5 FID() backward compatibility: return the filename as specified in OPEN.', bbj: 'bbj-specific' },
+    { byte: 8, mask: 0x10, label: 'Grid backward compatibility', detail: 'Grids run with Visual PRO/5 behavior.', bbj: 'bbj-specific' },
+    { byte: 8, mask: 0x08, label: 'Client-side ENV()/INFO()/SCALL()', detail: 'ENV(), INFO(4,*) and SCALL() reference the client; TIM, JUL() and DATE() use client-side values in BBj 12.00+.', bbj: 'bbj-specific', since: 'BBj 4.00+' },
+    { byte: 8, mask: 0x04, label: 'Allow duplicate template field names', bbj: 'bbj-specific', since: 'BBj 4.01+' },
+    { byte: 8, mask: 0x02, label: 'CTL unaffected by data-file reads', detail: 'CTL is only affected by reads from interactive devices, not data files.' },
+    // Byte 9 — input & parsing restrictions
+    { byte: 9, mask: 0x80, label: 'Reject unsigned exponents', detail: 'NUM(), INPUT and READ reject scientific notation whose exponent has no explicit sign.', since: 'PRO/5 6.30+, BBj 7.0+' },
+    { byte: 9, mask: 0x40, label: 'Zero-pad N template fields', detail: 'Assignments to fixed-length type N template fields are padded with leading zeroes.', since: 'PRO/5 14.0+, BBj 15.0+' },
+    { byte: 9, mask: 0x20, label: 'READ RECORD on STRING files without SIZ=', detail: 'Also treats $0D0A$ as a single separator.', bbj: 'bbj-specific', since: 'BBj 15.00+' },
+    { byte: 9, mask: 0x10, label: 'Restrict console-mode OPEN of pipes', detail: 'The OPEN verb refuses commands starting with "<", ">" or "|" in console mode.', since: 'PRO/5 15.01+, BBj 15.10+' },
+];
+
+// ---------------------------------------------------------------------------------------------
+// The options vector
+// ---------------------------------------------------------------------------------------------
+
+export interface SetOptsVector {
+    /** Byte values (0–255); index 0 is option byte 1. */
+    bytes: number[];
+    /**
+     * Number of hex digits in the source string, so encoding reproduces the exact original length
+     * (config.bbx strings vary — the stock config ships 14 digits, docs examples use 4).
+     * An odd count means the last byte is a high-nibble-only partial.
+     */
+    digitCount: number;
+}
+
+/** Parse a bare hex digit string (as found after the SETOPTS keyword). Undefined when invalid. */
+export function parseVector(hexDigits: string): SetOptsVector | undefined {
+    if (!/^[0-9A-Fa-f]+$/.test(hexDigits) || hexDigits.length > MAX_BYTES * 2) return undefined;
+    const padded = hexDigits.length % 2 === 0 ? hexDigits : hexDigits + '0';
+    const bytes: number[] = [];
+    for (let i = 0; i < padded.length; i += 2) {
+        bytes.push(parseInt(padded.slice(i, i + 2), 16));
+    }
+    return { bytes, digitCount: hexDigits.length };
+}
+
+/** Re-emit the vector as an uppercase hex string of exactly `digitCount` digits. */
+export function encodeVector(v: SetOptsVector): string {
+    return v.bytes.map(b => b.toString(16).toUpperCase().padStart(2, '0')).join('').slice(0, v.digitCount);
+}
+
+export function cloneVector(v: SetOptsVector): SetOptsVector {
+    return { bytes: [...v.bytes], digitCount: v.digitCount };
+}
+
+/** A fresh all-defaults vector for composing a new SETOPTS line (grows on demand). */
+export function emptyVector(): SetOptsVector {
+    return { bytes: [0, 0, 0, 0], digitCount: 8 };
+}
+
+/** Grow the vector (zero-filled) until `byteNo` exists. Never shrinks. */
+export function growTo(v: SetOptsVector, byteNo: number): void {
+    while (v.bytes.length < byteNo) v.bytes.push(0);
+    v.digitCount = Math.max(v.digitCount, byteNo * 2);
+}
+
+export function getBit(v: SetOptsVector, byteNo: number, mask: number): boolean {
+    return byteNo <= v.bytes.length && (v.bytes[byteNo - 1] & mask) !== 0;
+}
+
+/** Set/clear one bit. Setting grows the vector as needed; clearing a byte that isn't there is a no-op. */
+export function setBit(v: SetOptsVector, byteNo: number, mask: number, on: boolean): void {
+    if (on) {
+        growTo(v, byteNo);
+        v.bytes[byteNo - 1] |= mask;
+    } else if (byteNo <= v.bytes.length) {
+        v.bytes[byteNo - 1] &= ~mask;
+    }
+}
+
+/** OR of the catalog bits modeled for `byteNo` — everything else is preserved verbatim. */
+export function knownByteMask(byteNo: number): number {
+    return SETOPTS_BITS.filter(b => b.byte === byteNo).reduce((m, b) => m | b.mask, 0);
+}
+
+/** Bits set in option byte `byteNo` that no catalog entry models. */
+export function unknownBitsInByte(v: SetOptsVector, byteNo: number): number {
+    if (byteNo > v.bytes.length) return 0;
+    return v.bytes[byteNo - 1] & ~knownByteMask(byteNo);
+}
+
+export function maskReplacementEnabled(v: SetOptsVector): boolean {
+    return getBit(v, MASK_REPLACEMENT_BIT.byte, MASK_REPLACEMENT_BIT.mask);
+}
+
+/** The mask replacement character stored in byte 5 or 6, as a printable char ('' when 0/unprintable). */
+export function maskChar(v: SetOptsVector, byteNo: number): string {
+    const code = byteNo <= v.bytes.length ? v.bytes[byteNo - 1] : 0;
+    return code >= 0x20 && code <= 0x7e ? String.fromCharCode(code) : '';
+}
+
+/** Store a mask replacement character ('' clears the byte back to 0 = no replacement). */
+export function setMaskChar(v: SetOptsVector, byteNo: number, ch: string): void {
+    const code = ch ? ch.charCodeAt(0) & 0xff : 0;
+    if (code === 0 && byteNo > v.bytes.length) return; // nothing to clear, don't grow
+    growTo(v, byteNo);
+    v.bytes[byteNo - 1] = code;
+}
+
+/** The raw hex digits for bytes 10–16 (empty when the vector ends before byte 10). */
+export function rawTail(v: SetOptsVector): string {
+    return encodeVector(v).slice((FIRST_RAW_BYTE - 1) * 2);
+}
+
+/** Replace bytes 10–16 from raw hex digits; '' truncates the vector back to bytes 1–9. */
+export function setRawTail(v: SetOptsVector, hexDigits: string): void {
+    const headLen = (FIRST_RAW_BYTE - 1) * 2;
+    const head = encodeVector(v).slice(0, headLen);
+    const digits = hexDigits === '' ? head : head.padEnd(headLen, '0') + hexDigits;
+    const parsed = parseVector(digits);
+    if (!parsed) return;
+    v.bytes = parsed.bytes;
+    v.digitCount = parsed.digitCount;
+}
+
+/** Human-readable summary of everything the vector sets (or '(default settings)'). */
+export function describeVector(v: SetOptsVector): string {
+    const parts: string[] = [];
+    for (const byteNo of Object.keys(BYTE_GROUPS).map(Number)) {
+        const labels = SETOPTS_BITS.filter(b => b.byte === byteNo && getBit(v, byteNo, b.mask)).map(b => b.label);
+        const unknown = unknownBitsInByte(v, byteNo);
+        if (unknown !== 0) labels.push(`unknown bit(s) $${unknown.toString(16).toUpperCase().padStart(2, '0')}$`);
+        if (labels.length) parts.push(`Byte ${byteNo}: ${labels.join(' · ')}`);
+    }
+    if (maskReplacementEnabled(v)) {
+        const comma = maskChar(v, MASK_COMMA_BYTE), dot = maskChar(v, MASK_DOT_BYTE);
+        parts.push(`Mask chars: "," → "${comma || '(none)'}", "." → "${dot || '(none)'}"`);
+    }
+    const tail = rawTail(v);
+    if (/[^0]/.test(tail)) parts.push(`Bytes ${FIRST_RAW_BYTE}+: ${tail}`);
+    return parts.length ? parts.join('; ') : '(default settings)';
+}
+
+// ---------------------------------------------------------------------------------------------
+// config.bbx line parsing / composition
+// ---------------------------------------------------------------------------------------------
+
+export interface SetOptsLineInfo {
+    /** [start, end) of the hex token within the line, when the line carries one. */
+    hexRange?: [number, number];
+    hexDigits?: string;
+    /** The parsed vector, when the hex token is valid. */
+    vector?: SetOptsVector;
+    /** Where to insert ` <hex>` when the line is a bare `SETOPTS` with no digits yet. */
+    insertOffset?: number;
+}
+
+/**
+ * Recognize a config.bbx `SETOPTS hexstring` line (keyword case-insensitive, the docs' stated
+ * syntax). Lines with trailing junk or a malformed token return undefined — the composer must
+ * not touch what it cannot round-trip.
+ */
+export function parseSetOptsLine(line: string): SetOptsLineInfo | undefined {
+    const kw = /^\s*SETOPTS(?=\s|$)/i.exec(line);
+    if (!kw) return undefined;
+    const rest = line.slice(kw[0].length);
+    if (/^\s*$/.test(rest)) {
+        return { insertOffset: kw[0].length };
+    }
+    const tok = /^[ \t]+([^ \t]+)[ \t]*$/.exec(rest);
+    if (!tok) return undefined;
+    const start = kw[0].length + tok[0].indexOf(tok[1]);
+    const vector = parseVector(tok[1]);
+    if (!vector) return undefined;
+    return { hexRange: [start, start + tok[1].length], hexDigits: tok[1], vector };
+}
+
+/** Compose a full config.bbx line for the vector. */
+export function composeSetOptsLine(v: SetOptsVector): string {
+    return `SETOPTS ${encodeVector(v)}`;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Preview — the single entry point every UI uses
+// ---------------------------------------------------------------------------------------------
+
+/** Flat UI selection: checked catalog bits + the data-byte fields. */
+export interface SetOptsSelection {
+    /** Catalog bits currently checked ("byte:mask" would also do, but structured is clearer). */
+    bits: Array<{ byte: number; mask: number }>;
+    /** Mask replacement chars for bytes 5/6 (only applied while byte 3 $02$ is checked). */
+    maskComma: string;
+    maskDot: string;
+    /** Raw hex digits for bytes 10–16, verbatim. */
+    rawTail: string;
+}
+
+export interface SetOptsPreview {
+    hexDigits: string;
+    line: string;
+    summary: string;
+    /** Whether the byte 5/6 char inputs are meaningful for this selection. */
+    maskInputsEnabled: boolean;
+    /** Non-catalog bits present per byte, so the UI can flag what it preserves. */
+    unknownByBytes: Array<{ byte: number; mask: number }>;
+}
+
+/**
+ * Apply a UI selection on top of the original vector and compute the resulting line. Starting
+ * from the original (not from zero) is what makes the round-trip lossless: unknown bits and
+ * the original digit count survive untouched unless the user explicitly changes their byte.
+ */
+export function setoptsPreview(original: SetOptsVector | undefined, sel: SetOptsSelection): SetOptsPreview {
+    const v = original ? cloneVector(original) : emptyVector();
+    for (const bit of SETOPTS_BITS) {
+        const on = sel.bits.some(b => b.byte === bit.byte && b.mask === bit.mask);
+        setBit(v, bit.byte, bit.mask, on);
+    }
+    const maskEnabled = maskReplacementEnabled(v);
+    if (maskEnabled) {
+        // Only write a char that differs from what the UI displays: an unprintable byte 5/6 value
+        // renders as '' and must survive an untouched '' input (round-trip safety).
+        if (sel.maskComma !== maskChar(v, MASK_COMMA_BYTE)) setMaskChar(v, MASK_COMMA_BYTE, sel.maskComma);
+        if (sel.maskDot !== maskChar(v, MASK_DOT_BYTE)) setMaskChar(v, MASK_DOT_BYTE, sel.maskDot);
+    }
+    if (/^[0-9A-Fa-f]*$/.test(sel.rawTail) && sel.rawTail !== rawTail(v)) {
+        setRawTail(v, sel.rawTail);
+    }
+    return {
+        hexDigits: encodeVector(v),
+        line: composeSetOptsLine(v),
+        summary: describeVector(v),
+        maskInputsEnabled: maskEnabled,
+        unknownByBytes: Object.keys(BYTE_GROUPS).map(Number)
+            .map(byte => ({ byte, mask: unknownBitsInByte(v, byte) }))
+            .filter(u => u.mask !== 0),
+    };
+}

--- a/bbj-vscode/src/setopts-composer-ui.ts
+++ b/bbj-vscode/src/setopts-composer-ui.ts
@@ -1,0 +1,96 @@
+/**
+ * VS Code UI for the config.bbx SETOPTS composer (#474).
+ *
+ * Thin client layer over the editor-agnostic ./setopts-catalog module. Three entry points, all
+ * scoped to the `bbx-config` language (config.bbx / config.min files):
+ *   - CodeLens on every `SETOPTS <hex>` line -> open the composer on that line's vector.
+ *   - RefactorRewrite Code Action on a SETOPTS line -> same.
+ *   - Command "bbj.composeConfigSetopts" -> edit the file's existing SETOPTS line, or compose a
+ *     NEW one at the cursor when the file has none.
+ */
+import * as vscode from 'vscode';
+import { describeVector, parseSetOptsLine, SetOptsLineInfo } from './setopts-catalog.js';
+import { openSetOptsComposerPanel, SetOptsPanelArg } from './setopts-composer-webview.js';
+
+const BBX_CONFIG = { language: 'bbx-config' } as const;
+
+export function registerSetOptsComposer(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('bbj.composeConfigSetopts', (arg?: SetOptsPanelArg) => {
+            const resolved = arg ?? argForActiveEditor();
+            if (resolved) openSetOptsComposerPanel(context, resolved);
+        }),
+        vscode.languages.registerCodeActionsProvider(
+            BBX_CONFIG,
+            new SetOptsCodeActionProvider(),
+            { providedCodeActionKinds: [vscode.CodeActionKind.RefactorRewrite] },
+        ),
+        vscode.languages.registerCodeLensProvider(BBX_CONFIG, new SetOptsCodeLensProvider()),
+    );
+}
+
+/** The panel arg for a recognized SETOPTS line — shared by the lens, the action and the command. */
+function argForLine(document: vscode.TextDocument, line: number, info: SetOptsLineInfo): SetOptsPanelArg {
+    return {
+        target: {
+            uri: document.uri.toString(),
+            line,
+            hexRange: info.hexRange,
+            insertOffset: info.insertOffset,
+            originalHex: info.hexDigits,
+        },
+    };
+}
+
+/** Lens/action label: the vector's human summary, ellipsized to fit a one-line UI. */
+function lineLabel(info: SetOptsLineInfo): string {
+    if (!info.vector) return 'Compose SETOPTS…';
+    const summary = describeVector(info.vector);
+    return `Configure SETOPTS (${summary.length > 72 ? summary.slice(0, 71) + '…' : summary})`;
+}
+
+/**
+ * Command entry point without an arg: prefer the file's existing SETOPTS line (config.bbx is
+ * evaluated once — a second line would silently override, not add), else compose a NEW line
+ * to insert at the cursor.
+ */
+function argForActiveEditor(): SetOptsPanelArg | undefined {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'bbx-config') {
+        vscode.window.showInformationMessage('Open a config.bbx file first, then run the SETOPTS composer.');
+        return undefined;
+    }
+    for (let line = 0; line < editor.document.lineCount; line++) {
+        const info = parseSetOptsLine(editor.document.lineAt(line).text);
+        if (info) return argForLine(editor.document, line, info);
+    }
+    return {}; // NEW mode — insert at the cursor
+}
+
+class SetOptsCodeActionProvider implements vscode.CodeActionProvider {
+    provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection): vscode.CodeAction[] {
+        const line = range.start.line;
+        const info = parseSetOptsLine(document.lineAt(line).text);
+        if (!info) return [];
+        const label = lineLabel(info);
+        const action = new vscode.CodeAction(label, vscode.CodeActionKind.RefactorRewrite);
+        action.command = { command: 'bbj.composeConfigSetopts', title: label, arguments: [argForLine(document, line, info)] };
+        return [action];
+    }
+}
+
+class SetOptsCodeLensProvider implements vscode.CodeLensProvider {
+    provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+        const lenses: vscode.CodeLens[] = [];
+        for (let line = 0; line < document.lineCount; line++) {
+            const info = parseSetOptsLine(document.lineAt(line).text);
+            if (!info) continue;
+            const title = `$(settings-gear) ${lineLabel(info)}`;
+            lenses.push(new vscode.CodeLens(
+                new vscode.Range(line, 0, line, document.lineAt(line).text.length),
+                { command: 'bbj.composeConfigSetopts', title, arguments: [argForLine(document, line, info)] },
+            ));
+        }
+        return lenses;
+    }
+}

--- a/bbj-vscode/src/setopts-composer-webview.ts
+++ b/bbj-vscode/src/setopts-composer-webview.ts
@@ -1,0 +1,321 @@
+/**
+ * Visual config.bbx SETOPTS composer — a webview panel with per-byte checkbox groups, char
+ * inputs for the byte 5/6 mask replacement characters, a raw-hex passthrough for the reserved
+ * bytes 10–16, and a live hex + human-readable preview of the resulting line (#474).
+ *
+ * The panel is pure presentation: it renders the catalog, sends the raw selection back to the
+ * extension, and the shared ./setopts-catalog module computes the resulting vector on top of the
+ * ORIGINAL string — which is what makes the round-trip lossless (unknown bits, unmodeled bytes
+ * and the original digit count all survive).
+ *
+ * Two modes:
+ *   - EDIT (from the CodeLens/Code Action/command): rewrite the hex token of an existing
+ *     `SETOPTS <hex>` line in place (or append the token to a bare `SETOPTS` keyword line).
+ *   - NEW (command in a file with no SETOPTS line): insert a whole `SETOPTS <hex>` line at the cursor.
+ */
+import * as vscode from 'vscode';
+import {
+    BYTE_GROUPS, SETOPTS_BITS, getBit, maskChar, MASK_COMMA_BYTE, MASK_DOT_BYTE,
+    parseVector, rawTail, setoptsPreview, SetOptsSelection, SetOptsVector,
+} from './setopts-catalog.js';
+
+export interface SetOptsEditTarget {
+    uri: string;
+    line: number;
+    /** Replace this existing hex token… */
+    hexRange?: [number, number];
+    /** …or insert ` <hex>` here when the line is a bare `SETOPTS` keyword. */
+    insertOffset?: number;
+    /** The original hex digits — the lossless round-trip baseline. */
+    originalHex?: string;
+}
+
+export interface SetOptsPanelArg {
+    /** Present = EDIT a SETOPTS line in place. Absent = insert a NEW line at the cursor. */
+    target?: SetOptsEditTarget;
+}
+
+/** The raw form state the webview reports; mirrors {@link SetOptsSelection} with string bit ids. */
+interface PanelSelection {
+    checked: string[]; // "byte:mask" ids
+    maskComma: string;
+    maskDot: string;
+    rawTail: string;
+}
+
+export function openSetOptsComposerPanel(context: vscode.ExtensionContext, arg: SetOptsPanelArg): void {
+    const target = arg.target;
+    const editMode = !!target;
+    const original: SetOptsVector | undefined = target?.originalHex ? parseVector(target.originalHex) : undefined;
+
+    let insertUri: vscode.Uri | undefined;
+    let insertLine: number | undefined;
+    if (!editMode) {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) return;
+        insertUri = editor.document.uri;
+        insertLine = editor.selection.active.line;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+        'bbjSetOptsComposer',
+        editMode ? 'Edit SETOPTS' : 'SETOPTS Composer',
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        { enableScripts: true, retainContextWhenHidden: true },
+    );
+    panel.webview.html = getHtml(panel.webview);
+
+    const build = (sel: PanelSelection) => setoptsPreview(original, toSelection(sel));
+
+    panel.webview.onDidReceiveMessage(async (msg: { type: string; payload?: PanelSelection }) => {
+        switch (msg.type) {
+            case 'ready':
+                panel.webview.postMessage({
+                    type: 'init',
+                    editMode,
+                    catalog: SETOPTS_BITS,
+                    groups: BYTE_GROUPS,
+                    initial: initialSelection(original),
+                });
+                break;
+            case 'change':
+                if (msg.payload) panel.webview.postMessage({ type: 'preview', ...build(msg.payload) });
+                break;
+            case 'apply': {
+                if (!msg.payload) break;
+                const r = build(msg.payload);
+                const edit = new vscode.WorkspaceEdit();
+                if (target) {
+                    const uri = vscode.Uri.parse(target.uri);
+                    if (target.hexRange) {
+                        edit.replace(uri,
+                            new vscode.Range(target.line, target.hexRange[0], target.line, target.hexRange[1]),
+                            r.hexDigits);
+                    } else if (target.insertOffset !== undefined) {
+                        edit.insert(uri, new vscode.Position(target.line, target.insertOffset), ` ${r.hexDigits}`);
+                    }
+                } else if (insertUri !== undefined && insertLine !== undefined) {
+                    edit.insert(insertUri, new vscode.Position(insertLine, 0), `${r.line}\n`);
+                }
+                await vscode.workspace.applyEdit(edit);
+                panel.dispose();
+                break;
+            }
+            case 'cancel':
+                panel.dispose();
+                break;
+        }
+    }, undefined, context.subscriptions);
+}
+
+function toSelection(sel: PanelSelection): SetOptsSelection {
+    return {
+        bits: sel.checked.map(id => {
+            const [byte, mask] = id.split(':').map(Number);
+            return { byte, mask };
+        }),
+        maskComma: sel.maskComma,
+        maskDot: sel.maskDot,
+        rawTail: sel.rawTail.toUpperCase(),
+    };
+}
+
+function initialSelection(original: SetOptsVector | undefined): PanelSelection {
+    if (!original) return { checked: [], maskComma: '', maskDot: '', rawTail: '' };
+    return {
+        checked: SETOPTS_BITS.filter(b => getBit(original, b.byte, b.mask)).map(b => `${b.byte}:${b.mask}`),
+        maskComma: maskChar(original, MASK_COMMA_BYTE),
+        maskDot: maskChar(original, MASK_DOT_BYTE),
+        rawTail: rawTail(original),
+    };
+}
+
+function getHtml(webview: vscode.Webview): string {
+    const nonce = getNonce();
+    const csp = [
+        `default-src 'none'`,
+        `style-src ${webview.cspSource} 'unsafe-inline'`,
+        `script-src 'nonce-${nonce}'`,
+    ].join('; ');
+    return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SETOPTS Composer</title>
+<style>
+  body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 12px 16px; }
+  h2 { margin: 0 0 4px; font-size: 1.1em; }
+  .hint { font-size: 0.8em; opacity: 0.7; margin: 0 0 12px; }
+  fieldset { border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 3px; margin: 0 0 10px; padding: 6px 10px 8px; }
+  legend { font-size: 0.82em; opacity: 0.85; padding: 0 4px; }
+  legend .byte-no { opacity: 0.6; }
+  .bits { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1px 18px; }
+  .check { display: flex; align-items: baseline; gap: 6px; font-size: 0.9em; margin: 2px 0; }
+  .check code { font-size: 0.85em; opacity: 0.6; }
+  .check.ignored { opacity: 0.45; }
+  .check.ignored span.lbl { text-decoration: line-through dotted; text-decoration-thickness: 1px; }
+  .tag { font-size: 0.68em; padding: 0 6px; border-radius: 8px; background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); white-space: nowrap; }
+  .row { display: flex; align-items: center; gap: 10px; font-size: 0.9em; margin: 4px 0; }
+  input[type="text"] {
+    background: var(--vscode-input-background); color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent); padding: 3px 6px; border-radius: 2px;
+    font-family: var(--vscode-editor-font-family, monospace); font-size: 0.95em;
+  }
+  input[type="text"]:disabled { opacity: 0.4; }
+  .char-input { width: 2.2em; text-align: center; }
+  #raw-tail { width: 12em; text-transform: uppercase; }
+  .note { font-size: 0.78em; opacity: 0.65; }
+  .preview { margin: 10px 0 4px; }
+  pre {
+    background: var(--vscode-textCodeBlock-background); border: 1px solid var(--vscode-panel-border);
+    padding: 8px 10px; border-radius: 3px; white-space: pre-wrap; word-break: break-all; margin: 4px 0;
+    font-size: 1.02em;
+  }
+  .summary { font-size: 0.8em; opacity: 0.75; min-height: 1.1em; }
+  .buttons { display: flex; gap: 8px; margin-top: 14px; }
+  button {
+    background: var(--vscode-button-background); color: var(--vscode-button-foreground);
+    border: none; padding: 6px 14px; border-radius: 2px; cursor: pointer; font-size: 0.95em;
+  }
+  button:hover { background: var(--vscode-button-hoverBackground); }
+  button.secondary { background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); }
+</style>
+</head>
+<body>
+  <h2 id="heading">SETOPTS Composer</h2>
+  <p class="hint">Struck-through options are ignored in BBj (hover for details). Unknown bits and reserved bytes are preserved verbatim.</p>
+
+  <div id="byte-fieldsets"></div>
+
+  <fieldset>
+    <legend>Bytes 5–6 <span class="byte-no">— mask replacement characters</span></legend>
+    <div class="row">
+      <label for="mask-comma">"," becomes</label><input type="text" id="mask-comma" class="char-input" maxlength="1">
+      <label for="mask-dot">"." becomes</label><input type="text" id="mask-dot" class="char-input" maxlength="1">
+      <span class="note" id="mask-note">Enable "mask replacement characters" (byte 3 $02$) to edit.</span>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Bytes 10–16 <span class="byte-no">— reserved / application use</span></legend>
+    <div class="row">
+      <label for="raw-tail">Raw hex</label><input type="text" id="raw-tail" maxlength="14" spellcheck="false">
+      <span class="note">Passed through untouched; leave empty to end the vector at byte 9.</span>
+    </div>
+  </fieldset>
+
+  <div class="preview">
+    <label>Resulting config.bbx line</label>
+    <pre id="preview">—</pre>
+    <div class="summary" id="summary"></div>
+  </div>
+
+  <div class="buttons">
+    <button id="apply">Apply</button>
+    <button id="cancel" class="secondary">Cancel</button>
+  </div>
+
+<script nonce="${nonce}">
+  const vscode = acquireVsCodeApi();
+  const $ = (id) => document.getElementById(id);
+  const hex2 = (n) => n.toString(16).toUpperCase().padStart(2, '0');
+
+  function bitTooltip(bit) {
+    const parts = ['Byte ' + bit.byte + ' $' + hex2(bit.mask) + '$'];
+    if (bit.detail) parts.push(bit.detail);
+    if (bit.bbj === 'ignored') parts.push('Ignored in BBj' + (bit.bbjDetail ? ': ' + bit.bbjDetail : '.'));
+    else if (bit.bbjDetail) parts.push('BBj: ' + bit.bbjDetail);
+    if (bit.bbj === 'bbj-specific') parts.push('BBj-specific (no effect in PRO/5).');
+    if (bit.since) parts.push(bit.since);
+    return parts.join('\\n');
+  }
+
+  function renderCatalog(catalog, groups) {
+    const host = $('byte-fieldsets');
+    for (const byteNo of Object.keys(groups)) {
+      const fs = document.createElement('fieldset');
+      const legend = document.createElement('legend');
+      legend.innerHTML = 'Byte ' + byteNo + ' <span class="byte-no">— ' + groups[byteNo] + '</span>';
+      fs.appendChild(legend);
+      const grid = document.createElement('div');
+      grid.className = 'bits';
+      for (const bit of catalog.filter(b => String(b.byte) === byteNo)) {
+        const wrap = document.createElement('label');
+        wrap.className = 'check' + (bit.bbj === 'ignored' ? ' ignored' : '');
+        wrap.title = bitTooltip(bit);
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.value = bit.byte + ':' + bit.mask;
+        cb.className = 'bit-cb';
+        cb.addEventListener('change', change);
+        const code = document.createElement('code');
+        code.textContent = '$' + hex2(bit.mask) + '$';
+        const lbl = document.createElement('span');
+        lbl.className = 'lbl';
+        lbl.textContent = bit.label;
+        wrap.appendChild(cb); wrap.appendChild(code); wrap.appendChild(lbl);
+        if (bit.bbj === 'bbj-specific') { const t = document.createElement('span'); t.className = 'tag'; t.textContent = 'BBj'; wrap.appendChild(t); }
+        if (bit.since) { const t = document.createElement('span'); t.className = 'tag'; t.textContent = bit.since; wrap.appendChild(t); }
+        grid.appendChild(wrap);
+      }
+      fs.appendChild(grid);
+      host.appendChild(fs);
+    }
+  }
+
+  function readForm() {
+    return {
+      checked: Array.from(document.querySelectorAll('.bit-cb:checked')).map(c => c.value),
+      maskComma: $('mask-comma').value,
+      maskDot: $('mask-dot').value,
+      rawTail: $('raw-tail').value.replace(/[^0-9A-Fa-f]/g, ''),
+    };
+  }
+
+  function change() {
+    vscode.postMessage({ type: 'change', payload: readForm() });
+  }
+
+  window.addEventListener('message', (e) => {
+    const m = e.data;
+    if (m.type === 'init') {
+      $('heading').textContent = m.editMode ? 'Edit SETOPTS' : 'SETOPTS Composer';
+      renderCatalog(m.catalog, m.groups);
+      for (const cb of document.querySelectorAll('.bit-cb')) {
+        cb.checked = m.initial.checked.includes(cb.value);
+      }
+      $('mask-comma').value = m.initial.maskComma;
+      $('mask-dot').value = m.initial.maskDot;
+      $('raw-tail').value = m.initial.rawTail;
+      change();
+    } else if (m.type === 'preview') {
+      $('preview').textContent = m.line;
+      $('summary').textContent = m.hexDigits.length / 2 + ' byte(s)  ·  ' + m.summary;
+      $('mask-comma').disabled = !m.maskInputsEnabled;
+      $('mask-dot').disabled = !m.maskInputsEnabled;
+      $('mask-note').style.display = m.maskInputsEnabled ? 'none' : '';
+    }
+  });
+
+  for (const id of ['mask-comma', 'mask-dot', 'raw-tail']) {
+    $(id).addEventListener('input', change);
+  }
+  $('apply').addEventListener('click', () => vscode.postMessage({ type: 'apply', payload: readForm() }));
+  $('cancel').addEventListener('click', () => vscode.postMessage({ type: 'cancel' }));
+
+  vscode.postMessage({ type: 'ready' });
+</script>
+</body>
+</html>`;
+}
+
+function getNonce(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let text = '';
+    for (let i = 0; i < 32; i++) {
+        text += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return text;
+}

--- a/bbj-vscode/test/setopts-catalog.test.ts
+++ b/bbj-vscode/test/setopts-catalog.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the editor-agnostic config.bbx SETOPTS catalog/vector module (#474).
+ */
+import { describe, expect, test } from 'vitest';
+import {
+    BYTE_GROUPS, FIRST_RAW_BYTE, MASK_COMMA_BYTE, MASK_DOT_BYTE, SETOPTS_BITS,
+    composeSetOptsLine, describeVector, encodeVector, emptyVector, getBit, knownByteMask,
+    maskChar, parseSetOptsLine, parseVector, rawTail, setBit, setMaskChar, setRawTail,
+    setoptsPreview, unknownBitsInByte, type SetOptsSelection, type SetOptsVector,
+} from '../src/setopts-catalog.js';
+
+/** The SETOPTS line the stock BBj config.bbx ships with (7 bytes). */
+const STOCK = '08004020000000';
+
+const noSelection: SetOptsSelection = { bits: [], maskComma: '', maskDot: '', rawTail: '' };
+
+/** The selection a UI would build for `v`: checked catalog bits + displayed data-byte fields. */
+function selectionFor(v: SetOptsVector): SetOptsSelection {
+    return {
+        bits: SETOPTS_BITS.filter(b => getBit(v, b.byte, b.mask)).map(b => ({ byte: b.byte, mask: b.mask })),
+        maskComma: maskChar(v, MASK_COMMA_BYTE),
+        maskDot: maskChar(v, MASK_DOT_BYTE),
+        rawTail: rawTail(v),
+    };
+}
+
+describe('catalog integrity', () => {
+    test('every bit is a single-bit mask in a documented byte', () => {
+        for (const bit of SETOPTS_BITS) {
+            expect(BYTE_GROUPS[bit.byte], `byte ${bit.byte} has a group`).toBeDefined();
+            expect(bit.mask & (bit.mask - 1), `${bit.byte}:$${bit.mask.toString(16)}$ is a single bit`).toBe(0);
+            expect(bit.mask).toBeGreaterThan(0);
+            expect(bit.mask).toBeLessThanOrEqual(0xff);
+        }
+    });
+
+    test('no duplicate byte/mask pairs', () => {
+        const keys = SETOPTS_BITS.map(b => `${b.byte}:${b.mask}`);
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    test('bytes 5, 6 and 10+ carry no flag bits (they are data)', () => {
+        expect(SETOPTS_BITS.some(b => b.byte === 5 || b.byte === 6 || b.byte >= FIRST_RAW_BYTE)).toBe(false);
+    });
+
+    test('the twelve PRO/5-only bits are annotated as ignored in BBj', () => {
+        expect(SETOPTS_BITS.filter(b => b.bbj === 'ignored')).toHaveLength(12);
+    });
+});
+
+describe('parseVector / encodeVector', () => {
+    test('round-trips the stock config string', () => {
+        const v = parseVector(STOCK)!;
+        expect(v.bytes).toEqual([0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00]);
+        expect(encodeVector(v)).toBe(STOCK);
+    });
+
+    test('round-trips short and full-length strings, preserving length and case-normalizing', () => {
+        for (const digits of ['0010', '00c20240', '00C20240000000000000000000000000']) {
+            expect(encodeVector(parseVector(digits)!)).toBe(digits.toUpperCase());
+        }
+    });
+
+    test('an odd digit count survives as a high-nibble partial byte', () => {
+        const v = parseVector('081')!;
+        expect(v.bytes).toEqual([0x08, 0x10]);
+        expect(encodeVector(v)).toBe('081');
+    });
+
+    test('rejects non-hex input and more than 16 bytes', () => {
+        expect(parseVector('00G2')).toBeUndefined();
+        expect(parseVector('')).toBeUndefined();
+        expect(parseVector('0'.repeat(33))).toBeUndefined();
+        expect(parseVector('$0010$')).toBeUndefined();
+    });
+});
+
+describe('bit access', () => {
+    test('setBit grows the vector only when setting', () => {
+        const v = parseVector('0010')!;
+        setBit(v, 7, 0x20, false); // clearing beyond the end must not grow
+        expect(encodeVector(v)).toBe('0010');
+        setBit(v, 7, 0x20, true);
+        expect(encodeVector(v)).toBe('00100000000020');
+    });
+
+    test('toggling one bit changes exactly one nibble (issue #474 guarantee)', () => {
+        const before = encodeVector(parseVector('00C20240000000000000000000000000')!);
+        const v = parseVector(before)!;
+        setBit(v, 1, 0x80, true);
+        const after = encodeVector(v);
+        expect(after).toHaveLength(before.length);
+        const diffs = [...before].filter((c, i) => c !== after[i]);
+        expect(diffs).toHaveLength(1);
+        expect(after.startsWith('80C2')).toBe(true);
+    });
+
+    test('unknown bits are visible per byte and never claimed by the catalog', () => {
+        expect(knownByteMask(9)).toBe(0xf0);
+        const v = parseVector('0000000000000000C8')!; // byte 9 = $C8$: $80$+$40$ known, $08$ not
+        expect(unknownBitsInByte(v, 9)).toBe(0x08);
+        expect(unknownBitsInByte(v, 1)).toBe(0);
+        expect(unknownBitsInByte(v, 10)).toBe(0); // beyond documented flag bytes
+    });
+});
+
+describe('mask replacement characters (bytes 5/6)', () => {
+    test('read/write printable chars; empty string clears', () => {
+        const v = emptyVector();
+        setMaskChar(v, MASK_COMMA_BYTE, '.');
+        setMaskChar(v, MASK_DOT_BYTE, ',');
+        expect(maskChar(v, MASK_COMMA_BYTE)).toBe('.');
+        expect(maskChar(v, MASK_DOT_BYTE)).toBe(',');
+        expect(encodeVector(v)).toBe('000000002E2C');
+        setMaskChar(v, MASK_DOT_BYTE, '');
+        expect(encodeVector(v)).toBe('000000002E00');
+    });
+
+    test('clearing a char beyond the vector end does not grow it', () => {
+        const v = parseVector('0010')!;
+        setMaskChar(v, MASK_COMMA_BYTE, '');
+        expect(encodeVector(v)).toBe('0010');
+    });
+});
+
+describe('raw tail (bytes 10–16)', () => {
+    test('get/set replaces only the tail and preserves the head', () => {
+        const v = parseVector('00C202400000000000AABB')!;
+        expect(rawTail(v)).toBe('AABB');
+        setRawTail(v, 'FF');
+        expect(encodeVector(v)).toBe('00C202400000000000FF');
+        setRawTail(v, '');
+        expect(encodeVector(v)).toBe('00C202400000000000');
+    });
+
+    test('setting a tail on a short vector zero-pads the head through byte 9', () => {
+        const v = parseVector('0010')!;
+        setRawTail(v, '42');
+        expect(encodeVector(v)).toBe('00100000000000000042');
+    });
+});
+
+describe('parseSetOptsLine', () => {
+    test('recognizes the documented syntax, keyword case-insensitively', () => {
+        for (const line of [`SETOPTS ${STOCK}`, `setopts ${STOCK}`, `  SETOPTS   ${STOCK}  `]) {
+            const info = parseSetOptsLine(line)!;
+            expect(info.hexDigits).toBe(STOCK);
+            expect(line.slice(info.hexRange![0], info.hexRange![1])).toBe(STOCK);
+            expect(encodeVector(info.vector!)).toBe(STOCK);
+        }
+    });
+
+    test('a bare SETOPTS keyword yields an insert offset instead of a token', () => {
+        const info = parseSetOptsLine('SETOPTS')!;
+        expect(info.hexRange).toBeUndefined();
+        expect(info.insertOffset).toBe(7);
+    });
+
+    test('rejects non-SETOPTS lines, trailing junk and malformed tokens', () => {
+        expect(parseSetOptsLine('ALIAS X0 SYSGUI')).toBeUndefined();
+        expect(parseSetOptsLine('SETOPTSX 0010')).toBeUndefined();
+        expect(parseSetOptsLine(`SETOPTS ${STOCK} extra`)).toBeUndefined();
+        expect(parseSetOptsLine('SETOPTS $0010$')).toBeUndefined();
+        expect(parseSetOptsLine('SETOPTS 00G0')).toBeUndefined();
+    });
+});
+
+describe('describeVector', () => {
+    test('summarizes the stock config', () => {
+        const summary = describeVector(parseVector(STOCK)!);
+        expect(summary).toContain('Console mode in public programs');
+        expect(summary).toContain('Advisory locking in data files');
+        expect(summary).toContain('Enable Data Server access');
+    });
+
+    test('an all-zero vector reads as defaults; unknown bits and tails are flagged', () => {
+        expect(describeVector(parseVector('0000')!)).toBe('(default settings)');
+        expect(describeVector(parseVector('0000000000000000C8')!)).toContain('unknown bit(s) $08$');
+        expect(describeVector(parseVector('000000000000000000FF')!)).toContain('Bytes 10+: FF');
+    });
+});
+
+describe('setoptsPreview (the round-trip contract)', () => {
+    test('an untouched selection reproduces the original string exactly', () => {
+        for (const digits of [STOCK, '0010', '00C20240000000000000AABB', '0000000000000000C8']) {
+            const v = parseVector(digits)!;
+            expect(setoptsPreview(v, selectionFor(v)).hexDigits).toBe(digits);
+        }
+    });
+
+    test('toggling one bit changes exactly one nibble of the stock config', () => {
+        const v = parseVector(STOCK)!;
+        const sel = selectionFor(v);
+        sel.bits.push({ byte: 2, mask: 0x10 }); // NUM() strips embedded spaces
+        const preview = setoptsPreview(v, sel);
+        expect(preview.hexDigits).toBe('08104020000000');
+        expect(preview.line).toBe('SETOPTS 08104020000000');
+    });
+
+    test('unchecking a bit clears it; unknown bits in the same byte survive', () => {
+        const v = parseVector('0000000000000000C8')!; // byte 9: $80$+$40$ known, $08$ unknown
+        const sel = selectionFor(v);
+        sel.bits = sel.bits.filter(b => !(b.byte === 9 && b.mask === 0x80));
+        expect(setoptsPreview(v, sel).hexDigits).toBe('000000000000000048');
+    });
+
+    test('mask chars only apply while byte 3 $02$ is checked', () => {
+        const v = parseVector('0000')!;
+        const off = setoptsPreview(v, { ...noSelection, maskComma: 'x', maskDot: 'y' });
+        expect(off.hexDigits).toBe('0000');
+        expect(off.maskInputsEnabled).toBe(false);
+        const on = setoptsPreview(v, {
+            ...noSelection, bits: [{ byte: 3, mask: 0x02 }], maskComma: 'x', maskDot: 'y',
+        });
+        expect(on.hexDigits).toBe('000002007879');
+        expect(on.maskInputsEnabled).toBe(true);
+    });
+
+    test('an unprintable byte 5/6 value survives an untouched empty char input', () => {
+        const v = parseVector('000002010200')!; // replacement on; byte 5 = $01$ (unprintable), byte 6 = $02$
+        const preview = setoptsPreview(v, selectionFor(v));
+        expect(preview.hexDigits).toBe('000002010200');
+    });
+
+    test('a new composition starts from an all-defaults vector and grows on demand', () => {
+        const fresh = setoptsPreview(undefined, noSelection);
+        expect(fresh.hexDigits).toBe('00000000');
+        const grown = setoptsPreview(undefined, { ...noSelection, bits: [{ byte: 9, mask: 0x20 }] });
+        expect(grown.hexDigits).toBe('000000000000000020');
+    });
+});


### PR DESCRIPTION
Closes #474.

## What

A visual composer for the bare-hex `SETOPTS` line in config.bbx — `SETOPTS 08004020000000` — which nobody can read or safely edit by hand. Since the config.bbx string is absolute and stateless (no OPTS query, no IOR/AND), the composer gets a perfect lossless round-trip, same shape as the addWindow hex composer (#432).

## Shared catalog module — `setopts-catalog.ts` (no `vscode` dep)

- Byte/bit catalog for bytes 1–4 and 7–9 per the [SETOPTS verb docs](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/setopts_verb.htm) and the [BBj-specific page](https://documentation.basis.cloud/BASISHelp/WebHelp/commands/bbj-commands/setopts_verb_bbj.htm): hex mask, label, description, per-bit BBj annotation (12 bits *ignored in BBj*, BBj-specific bits, version gates like "BBj 15.00+"), grouped per byte.
- Special bytes as data, not flags: bytes 5–6 (mask replacement characters, gated on byte 3 `$02$`), bytes 10–16 (reserved/application use — raw hex passthrough).
- `parseVector`/`encodeVector` preserve the original digit count (the stock config ships 14 digits, docs examples use 4) and unknown bits; `describeVector` produces the human summary.
- The round-trip trick: `setoptsPreview` clones the **original** vector and flips only catalog bits — it never re-encodes from the catalog — so unmodeled bits, unprintable byte 5/6 values, and string length survive verbatim. Ready for reuse by the BBj-code SETOPTS composer (#475).

## VS Code UI — first language feature on `bbx-config`

- CodeLens (new to the extension) + RefactorRewrite code action on `SETOPTS` lines → webview with checkboxes grouped by byte, BBj-ignored bits struck through/de-emphasized with a tooltip explaining why, char inputs for bytes 5–6 enabled only while byte 3 `$02$` is checked, raw-hex field for the reserved tail, and a live hex + human-readable preview of the resulting line.
- Command `bbj.composeConfigSetopts`: edits the file's existing SETOPTS line (config.bbx is evaluated once — a second line would override, not add), or inserts a new line at the cursor when the file has none.

## Verification

- 26 Vitest cases in `test/setopts-catalog.test.ts`: catalog integrity, length-preserving round-trips (incl. odd digit counts), the "toggling one bit changes exactly one nibble" guarantee, unknown-bit survival, mask-char gating, line parsing.
- Exercised against a real `/opt/bbx/cfg/config.bbx`: `SETOPTS 08004020000000` → "Console mode in public programs · Advisory locking in data files · Enable Data Server access", byte-identical round-trip, single-nibble toggle.
- `npm run build` and `npm run lint` clean; the 11 `linking.test.ts` failures are pre-existing on main (Java interop not running).

Out of scope per the issue: `SETOPTS` in BBj source (#475), validation of other config.bbx directives. VS Code only — #474 doesn't include an IntelliJ side (unlike #473).

🤖 Generated with [Claude Code](https://claude.com/claude-code)