### PR TITLE
fix(#494): terminate the visibility hierarchy walk on cyclic inheritance

### DIFF
--- a/bbj-vscode/src/language/bbj-validator.ts
+++ b/bbj-vscode/src/language/bbj-validator.ts
@@ -221,12 +221,23 @@ export class BBjValidator {
                 expectedAccessLevels.push("PRIVATE", "PROTECTED");
             } else {
                 const remainingClasses = [classOfUsage];
+                // Cyclic `extends` (A extends B, B extends A) would otherwise re-expand the
+                // same classes forever. This walk is synchronous, so that blocks the event
+                // loop: no diagnostics, no completion, and the clientProcessId watchdog can
+                // no longer fire, leaving a spinning server behind after the editor exits
+                // (#494, same failure mode as #232). Expansion is deterministic, so skipping
+                // classes already seen cannot change whether classOfDeclaration is reachable.
+                const visitedClasses = new Set<Class>();
                 while (remainingClasses.length > 0) {
                     const c = remainingClasses.pop();
                     if (c === classOfDeclaration) {
                         expectedAccessLevels.push("PROTECTED");
                         break;
                     }
+                    if (!c || visitedClasses.has(c)) {
+                        continue;
+                    }
+                    visitedClasses.add(c);
                     if (isBbjClass(c)) {
                         remainingClasses.push(...c.extends.map(x => getClass(x)).filter(x => x !== undefined).map(x => x as Class))
                     }

--- a/bbj-vscode/test/inheritance-cycle-validation.test.ts
+++ b/bbj-vscode/test/inheritance-cycle-validation.test.ts
@@ -1,0 +1,107 @@
+import { EmptyFileSystem } from 'langium';
+import { validationHelper, ValidationResult } from 'langium/test';
+import { describe, expect, test } from 'vitest';
+import { createBBjServices } from '../src/language/bbj-module.js';
+import type { Program } from '../src/language/generated/ast.js';
+
+const services = createBBjServices(EmptyFileSystem);
+const validate = validationHelper<Program>(services.BBj);
+
+/**
+ * Regression coverage for #494: the member-visibility check walked the using class's
+ * `extends` chain with no visited set, so a cycle that did not contain the declaring
+ * class re-expanded the same classes forever.
+ *
+ * The walk is synchronous, so the consequence was the #232 signature — 100% CPU, a
+ * server that stops answering, and one that outlives the editor because a blocked
+ * event loop starves the `clientProcessId` watchdog timer.
+ *
+ * Which is also why these tests cannot fail fast: if the guard is removed they hang
+ * rather than fail, since no in-process timeout can interrupt a blocked event loop.
+ * Once #493 lands, adding these sources to its child-process guard table converts a
+ * regression here into a readable failure.
+ *
+ * The access-level semantics themselves are covered by
+ * "Call instance members with different access levels" in validation.test.ts; the
+ * cases below pin that the cycle guard leaves those semantics intact.
+ */
+
+const CYCLE_DIAGNOSTICS = [
+    "Cyclic inheritance detected: class 'A' is involved in an inheritance cycle.",
+    "Cyclic inheritance detected: class 'B' is involved in an inheritance cycle."
+];
+
+function messages(result: ValidationResult<Program>): string[] {
+    return result.diagnostics.map(d => d.message);
+}
+
+describe('cyclic inheritance does not hang validation (#494)', () => {
+    test('member of a class outside the cycle terminates the hierarchy walk', async () => {
+        // The original hang: walking up from B looks for Helper, which is not in the
+        // B -> A -> B cycle, so the only loop exit was never reached.
+        const result = await validate(`class public Helper
+    field public num k
+classend
+
+class public A extends B
+classend
+
+class public B extends A
+    method public void go()
+        h! = new Helper()
+        x = h!.k
+    methodend
+classend
+`);
+
+        // The document must parse cleanly, otherwise validation never runs and this
+        // covers nothing.
+        expect(result.document.parseResult.parserErrors).toHaveLength(0);
+        // The cycle is reported, and the public member access is not flagged.
+        expect(messages(result)).toEqual(CYCLE_DIAGNOSTICS);
+    });
+
+    test('protected member reached through the cycle is still visible', async () => {
+        // Reachability must survive the guard: B does extend A, through the cycle, so
+        // A's protected member stays accessible.
+        const result = await validate(`class public A extends B
+    method protected void prot()
+    methodend
+classend
+
+class public B extends A
+    method public void go()
+        a! = new A()
+        a!.prot()
+    methodend
+classend
+`);
+
+        expect(result.document.parseResult.parserErrors).toHaveLength(0);
+        expect(messages(result)).toEqual(CYCLE_DIAGNOSTICS);
+    });
+
+    test('private member of another class in the cycle is still flagged', async () => {
+        // Negative guard: skipping visited classes must not turn the walk into a blanket
+        // "everything is visible".
+        const result = await validate(`class public A extends B
+    method private void priv()
+    methodend
+classend
+
+class public B extends A
+    method public void go()
+        a! = new A()
+        a!.priv()
+    methodend
+classend
+`);
+
+        expect(result.document.parseResult.parserErrors).toHaveLength(0);
+        // Matched loosely: the message embeds the declaring file name, which the test
+        // helper derives from a per-run document counter.
+        expect(messages(result)).toHaveLength(CYCLE_DIAGNOSTICS.length + 1);
+        expect(messages(result).slice(0, CYCLE_DIAGNOSTICS.length)).toEqual(CYCLE_DIAGNOSTICS);
+        expect(messages(result).at(-1)).toMatch(/The member 'priv' from the type 'A'.*is not visible/);
+    });
+});


### PR DESCRIPTION
Closes #494.

`checkMemberCallUsingAccessLevels` walked the using class's `extends` chain looking for the declaring class, pushing supertypes with no visited set and no depth cap. Its only loop exit was *finding* the declaring class, so an `extends` cycle that does not contain it re-expands the same classes forever.

## Reproduction

```bbj
class public Helper
    field public num k
classend

class public A extends B
classend

class public B extends A
    method public void go()
        h! = new Helper()
        x = h!.k
    methodend
classend
```

Walking up from `B` looks for `Helper`, which is not in the `B -> A -> B` cycle. Validating this document never returns.

The walk is synchronous, so this is the #232 failure mode again: 100% CPU on one core, a server that stops answering, and one that outlives the editor — the `--clientProcessId` watchdog in `vscode-languageserver` is a `setInterval`, and a blocked event loop starves it. The document parses cleanly, so nothing stops validation from running, and two mutually-extending classes is an ordinary mid-refactor state.

## Fix

Skip classes already visited. Expansion is deterministic, so this cannot change whether the declaring class is reachable — the search result is unchanged, it simply terminates.

`check-classes.ts` already walks hierarchies this way (`bbjSupertypesReach()` keeps a `visited` set; the cycle detector adds `MAX_INHERITANCE_DEPTH`), so this loop was the outlier rather than a missing convention.

## Verification

- **The test covers the bug, not just the fixed behaviour.** Removing the guard again makes the run hang and require an external kill (exit 124).
- **Reachability preserved:** a `protected` member reached *through* the cycle is still visible.
- **No blanket permissiveness:** a `private` member of another class in the cycle is still flagged `is not visible`.
- **Existing semantics intact:** "Call instance members with different access levels" in `validation.test.ts`, which already covers protected-from-subclass and private-from-unrelated across 11 member calls, still passes. Not duplicated here.
- `tsc -b` clean; `npm run lint` clean apart from two pre-existing warnings in `bbj-document-symbol-provider.ts`.
- Full suite: the failing **test** names were captured on this branch and again with the changes stashed. The lists are identical — the same 11 interop-dependent `linking.test.ts` failures, no new ones. (File-level `FAIL` lines shift between runs; that is the RPC-teardown flake documented in `bbj-test-module.ts`, not a test result.)

## Follow-up

These tests hang rather than fail if the guard is ever removed, because no in-process timeout can interrupt a blocked event loop. Once #493 lands, adding these three sources to its `test/support/line-break-walk-inputs.ts` table converts a future regression into a readable failure. No dependency between the two PRs — this one is independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
