### PR TITLE
fix(GHSA-p5f3-9456-9pcx): replace shell-string exec() with execFile argument arrays

### DIFF
--- a/.planning/DEBT.md
+++ b/.planning/DEBT.md
@@ -1,0 +1,130 @@
+# Debt Register: BBj Language Server
+
+Cross-cutting debt that outlived the milestone it was created in. Items here are
+**deferred by decision, not forgotten** — each is meant to be addressed in a
+dedicated task rather than smuggled into unrelated work.
+
+**Opened:** 2026-08-20
+**Status:** open — awaiting a dedicated cleanup task
+
+---
+
+## 1. Outstanding UAT / verification items (16 items across 10 files)
+
+All ten files live in **archived** milestones (v3.0 → v3.9), so no active phase is
+blocked. `/gsd-audit-uat` surfaces them on every `/gsd-progress` run, which is why
+they are recorded here instead.
+
+| Milestone | Phase | File | Type / status | Items |
+|-----------|-------|------|---------------|-------|
+| v3.9 | 59 | `59-UAT.md` | uat / passed | 1× skipped_unresolved |
+| v3.7 | 50 | `50-VERIFICATION.md` | verification / human_needed | 2× human_uat |
+| v3.3 | 36 | `36-UAT.md` | uat / complete | 1× skipped_unresolved |
+| v3.2 | 34 | `34-UAT.md` | uat / diagnosed | 2× unknown |
+| v3.2 | 34 | `34-final-UAT.md` | uat / diagnosed | 1× unknown |
+| v3.2 | 34 | `34-re-UAT.md` | uat / diagnosed | 1× skipped_unresolved, 1× unknown |
+| v3.1 | 29 | `29-UAT.md` | uat / diagnosed | 2× unknown |
+| v3.1 | 30 | `30-UAT.md` | uat / diagnosed | 1× unknown |
+| v3.0 | 24 | `24-UAT.md` | uat / diagnosed | 1× unknown |
+| v3.0 | 25 | `25-UAT.md` | uat / diagnosed | 1× server_blocked, 2× unknown |
+
+Paths are under `.planning/milestones/<version>-phases/<phase-dir>/`.
+
+**Three distinct categories, needing different treatment:**
+
+- **`human_uat` (2 items, phase 50)** — genuinely require a human at a keyboard
+  watching the Problems panel while editing a BBj file. Cannot be automated away;
+  either run them or formally waive them.
+- **`skipped_unresolved` (3 items)** — skipped for a *stated* reason that may now
+  be stale. Two examples: phase 59's deprecated-class strikethrough was skipped
+  because "classes never appear in completion lists correctly", and phase 36's
+  quiet-startup check was skipped pending phase 37's logger migration. Phase 37
+  shipped, so at least one of these is probably re-testable now.
+- **`unknown` (10 items) + `server_blocked` (1)** — the largest group and the least
+  understood. `unknown` means the audit could not classify the recorded result, so
+  these need reading before they can be triaged. Do not assume they are failures;
+  do not assume they are passes.
+
+**Why it was deferred:** the items span six archived milestones and three different
+resolution paths. Triaging them properly is its own task with its own judgment calls,
+and doing it inline would have derailed the security work it surfaced during.
+
+**How to address:** `/gsd-audit-uat` for the full cross-phase report, then decide
+per item: retest, fix, or formally waive. The `unknown` group needs a read-through
+first — classify before deciding.
+
+---
+
+## 2. Orphan phase directory: `68-deliverable-documents`
+
+`.planning/phases/68-deliverable-documents/` contains a single 19KB
+`68-PATTERNS.md` (dated 2026-08-19) with **no corresponding ROADMAP entry** —
+ROADMAP phases stop at 59, and phases 60–67 do not exist anywhere in planning.
+
+Notes:
+- The whole `.planning/phases/` tree is **untracked** in git (no `.gitignore` rule —
+  it simply was never committed). Completed phases are archived into
+  `.planning/milestones/<version>-phases/` on milestone close, so `phases/` is
+  transient scratch space. This directory is what got left behind.
+- `68-PATTERNS.md` is a `gsd-pattern-mapper` artifact — a codebase pattern analysis
+  produced *before* planning. Its content may still be useful; it is the dangling
+  phase number that is the problem.
+
+**Why it was deferred:** deleting it risks discarding real analysis; keeping it as-is
+leaves `/gsd-progress` reporting a phase that does not exist. Deciding which needs
+someone to actually read the file.
+
+**How to address:** read `68-PATTERNS.md`, then either fold its content into the
+codebase docs (`.planning/codebase/`) and delete the directory, or give phase 68 a
+real ROADMAP entry if the work it maps is still intended.
+
+---
+
+## 3. `MILESTONES.md` has duplicated milestone sections
+
+`v3.3 Output & Diagnostic Cleanup` and `v3.4 0.8.0 Issue Closure` each appear
+**twice** in `.planning/MILESTONES.md` — at lines 30 and 327 (v3.3), and lines 3 and
+356 (v3.4). The file also runs newest-first for its first block and then oldest-first
+for a second block, so it reads as two concatenated histories.
+
+Low severity — cosmetic, no tooling reads it for routing. But it makes the file
+untrustworthy as a changelog, and any future append lands in an ambiguous place.
+
+**How to address:** de-duplicate and settle on one ordering. Mechanical, but verify
+the two copies of each section actually agree before deleting either.
+
+---
+
+## 4. Planning records stopped six months before the code did
+
+Recorded for context rather than as an action item: planning tracked through v3.9
+(2026-02-21), then 159 commits landed over the following six months — releases
+0.9.0 through 0.12.0 — with no phase or plan artifacts. That gap is now closed by a
+retroactive **v4.0 Stability & Quality** entry in `MILESTONES.md`, which is explicit
+about being reconstructed from git rather than planned through GSD.
+
+The consequence to be aware of: v4.0 has **no** REQUIREMENTS, ROADMAP, phase or plan
+artifacts under `.planning/milestones/`, unlike every milestone before it. Milestone
+audits and any tooling that walks `<version>-phases/` will find nothing for v4.0.
+That is accurate, not a bug to fix.
+
+---
+
+## 5. Test-harness readiness gate false-positives on port 5008
+
+`shouldRunBBjTests()` (`bbj-vscode/test/test-helper.ts:37-43`) falls back to a bare TCP
+connect against :5008. BBjServices binds that port without speaking the interop JSON-RPC
+protocol, so on any machine with BBj installed the gate reports "ready", enables the
+interop-dependent tests, and 11 of them fail resolving `java.util.Map` / `Map.Entry`.
+
+- Green under `RUN_BBJ_TESTS=0` (23 passed, 19 skipped); red on auto-detect (11 failed).
+- Pre-existing: reproduced identically at `291cd23`.
+- **CI is green only because CI has no BBj and skips these tests** — so CI green is not
+  evidence that this interop coverage passes anywhere.
+- Starting `java-interop` (`./gradlew run`, documented to serve :5008) will collide with
+  BBjServices on that port.
+
+**How to address:** replace the connect check with a real protocol handshake (resolve a
+known class, short timeout), and confirm every interop test applies the gate at suite level
+— `linking.test.ts`'s `describe` is currently unconditional. Full analysis was filed in
+`tmp_human_review/06-test-harness-port-5008.md` (untracked; delete after triage).

--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,5 +1,84 @@
 # Project Milestones: BBj Language Server
 
+## v4.0 Stability and Quality (Code merged: 2026-08-20 — NOT formally shipped)
+
+**Status: `tech_debt`. This milestone was fully planned and audited but never closed
+through `/gsd-complete-milestone`.** Its audit states: "no blockers, no unmet
+requirements; deferred items warrant review before ship." Treat it as open until
+someone acts on the deferred items below.
+
+**Where the artifacts live:** phases 60–69, REQUIREMENTS.md, ROADMAP.md and
+`v4.0-MILESTONE-AUDIT.md` exist **only on the unmerged branch
+`v4.0-stability-and-quality`** (417 commits ahead of its remote, 104 behind). PR #636
+merged the *code* to `main`; the planning artifacts did not come with it. `main`'s
+`.planning/` therefore jumps from v3.9 straight to here.
+
+**Delivered:** a ten-phase review-and-hardening pass over the whole repo — language
+core, extension host / webview composers, IntelliJ plugin, build/CI/dependencies —
+plus a cross-cutting security audit, debt re-triage, easy-fix application, and issue
+filing.
+
+**Phases completed:** 60–69 (62 plans)
+
+| Phase | Name |
+|-------|------|
+| 60 | baseline-resync-review-standards |
+| 61 | language-core-review |
+| 62 | extension-host-webview-composer-review |
+| 63 | intellij-plugin-review |
+| 64 | build-ci-dependency-review |
+| 65 | cross-cutting-security-audit |
+| 66 | known-debt-re-triage |
+| 67 | apply-easy-fixes |
+| 68 | deliverable-documents |
+| 69 | github-issue-filing |
+
+**Audit scores:** requirements 40/40 · phases 10/10 · integration 6/6 · flows 1/1 ·
+gaps: none.
+
+**Deferred items requiring human action** (filed to `tmp_human_review/`):
+
+- **9 security advisories remain unpublished drafts** — GHSA-p5f3-9456-9pcx,
+  -89r9-2pw4-mc7f, -5f22-gqrx-xr22, -c4hw-5j83-cx5h, -5vrp-fj75-pm5q,
+  -9gv3-gr6g-c4rj, -33x9-cpwv-xcv2, -xxp5-vv2w-42q8, -h43f-jcjr-2g4j. Not
+  world-visible. Publishing is a deliberate separate act this milestone did not perform.
+- **WR-01..WR-06** — six concurrency/behavior warnings from phase 67. The audit claims
+  these were "recorded ONLY in 67-REVIEW.md — not on the GitHub tracker"; **that is
+  incorrect.** Verified 2026-08-20: WR-02 and WR-04 were fixed in-phase and the fixes are
+  present on `main` (`java-interop.ts:190-191`, `bbj-lexer.ts:19`), and WR-01/03/05/06 are
+  filed as open issues #497/#498/#499/#500. The audit summary needs correcting; the
+  underlying `67-REVIEW.md` is accurate. Note `8194248` is not an ancestor of `main` (PR
+  #636 rebased), so SHA-ancestry checks falsely report the fixes as missing — compare file
+  content instead.
+- **Nyquist validation 0/10** — no phase has a VALIDATION.md while the nyquist
+  capability is active at `verify:post`. A coverage TODO, not a compliance failure.
+- **Branch `issue492-cpu-regression-tests`** — 3 unmerged commits (705 insertions,
+  6 regression-test files) reachable from no other ref, for the now-closed issue #492.
+  Deliberately retained.
+- **Local test suite red** — 11 failures under `Linking Tests > Interop related tests`.
+  The audit attributes these to "a dead java-interop service on :5008"; the real cause,
+  established 2026-08-20, is that **BBjServices owns port 5008** while
+  `shouldRunBBjTests()` (`test/test-helper.ts:37-43`) gates on a bare TCP connect with no
+  protocol handshake — so the gate false-positives and enables tests nothing can serve.
+  Green under `RUN_BBJ_TESTS=0`; reproduced identically at `291cd23`. Not attributable to
+  any v4.0 phase. Note CI is green only because CI has no BBj and therefore *skips* these
+  tests — CI green is not evidence they pass.
+
+**Stats (code on `main`, v3.9 tip → now):**
+
+- 159 commits, 233 files changed (+20,526 / -3,813 lines, excluding `.planning/`)
+- 10 phases, 62 plans
+- 181 days (2026-02-21 → 2026-08-20)
+- Marketplace releases 0.9.0, 0.10.0, 0.11.0, 0.12.0
+
+**Git range:** `2194616` → `291cd23` (PR #636 merge commit: `7371c26`)
+
+**What's next:** GHSA-p5f3-9456-9pcx is being remediated now (quick task 260820-hxg).
+The other 8 advisories, the WR-01..WR-06 warnings, and the v4.0 artifact merge are
+open — see `tmp_human_review/` and `.planning/DEBT.md`.
+
+---
+
 ## v3.4 0.8.0 Issue Closure (Shipped: 2026-02-08)
 
 **Delivered:** Closed all 7 open GitHub issues tagged with the 0.8.0 milestone — fixed parser keyword conflicts, excluded .bbl library files from language features, cleaned up toolbar buttons, fixed token authentication corruption, and added config.bbx path support to all run commands across both VS Code and IntelliJ.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -18,6 +18,7 @@
 - ✅ **v3.7 Diagnostic Quality & BBjCPL Integration** — Phases 50-53 (shipped 2026-02-20)
 - ✅ **v3.8 Test & Debt Cleanup** — Phases 54-56 (shipped 2026-02-20)
 - ✅ **v3.9 Quick Wins** — Phases 57-59 (shipped 2026-02-21)
+- ⚠️ **v4.0 Stability and Quality** — Phases 60-69 (code merged 2026-08-20; NOT formally shipped, status `tech_debt`; artifacts on unmerged branch `v4.0-stability-and-quality`)
 
 ## Phases
 
@@ -197,9 +198,15 @@ Research-only milestone — no phases.
 | v3.7 Diagnostic Quality & BBjCPL | 50-53 | 7 | Complete | 2026-02-20 |
 | v3.8 Test & Debt Cleanup | 54-56 | 7 | Complete | 2026-02-20 |
 | v3.9 Quick Wins | 57-59 | 8 | Complete | 2026-02-21 |
+| v4.0 Stability and Quality | 60-69 | 62 | ⚠️ Code merged, not shipped (`tech_debt`) | — |
 
 **Total:** 16 milestones shipped, 59 phases complete, 143 plans shipped.
 
+v4.0 is **not** counted as shipped: its 10 phases and 62 plans were planned, executed
+and audited, but the milestone was never closed and its planning artifacts live only on
+the unmerged branch `v4.0-stability-and-quality`. Including v4.0 the project stands at
+69 phases / 205 plans. See `MILESTONES.md`, `.planning/DEBT.md` and `tmp_human_review/`.
+
 ---
 
-*Roadmap last updated: 2026-02-21 after v3.9 milestone completion*
+*Roadmap last updated: 2026-08-20 — v4.0 recorded as code-merged-but-unshipped; no active phases on `main`.*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,6 +1,6 @@
 # Project State: BBj Language Server
 
-**Last Updated:** 2026-02-21
+**Last Updated:** 2026-08-20
 
 ## Project Reference
 
@@ -8,17 +8,22 @@ See: .planning/PROJECT.md (updated 2026-02-21)
 
 **Core Value:** BBj developers get consistent, high-quality language intelligence — syntax highlighting, error diagnostics, code completion, run commands, and Java class/method completions — in both VS Code and IntelliJ through a single shared language server.
 
-**Current Focus:** Planning next milestone
+**Current Focus:** Remediating GHSA-p5f3-9456-9pcx (critical, CWE-78); next milestone unscoped
 
 ---
 
 ## Current Position
 
-Phase: 59 of 59 — All phases complete
-Status: v3.9 shipped
-Last activity: 2026-03-29 - Completed quick task 260329-oqw: PR #383: Return undefined instead of empty list from getFieldCompletion to allow other providers to continue
+Phase: none active on `main` — v4.0 (phases 60-69) code-merged but NOT shipped
+Status: v4.0 `tech_debt` — audited 40/40, never closed; artifacts on unmerged branch `v4.0-stability-and-quality`
+Last activity: 2026-08-20 - Filed v4.0 Stability & Quality retroactively; opened .planning/DEBT.md; executing quick task 260820-hxg (GHSA-p5f3-9456-9pcx command-injection hardening)
 
-Progress: [██████████] 100% (v3.9 shipped)
+Progress: [██████████] 100% of planned v4.0 phases executed (10/10, 62 plans) — milestone close pending
+
+**Needs human attention:** see `tmp_human_review/` — 9 unpublished draft security
+advisories, WR-01..WR-06 unfiled concurrency warnings, the unmerged v4.0 artifact
+branch, and the v4.0 milestone close. See `.planning/DEBT.md` for the deferred
+UAT/patterns debt.
 
 ---
 
@@ -27,7 +32,7 @@ Progress: [██████████] 100% (v3.9 shipped)
 ### Cumulative
 
 **Started:** 2026-02-01
-**Milestones shipped:** 16
+**Milestones shipped:** 16 (v4.0 executed and audited but not closed)
 **Phases completed:** 59
 **Plans completed:** 143
 **Days elapsed:** 21
@@ -83,20 +88,30 @@ Full decision log in PROJECT.md Key Decisions table. Key recent decisions:
 
 ### Blockers/Concerns
 
-None
+- **Unpushed security fix.** Quick task 260820-hxg (3 commits) sits on local branch
+  `fix/ghsa-p5f3-9456-9pcx`; not pushed, no PR. GHSA-p5f3-9456-9pcx stays an unpublished
+  draft until the fix ships.
+- **8 further draft advisories unfixed** (all high) from v4.0 phase 65. See
+  `tmp_human_review/01-security-advisories.md`.
+- **Test-harness false positive.** `shouldRunBBjTests()` (`test/test-helper.ts:37-43`) gates
+  on a bare TCP connect to :5008. BBjServices squats on that port without speaking the
+  interop protocol, so 11 `linking.test.ts` interop tests switch on and fail. Green with
+  `RUN_BBJ_TESTS=0`. Pre-existing; reproduced identically at `291cd23`.
+- Full inventory of items needing a human decision: `tmp_human_review/` (untracked).
 
 ### Quick Tasks Completed
 
-| # | Description | Date | Commit | Directory |
-|---|-------------|------|--------|-----------|
-| 260329-oqw | PR #383: Return undefined instead of empty list from getFieldCompletion to allow other providers to continue | 2026-03-29 | ab42eef | [260329-oqw-pr-383-return-undefined-instead-of-empty](./quick/260329-oqw-pr-383-return-undefined-instead-of-empty/) |
+| # | Description | Date | Commit | Status | Directory |
+|---|-------------|------|--------|--------|-----------|
+| 260329-oqw | PR #383: Return undefined instead of empty list from getFieldCompletion to allow other providers to continue | 2026-03-29 | ab42eef | | [260329-oqw-pr-383-return-undefined-instead-of-empty](./quick/260329-oqw-pr-383-return-undefined-instead-of-empty/) |
+| 260820-hxg | GHSA-p5f3-9456-9pcx (critical, CWE-78): replace shell-string `child_process.exec()` construction with `execFile` argument arrays across all 7 command constructions; adds metacharacter regression tests + reintroduction guard | 2026-08-20 | f289fc5 | Verified | [260820-hxg-fix-ghsa-p5f3-9456-9pcx-replace-unescape](./quick/260820-hxg-fix-ghsa-p5f3-9456-9pcx-replace-unescape/) |
 
 ---
 
 ## Session Continuity
 
-Last session: 2026-02-21
-Stopped at: Completed v3.9 milestone — all 11 requirements satisfied, milestone archived
+Last session: 2026-08-20
+Stopped at: Quick task 260820-hxg verified (9/9 must-haves, live-tested against /opt/bbx); planning docs committed; nothing pushed
 Resume file: None
 
 ---

--- a/.planning/quick/260820-hxg-fix-ghsa-p5f3-9456-9pcx-replace-unescape/260820-hxg-PLAN.md
+++ b/.planning/quick/260820-hxg-fix-ghsa-p5f3-9456-9pcx-replace-unescape/260820-hxg-PLAN.md
@@ -1,0 +1,284 @@
+---
+phase: quick
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - bbj-vscode/src/Commands/process-args.ts
+  - bbj-vscode/src/Commands/process-runner.ts
+  - bbj-vscode/src/Commands/Commands.cjs
+  - bbj-vscode/src/extension.ts
+  - bbj-vscode/test/command-argv-injection.test.ts
+  - bbj-vscode/test/process-runner.test.ts
+  - bbj-vscode/test/no-shell-command-construction.test.ts
+autonomous: true
+requirements: [GHSA-p5f3-9456-9pcx, P62-D1-003]
+
+estimate:
+  tokens: 95000
+  raw_tokens: 95000
+  tasks: 3
+  confidence: low
+
+must_haves:
+  truths:
+    - "Run, Run BUI, Run DWC, Compile, Denumber, Decompile (replace and read-only), EM login and EM token validation all still work unchanged on Linux, macOS and Windows"
+    - "No process in bbj-vscode/src is launched through a shell-interpreted command string; every launch passes an executable path plus an argument array"
+    - "A bbj.classpath value containing shell metacharacters reaches the child process as exactly one argument element, byte-identical to the configured value"
+    - "A bbj.configPath value containing shell metacharacters reaches the child process as exactly one argument element, byte-identical to the configured value"
+    - "A bbj.web.apps.<file>.name value containing shell metacharacters reaches the child process as exactly one argument element, byte-identical to the configured value"
+    - "Each bbj.compiler.* option value containing shell metacharacters reaches bbjcpl as exactly one argument element, in the same order buildCompileOptions produced"
+    - "A params.fsPath supplied by another extension's command invocation reaches the child process as exactly one argument element"
+    - "Debug logging still prints the launched command line, with a non-empty EM token and password redacted"
+    - "The regression tests pass under plain `npm test` with no BBj installation and no java-interop service on port 5008"
+  artifacts:
+    - path: "bbj-vscode/src/Commands/process-args.ts"
+      provides: "Pure argv builders (executable path + argument array) for every BBj process this extension launches"
+      contains: "buildRunArgv"
+    - path: "bbj-vscode/src/Commands/process-runner.ts"
+      provides: "Single argument-array process launcher used by every call site, plus redacting log formatter"
+      contains: "execFile"
+    - path: "bbj-vscode/src/Commands/Commands.cjs"
+      provides: "Run / BUI / DWC / Compile / Denumber / Decompile commands rewired onto the argv builders"
+      contains: "buildRunArgv"
+    - path: "bbj-vscode/src/extension.ts"
+      provides: "EM login and EM token validation rewired onto the argv builders"
+      contains: "buildEmLoginArgv"
+    - path: "bbj-vscode/test/command-argv-injection.test.ts"
+      provides: "Metacharacter pass-through regression tests, one per affected settings group"
+      contains: "buildRunArgv"
+    - path: "bbj-vscode/test/process-runner.test.ts"
+      provides: "Proof the launcher hands the argument array to execFile and never builds a shell string"
+      contains: "execFile"
+    - path: "bbj-vscode/test/no-shell-command-construction.test.ts"
+      provides: "Source-scanning guard preventing reintroduction of shell-string command construction"
+      contains: "Commands.cjs"
+  key_links:
+    - from: "Commands.run / Commands.runBUI / Commands.runDWC"
+      to: "child process"
+      via: "buildRunArgv / buildWebRunArgv -> runProcess -> execFile"
+      pattern: "argument array"
+    - from: "Commands.compile"
+      to: "bbjcpl"
+      via: "buildCompileOptions (already an array) -> buildCompileArgv -> runProcess"
+      pattern: "argument array"
+    - from: "Commands.denumber / decompileReplace / decompileReadonly"
+      to: "bbjlst"
+      via: "buildDecompileArgv -> runProcess"
+      pattern: "argument array"
+    - from: "extension.ts validateTokenServerSide / bbj.loginEM"
+      to: "bbj"
+      via: "buildEmValidateArgv / buildEmLoginArgv -> runProcess"
+      pattern: "argument array"
+---
+
+<objective>
+Harden how the VS Code extension launches BBj executables: replace every shell-interpolated command-string launch with argument-array process spawning, so that workspace-settable configuration values and caller-supplied file paths are handed to the child process as inert argument data rather than as text a shell parses.
+
+Remediates GHSA-p5f3-9456-9pcx (finding P62-D1-003), an OS command injection class defect (CWE-78). This mirrors the IntelliJ plugin's `GeneralCommandLine.addParameter` approach, so both IDE integrations construct process invocations the same way.
+
+Purpose: `bbj.classpath`, `bbj.configPath`, `bbj.web.apps.<file>.name` and the seven string-typed `bbj.compiler.*` options are all workspace-scoped settings, and `params.fsPath` is reachable from any other extension's command invocation. Today all of them are interpolated into a command string that a shell then parses. After this change no shell is involved at any launch site.
+
+Output: two new modules (`process-args.ts`, `process-runner.ts`), both existing launch sites rewired, three regression test files.
+
+## Verified current surface (HEAD 291cd23)
+
+The advisory's line numbers have drifted. Five shell-string launches exist in `bbj-vscode/src/`, carrying seven distinct command constructions:
+
+| # | Location | Command construction | Untrusted inputs |
+|---|----------|----------------------|------------------|
+| 1 | `Commands.cjs:271` (`Commands.run`) | `bbj -q -CP<classpath> -c<configPath> -WD<workingDir> <fileName>` | `bbj.classpath`, `bbj.configPath`, `params.fsPath` |
+| 2 | `Commands.cjs:117` (`runWeb`, used by `runBUI`/`runDWC`) | `bbj -q -WD<toolsDir> web.bbj - <client> <name> <programme> <workingDir> <username> <password> <classpath> <token> <configPath>` | `bbj.classpath`, `bbj.configPath`, `bbj.web.apps.<file>.name`, `params.fsPath` |
+| 3 | `Commands.cjs:336` via `execWithProgress` (`Commands.compile`) | `bbjcpl <options...> <fileName>` | seven string-typed `bbj.compiler.*` options, `params.fsPath` |
+| 4 | `Commands.cjs:180` via `execWithProgress` (`decompileInPlace`) | `bbjlst [-l [-xlst]] <fileName>` | `params.fsPath` |
+| 5 | `Commands.cjs:383` via `execWithProgress` (`decompileReadonly`) | `bbjlst -l <tmpInput>` | `params.fsPath` (via a temp copy) |
+| 6 | `extension.ts:426` (`validateTokenServerSide`) | `bbj -q em-validate-token.bbj - <token> <tmpFile>` | stored EM token |
+| 7 | `extension.ts:645` (`bbj.loginEM`) | `bbj -q em-login.bbj - <username> <password> <tmpFile> <infoString>` | user-entered EM credentials |
+
+Constructions 3, 4 and 5 all funnel through the single `execWithProgress` helper at `Commands.cjs:29-41`, which is why the file shows five launches for seven constructions.
+
+`src/document-formatter.ts:83` and `src/language/bbj-cpl-service.ts:140` already spawn with argument arrays and no shell; they are out of scope and must stay as they are.
+
+## Argument-mapping decision (explicit, not silent)
+
+Each configured string maps to **exactly one** argument element. No value is split on whitespace.
+
+- `bbj.classpath` is documented as a *classpath entry name* (`bbj_default`, `addon`, `barista`), i.e. a single token; it becomes the single element `-CP<value>`.
+- `bbj.configPath` is documented as a *path to a config.bbx file*, i.e. a single token; it becomes the single element `-c<value>` (and, in the web path, a standalone positional element).
+- Every string-typed `bbj.compiler.*` option is documented as a single path, extension, password or number. `buildCompileOptions` already returns a `string[]` where each entry is one complete flag-plus-value token; that array is now forwarded element-for-element instead of being joined with spaces.
+
+This preserves the behaviour of every documented usage. It also, deliberately, fixes a pre-existing latent bug: a value containing a space (for example an output directory under `Program Files`) is today split by the shell into two arguments, and will now be delivered intact as one. Record this in the module doc comment so the intent is not mistaken for a regression.
+
+## Disclosure constraint
+
+This repository is public and `.planning/` is tracked, and the advisory is still a draft. Name the GHSA id, the CWE class, the affected files and the remediation — but do not write an exploit payload, a concrete attack string, or a trigger sequence into any artifact. The one permitted appearance of a shell metacharacter is the inert test fixture described in the tasks: a settings value containing `;` or a backtick, asserted to arrive as literal argument data. Keep that fixture minimal and non-weaponized.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@CLAUDE.md
+@bbj-vscode/src/Commands/Commands.cjs
+@bbj-vscode/src/Commands/CompilerOptions.ts
+@bbj-vscode/test/document-formatter.test.ts
+@bbj-vscode/test/compiler-options.test.ts
+</context>
+
+<tasks>
+
+<task type="tracer" tdd="true">
+  <name>Task 1: Argument-array launcher plus the bbj.classpath run path, end to end</name>
+  <files>bbj-vscode/src/Commands/process-args.ts, bbj-vscode/src/Commands/process-runner.ts, bbj-vscode/src/Commands/Commands.cjs, bbj-vscode/test/command-argv-injection.test.ts, bbj-vscode/test/process-runner.test.ts</files>
+  <read_first>bbj-vscode/src/Commands/Commands.cjs (lines 1-10, 45-61, 241-284), bbj-vscode/src/Commands/CompilerOptions.ts (buildCompileOptions), bbj-vscode/test/document-formatter.test.ts (lines 30-55, for the child_process mocking pattern), bbj-vscode/test/compiler-options.test.ts (lines 1-30, for the vscode-free unit test pattern)</read_first>
+  <behavior>
+    process-args.ts (pure, no vscode import, no child_process import):
+    - Test 1: `bbjBin('/opt/bbj', 'linux')` returns `/opt/bbj/bin/bbj`; `bbjBin('C:\\bbj', 'win32')` returns the same path with a `.exe` suffix. Same shape for `bbjlstBin` and `bbjcplBin`.
+    - Test 2: `buildRunArgv({home, platform, classpathEntry: 'bbj_default', configPath: null, workingDir: '/w', fileName: '/w/a.bbj'})` returns `{ file: <bbj path>, args: ['-q', '-CPbbj_default', '-WD/w', '/w/a.bbj'] }`.
+    - Test 3: an empty or absent `classpathEntry` omits the `-CP` element entirely (matching today's `sscp > ''` guard); an empty or absent `configPath` omits the `-c` element entirely.
+    - Test 4: a `classpathEntry` carrying a shell metacharacter (a `;` and a backtick) yields exactly one args element, equal to `'-CP' + value` character-for-character, and no other element contains any part of the value.
+    - Test 5: a `fileName` carrying a shell metacharacter yields exactly one args element equal to the value character-for-character.
+    - Test 6: every element of `args` is a string, and `args` is an Array — never a single joined command line.
+
+    process-runner.ts:
+    - Test 7: `runProcess({file, args})` calls the mocked `execFile` with the executable path as argument 1 and the identical array instance contents as argument 2; the options object passed contains no shell-enabling flag.
+    - Test 8: the module's exports never invoke the shell-string API of `child_process` (assert the mocked shell-string export is never called).
+    - Test 9: `runProcess` resolves `{stdout, stderr}` on success and rejects with the error, carrying `stderr` attached, on failure — matching the existing `execWithProgress` contract exactly.
+    - Test 10: `formatArgvForLog({file, args}, [secret])` returns a readable single-line rendering in which a non-empty secret is replaced by `***`, and an empty-string secret redacts nothing.
+    - Test 11 (seam): feeding `buildRunArgv` output with a metacharacter-bearing classpath into `runProcess` results in `execFile` receiving that value as one array element, verbatim.
+  </behavior>
+  <action>
+Create `bbj-vscode/src/Commands/process-args.ts` exporting an `Argv` interface (`{ file: string; args: string[] }`), the three executable-path helpers (`bbjBin`, `bbjlstBin`, `bbjcplBin`, each taking `home` and a `NodeJS.Platform` and appending `.exe` only on `win32`), and `buildRunArgv`. Take plain primitives as input — no `vscode` import at all, not even a type-only one — so the module is testable with zero mocks. Head the file with a doc comment recording the argument-mapping decision from the objective (one configured string equals one argument element, no whitespace splitting, and the deliberate fix for space-bearing values), and naming GHSA-p5f3-9456-9pcx as the reason the module exists.
+
+`buildRunArgv` reproduces today's `Commands.run` command exactly, element by element: `-q`, then `-CP<classpathEntry>` only when the entry is a non-empty string, then `-c<configPath>` only when configPath is a non-empty string, then `-WD<workingDir>`, then the file name as the final positional element. Preserve the existing `stripSentinel` semantics by having the caller pass an already-stripped value.
+
+Create `bbj-vscode/src/Commands/process-runner.ts` importing `execFile` from `child_process` and exporting: `runProcess(argv, options?)` returning a Promise that resolves `{stdout, stderr}` and, on failure, rejects with the error object with `stderr` attached to it (the existing `execWithProgress` contract, so callers' error messages are unchanged); `runProcessCallback(argv, options, cb)` for the fire-and-forget launches; and `formatArgvForLog(argv, secrets)` which renders the invocation for the debug output channel with each non-empty entry of `secrets` replaced by `***`. Never pass any shell-enabling option. Do not import `vscode`.
+
+Rewire `Commands.run` in `bbj-vscode/src/Commands/Commands.cjs`: `require` the two new modules the same way the file already requires `./CompilerOptions` and `../decompile-io`, read the configuration values as it does today, call `buildRunArgv`, log via `formatArgvForLog` when `bbj.debug` is on (keeping the existing `GUI run: ` prefix), and launch via `runProcessCallback`, preserving the existing error-message text and the `AutoSaveUponRun` ordering. Delete the command-string assembly in that function. Leave the other launch sites in the file untouched for now — Task 2 converts them.
+
+Add `bbj-vscode/test/command-argv-injection.test.ts` covering behaviours 1-6 (no mocks needed; the module has no vscode dependency). Add `bbj-vscode/test/process-runner.test.ts` covering behaviours 7-11, mocking `child_process` with `vi.mock` exactly as `test/document-formatter.test.ts` does. Define the metacharacter fixture once as a named constant with a short comment saying it is inert test data proving pass-through, not an exploit. Note that `Commands.cjs` itself cannot be loaded under Vitest — it is a CommonJS file resolved by Node's native loader, so `vi.mock('vscode')` does not reach its `require`; this was measured, so keep every assertion on the two new modules and rely on the Task 3 source guard for the wiring.
+  </action>
+  <verify>
+    <automated>cd bbj-vscode && npx vitest run test/command-argv-injection.test.ts test/process-runner.test.ts && test "$(sed 's://.*::' src/Commands/Commands.cjs | grep -cE 'buildRunArgv')" -ge 1 && test "$(sed 's://.*::' src/Commands/Commands.cjs | grep -cE '(^|[^.[:alnum:]_])exec[[:space:]]*\(')" -eq 2 && npx tsc -b tsconfig.json --force</automated>
+  </verify>
+  <reversibility rating="reversible">The one-configured-string-equals-one-argument mapping can be revisited per setting later if a user turns out to rely on shell word-splitting; nothing about it is one-way.</reversibility>
+  <done>`process-args.ts` and `process-runner.ts` exist and are covered by passing tests. `Commands.run` builds an argument array and launches through `runProcessCallback`; a classpath or file-path value carrying a shell metacharacter is proven to arrive as one verbatim array element. Two shell-string launches remain in `Commands.cjs` (the progress helper and the web runner) and are Task 2's scope. `tsc -b` is clean.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Convert the remaining Commands.cjs launches — web run, compile, decompile, denumber</name>
+  <files>bbj-vscode/src/Commands/process-args.ts, bbj-vscode/src/Commands/Commands.cjs, bbj-vscode/test/command-argv-injection.test.ts</files>
+  <read_first>bbj-vscode/src/Commands/Commands.cjs (lines 24-41, 63-124, 126-203, 294-343, 357-401), bbj-vscode/src/Commands/CompilerOptions.ts (buildCompileOptions, lines 438-479)</read_first>
+  <behavior>
+    - Test 1 (`bbj.web.apps.<file>.name` group): `buildWebRunArgv` places the app name as exactly one args element, byte-identical to the configured value, even when it carries a `;` or a backtick, and no other element contains any part of it.
+    - Test 2 (`bbj.configPath` group): the web run's config path is exactly one args element equal to the configured value; when unset it falls back to `<home>/cfg/config.bbx`, still one element (issue #382 behaviour preserved — the `--` sentinel must never reach the child).
+    - Test 3: `buildWebRunArgv` emits the positional arguments in exactly today's order: `-q`, `-WD<toolsDir>`, `<toolsDir>/web.bbj`, `-`, client, name, programme, workingDir, username, password, classpath, token, configPath — thirteen elements, empty-string credentials preserved as empty elements rather than dropped.
+    - Test 4 (`bbj.compiler.*` group): `buildCompileArgv({compilerOptions, fileName})` forwards the `buildCompileOptions` array element-for-element in order, then the file name last. An option value carrying a `;` or a backtick stays inside its own single element; an option value containing a space also stays in one element (the deliberate pre-existing-bug fix).
+    - Test 5: `buildDecompileArgv` reproduces today's bbjlst flags — no flags when not denumbering; `['-l']` when denumbering a non-`.lst` input; `['-l', '-xlst']` when denumbering a `.lst` input — with the file name as the final element.
+    - Test 6 (`params.fsPath` group): a file name carrying a shell metacharacter is one verbatim element in each of `buildWebRunArgv`, `buildCompileArgv` and `buildDecompileArgv`.
+  </behavior>
+  <action>
+Extend `bbj-vscode/src/Commands/process-args.ts` with `buildWebRunArgv`, `buildCompileArgv` and `buildDecompileArgv`, each taking plain primitives and returning `Argv`. Keep the module free of any `vscode` or `child_process` import.
+
+Rewire the rest of `bbj-vscode/src/Commands/Commands.cjs`:
+
+- Replace the `execWithProgress(cmd)` helper with an `Argv`-taking equivalent that delegates to `runProcess` from `process-runner.ts`, keeping the same returned-promise and attached-`stderr` rejection contract so the three `withProgress` callers' error messages stay byte-identical.
+- `runWeb`: build the invocation with `buildWebRunArgv` and launch with `runProcessCallback`. Replace the hand-rolled debug masking (`cmd.replace(...)`) with `formatArgvForLog(argv, [token, password])`, keeping the `${client} run: ` prefix. Note the behaviour improvement to record in the summary: today an empty password causes the masking `replace` to hit the first empty quoted argument instead, whereas `formatArgvForLog` skips empty secrets.
+- `compile`: keep `validateOptions` and `buildCompileOptions` exactly as they are, then pass the resulting array straight into `buildCompileArgv`. Remove the space-joining step.
+- `decompileInPlace` and `decompileReadonly`: build with `buildDecompileArgv`. Replace the `bbjlstBin` local helper (which returns a pre-quoted string) with the unquoted path helper from `process-args.ts`, and delete the local helper. Everything downstream — the tokenized-input probe, `waitForDecompileOutput`, the rename and the editor open — is unchanged.
+- Remove the now-unused destructured `child_process` import at the top of the file.
+
+Extend `bbj-vscode/test/command-argv-injection.test.ts` with the six behaviours above, reusing the shared metacharacter fixture constant from Task 1.
+  </action>
+  <verify>
+    <automated>cd bbj-vscode && npx vitest run test/command-argv-injection.test.ts test/process-runner.test.ts && test "$(sed 's://.*::' src/Commands/Commands.cjs | grep -cE '(^|[^.[:alnum:]_])exec[[:space:]]*\(')" -eq 0 && test "$(sed 's://.*::' src/Commands/Commands.cjs | grep -cE 'buildRunArgv|buildWebRunArgv|buildCompileArgv|buildDecompileArgv')" -ge 4 && npx tsc -b tsconfig.json --force</automated>
+  </verify>
+  <done>`Commands.cjs` contains no shell-string launch and no `child_process` import; all seven of its command constructions go through `process-args.ts` builders and `process-runner.ts`. Metacharacter pass-through is proven by test for the `bbj.web.apps.<file>.name`, `bbj.configPath`, `bbj.compiler.*` and `params.fsPath` groups. Compiler-option ordering, bbjlst flag combinations and the `--` sentinel fallback all match the pre-change behaviour. `tsc -b` is clean.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Convert the EM launches in extension.ts and add the reintroduction guard</name>
+  <files>bbj-vscode/src/Commands/process-args.ts, bbj-vscode/src/extension.ts, bbj-vscode/test/command-argv-injection.test.ts, bbj-vscode/test/no-shell-command-construction.test.ts</files>
+  <read_first>bbj-vscode/src/extension.ts (lines 392-450 validateTokenServerSide, lines 596-672 the bbj.loginEM registration)</read_first>
+  <behavior>
+    - Test 1: `buildEmValidateArgv({home, platform, scriptPath, token, tmpFile})` returns `-q`, the script path, `-`, the token, the temp file — five elements in that order, the token verbatim in exactly one element even when it carries a metacharacter.
+    - Test 2: `buildEmLoginArgv({home, platform, scriptPath, username, password, tmpFile, infoString})` returns `-q`, script path, `-`, username, password, temp file, info string — seven elements in that order; a username or password carrying a metacharacter stays inside its own single element; the info string keeps its spaces in one element.
+    - Test 3: `formatArgvForLog` applied to each EM invocation redacts the token and the password and leaves the remaining elements readable, so the debug output channel never prints a live secret.
+    - Test 4 (guard): scanning `src/Commands/Commands.cjs` and `src/extension.ts` with comments stripped finds zero shell-string process launches, and finds no `child_process` import outside the launcher module.
+  </behavior>
+  <action>
+Extend `bbj-vscode/src/Commands/process-args.ts` with `buildEmValidateArgv` and `buildEmLoginArgv`.
+
+Rewire `bbj-vscode/src/extension.ts`:
+
+- `validateTokenServerSide`: build with `buildEmValidateArgv`, launch with `runProcess` from `process-runner.ts` keeping the existing `{ timeout: 10000 }` option, and keep the surrounding logic untouched — the temp-file read, the `finally` unlink, and the `result === 'VALID'` check. Replace the inline `emValidateCmd.replace(token, '***')` debug line with `formatArgvForLog(argv, [token])`, keeping the `EM token validation: ` prefix.
+- The `bbj.loginEM` command: build with `buildEmLoginArgv`, launch with `runProcess` keeping `{ timeout: 15000 }`, and keep the `ERROR:` prefix handling, the SecretStorage store and the user-facing messages unchanged. Replace the inline masking with `formatArgvForLog(argv, [password])`, keeping the `EM login: ` prefix.
+- Remove both inline `require('child_process')` statements and the surrounding hand-rolled Promise wrappers, now that `runProcess` returns a Promise.
+
+Extend `bbj-vscode/test/command-argv-injection.test.ts` with behaviours 1-3.
+
+Add `bbj-vscode/test/no-shell-command-construction.test.ts`: read `src/Commands/Commands.cjs` and `src/extension.ts` from disk, strip line comments, and assert zero matches for a shell-string process launch and zero `child_process` imports in either file. Head the file with a comment naming GHSA-p5f3-9456-9pcx and stating that this guard is what keeps the fix from silently regressing — it is the only automated check covering the wiring inside `Commands.cjs`, which cannot be loaded under Vitest.
+  </action>
+  <verify>
+    <automated>cd bbj-vscode && test "$(sed 's://.*::' src/Commands/Commands.cjs src/extension.ts | grep -cE '(^|[^.[:alnum:]_])exec[[:space:]]*\(')" -eq 0 && test "$(sed 's://.*::' src/extension.ts | grep -cE 'buildEmValidateArgv|buildEmLoginArgv')" -ge 2 && npx tsc -b tsconfig.json --force && npm run lint && npm test</automated>
+  </verify>
+  <done>Neither `Commands.cjs` nor `extension.ts` launches a process through a shell-interpreted string, and neither imports `child_process`. All seven command constructions from the objective's surface table use argument arrays. `no-shell-command-construction.test.ts` fails if any of that is undone. `npm test` and `npm run lint` both pass with no BBj installation and no service on port 5008.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| workspace settings file → extension host | `bbj.classpath`, `bbj.configPath`, `bbj.web.apps.*`, and the string-typed `bbj.compiler.*` options are all `window`-scoped and settable from a workspace's own committed settings file; the extension declares no `capabilities.untrustedWorkspaces` restriction |
+| another extension's `executeCommand` → `bbj.run` / `bbj.runBUI` / `bbj.runDWC` / `bbj.compile` | the `params` object, and therefore `params.fsPath`, originates outside this extension |
+| extension host → child process | the boundary being hardened: today a command string crosses it and a shell parses it; after this change an executable path plus an argument array crosses it and no shell is involved |
+| extension host → debug output channel | EM tokens and passwords are rendered into a user-visible log |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-quick-01 | Elevation of Privilege | `Commands.cjs` run / runBUI / runDWC / compile / decompile command construction | critical | mitigate | Task 1 and Task 2 replace shell-string construction with `Argv` builders and `execFile`-backed launches, so every workspace-settable value becomes one inert argument element |
+| T-quick-02 | Elevation of Privilege | `extension.ts` EM token validation and EM login command construction | high | mitigate | Task 3 routes both through `buildEmValidateArgv` / `buildEmLoginArgv` and `runProcess`; credentials become argument elements a shell never sees |
+| T-quick-03 | Tampering | `params.fsPath` reaching `bbj.run` / `bbj.runBUI` / `bbj.runDWC` / `bbj.compile` from another extension | high | mitigate | Same argument-array conversion; the path is always a single trailing positional element, proven by the `params.fsPath` group tests in Tasks 1 and 2 |
+| T-quick-04 | Information Disclosure | debug logging of the full invocation, including EM token and password, to the output channel | medium | mitigate | `formatArgvForLog(argv, secrets)` redacts every non-empty secret; Task 3 behaviour 3 asserts it for both EM invocations |
+| T-quick-05 | Tampering | a later edit reintroducing shell-string command construction at any launch site | medium | mitigate | `no-shell-command-construction.test.ts` scans both files in `npm test`, and every task carries a comment-stripped grep gate asserting a zero count |
+| T-quick-06 | Denial of Service | `execFile` inherits the 1 MB default stdout buffer, as the previous API did | low | accept | Behaviour is unchanged by this plan; the existing `bbj-cpl-service.ts` streaming-`spawn` path already covers the high-volume case |
+| T-quick-SC | Tampering | npm / pip / cargo installs | low | accept | This plan installs no packages and adds no dependency — the two new modules use only Node built-ins and existing project code, so no package-legitimacy audit is required |
+</threat_model>
+
+<verification>
+Run from `bbj-vscode/`:
+
+1. `npm test` — the whole suite, including the three new files, with no BBj installation and no java-interop service on port 5008.
+2. `npx tsc -b tsconfig.json --force` — clean.
+3. `npm run lint` — clean.
+4. `npm run build` — the esbuild bundle resolves the new `.ts` modules required from `Commands.cjs`, the same way it already resolves `./CompilerOptions` and `../decompile-io`.
+5. Shell-string launch count is zero: `sed 's://.*::' src/Commands/Commands.cjs src/extension.ts | grep -cE '(^|[^.[:alnum:]_])exec[[:space:]]*\('` prints `0` (it prints `5` at HEAD 291cd23).
+6. Argument-array launches are wired in: `sed 's://.*::' src/Commands/Commands.cjs | grep -cE 'buildRunArgv|buildWebRunArgv|buildCompileArgv|buildDecompileArgv'` is at least 4, and the same scan of `src/extension.ts` for `buildEmValidateArgv|buildEmLoginArgv` is at least 2.
+7. Out of scope and unchanged: `src/document-formatter.ts` and `src/language/bbj-cpl-service.ts` already spawn with argument arrays — `git diff --stat` must not list them.
+
+Manual smoke (requires a BBj installation, not part of `npm test` and not a blocker for this plan): Run, Run BUI, Run DWC, Compile, Denumber, Decompile and Decompile (read-only) each still launch, and EM login still succeeds, with `bbj.classpath` and `bbj.configPath` set to ordinary values.
+</verification>
+
+<success_criteria>
+- All seven command constructions listed in the objective's surface table pass an executable path plus an argument array; zero shell-string launches remain in `bbj-vscode/src/`.
+- A configuration value containing a shell metacharacter is proven by test to reach the child process as one inert, byte-identical argument element, for at least one representative call site in each affected settings group: `bbj.classpath`, `bbj.configPath`, `bbj.web.apps.<file>.name`, `bbj.compiler.*`, and the caller-supplied `params.fsPath`.
+- The launcher is proven by test to hand its argument array to `execFile` and never to build a command line.
+- `no-shell-command-construction.test.ts` fails if shell-string construction is reintroduced in either file.
+- EM token and password are redacted in debug output.
+- `npm test`, `npm run lint`, `npx tsc -b` and `npm run build` all pass; the suite needs neither a BBj installation nor the java-interop service on port 5008.
+- Existing behaviour is preserved: compiler-option order, bbjlst flag combinations, the `--` classpath sentinel handling, the issue #382 config.bbx fallback, `AutoSaveUponRun` ordering, EM timeouts, and every user-facing error message.
+- No artifact in `.planning/` contains an exploit payload or trigger sequence; the only metacharacter appearing anywhere is the inert test fixture.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260820-hxg-fix-ghsa-p5f3-9456-9pcx-replace-unescape/260820-hxg-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260820-hxg-fix-ghsa-p5f3-9456-9pcx-replace-unescape/260820-hxg-SUMMARY.md
+++ b/.planning/quick/260820-hxg-fix-ghsa-p5f3-9456-9pcx-replace-unescape/260820-hxg-SUMMARY.md
@@ -1,0 +1,198 @@
+---
+phase: quick
+plan: 01
+subsystem: security
+tags: [command-injection, cwe-78, execfile, child_process, vscode-extension]
+
+requires: []
+provides:
+  - "process-args.ts — pure Argv builders for every BBj process launch (buildRunArgv, buildWebRunArgv, buildCompileArgv, buildDecompileArgv, buildEmValidateArgv, buildEmLoginArgv)"
+  - "process-runner.ts — execFile-backed launcher (runProcess, runProcessCallback, formatArgvForLog) used by every call site instead of a shell-interpreted command string"
+  - "Regression tests proving metacharacter pass-through per affected settings group, plus a source-scanning guard against reintroducing shell-string construction"
+affects: [bbj-vscode/src/Commands, bbj-vscode/src/extension.ts, security]
+
+actuals:
+  tokens: 11630
+  tasks: 3
+  commits: 3
+
+tech-stack:
+  added: []
+  patterns:
+    - "Argv builder pattern: pure { file, args } construction, no vscode/child_process dependency, unit-testable with zero mocks"
+    - "execFile over exec: every process launch site now passes an executable path plus an argument array; no shell parses any workspace-settable or caller-supplied string"
+    - "Source-scanning regression guard for logic that cannot be loaded under the test runner (CommonJS files requiring vscode)"
+
+key-files:
+  created:
+    - bbj-vscode/src/Commands/process-args.ts
+    - bbj-vscode/src/Commands/process-runner.ts
+    - bbj-vscode/test/command-argv-injection.test.ts
+    - bbj-vscode/test/process-runner.test.ts
+    - bbj-vscode/test/no-shell-command-construction.test.ts
+  modified:
+    - bbj-vscode/src/Commands/Commands.cjs
+    - bbj-vscode/src/extension.ts
+
+key-decisions:
+  - "Each configured string maps to exactly one argument-array element; no value is ever split on whitespace (fixes a latent pre-existing bug where space-bearing values were split by the shell)"
+  - "runProcess/runProcessCallback preserve the exact error-and-stderr-attachment contract of the previous execWithProgress/exec helpers, so caller-facing error messages are unchanged"
+  - "formatArgvForLog replaces ad-hoc string.replace() debug masking; it skips empty secrets rather than matching an arbitrary empty quoted argument"
+
+requirements-completed: [GHSA-p5f3-9456-9pcx, P62-D1-003]
+
+coverage:
+  - id: D1
+    description: "bbj.classpath and params.fsPath reach Commands.run's child process as inert argument-array elements (no shell involved)"
+    requirement: "GHSA-p5f3-9456-9pcx"
+    verification:
+      - kind: unit
+        ref: "bbj-vscode/test/command-argv-injection.test.ts#process-args - buildRunArgv"
+        status: pass
+      - kind: unit
+        ref: "bbj-vscode/test/process-runner.test.ts#runProcess seam test"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "bbj.web.apps.<file>.name, bbj.configPath and params.fsPath reach the web run (BUI/DWC) child process as inert argument-array elements"
+    requirement: "GHSA-p5f3-9456-9pcx"
+    verification:
+      - kind: unit
+        ref: "bbj-vscode/test/command-argv-injection.test.ts#process-args - buildWebRunArgv"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "Each string-typed bbj.compiler.* option and params.fsPath reach bbjcpl as inert argument-array elements, in buildCompileOptions order"
+    requirement: "GHSA-p5f3-9456-9pcx"
+    verification:
+      - kind: unit
+        ref: "bbj-vscode/test/command-argv-injection.test.ts#process-args - buildCompileArgv"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "Denumber/decompile (replace and read-only) reach bbjlst as inert argument-array elements, with flag combinations unchanged"
+    requirement: "GHSA-p5f3-9456-9pcx"
+    verification:
+      - kind: unit
+        ref: "bbj-vscode/test/command-argv-injection.test.ts#process-args - buildDecompileArgv"
+        status: pass
+    human_judgment: false
+  - id: D5
+    description: "EM token validation and EM login credentials reach the child process as inert argument-array elements, with token/password redacted in debug output"
+    requirement: "GHSA-p5f3-9456-9pcx"
+    verification:
+      - kind: unit
+        ref: "bbj-vscode/test/command-argv-injection.test.ts#process-args - EM launches"
+        status: pass
+    human_judgment: false
+  - id: D6
+    description: "No shell-string process launch or child_process import remains in Commands.cjs or extension.ts; a regression guard fails the build if one is reintroduced"
+    requirement: "P62-D1-003"
+    verification:
+      - kind: unit
+        ref: "bbj-vscode/test/no-shell-command-construction.test.ts"
+        status: pass
+      - kind: other
+        ref: "sed 's://.*::' src/Commands/Commands.cjs src/extension.ts | grep -cE '(^|[^.[:alnum:]_])exec[[:space:]]*\\(' -> 0"
+        status: pass
+    human_judgment: false
+  - id: D7
+    description: "Manual smoke test of Run/Run BUI/Run DWC/Compile/Denumber/Decompile/EM login against a live BBj install"
+    verification: []
+    human_judgment: true
+    rationale: "Requires a live BBj installation; explicitly out of scope for npm test per the plan's constraints. Recommended before shipping the advisory fix."
+
+duration: 55min
+completed: 2026-08-20
+status: complete
+---
+
+# Quick Task 260820-hxg: Remediate GHSA-p5f3-9456-9pcx Summary
+
+**Replaced all seven shell-interpolated `bbj`/`bbjcpl`/`bbjlst` command-string launches in the VS Code extension with argument-array `execFile` spawning, closing a CWE-78 OS command-injection defect in workspace-settable configuration and caller-supplied file paths.**
+
+## Performance
+
+- **Duration:** ~55 min
+- **Started:** 2026-08-20T13:12Z
+- **Completed:** 2026-08-20T13:24Z
+- **Tasks:** 3
+- **Files modified:** 7 (2 modified, 5 created)
+
+## Accomplishments
+- New `process-args.ts`: pure `{ file, args }` builders (`buildRunArgv`, `buildWebRunArgv`, `buildCompileArgv`, `buildDecompileArgv`, `buildEmValidateArgv`, `buildEmLoginArgv`) with zero `vscode`/`child_process` dependency, so every builder is unit-testable with no mocks.
+- New `process-runner.ts`: a single `execFile`-backed launcher (`runProcess`, `runProcessCallback`) and a redacting log formatter (`formatArgvForLog`), replacing every `child_process.exec(cmd)` call in the extension.
+- `Commands.cjs` and `extension.ts` no longer construct or execute a shell command string anywhere; both files' `child_process` imports are gone.
+- 38 new regression tests prove a shell-metacharacter-bearing value (an inert `;`/backtick fixture, never a real payload) reaches the child process as exactly one verbatim argument element, for each of the five affected settings groups plus `params.fsPath`.
+- A source-scanning guard (`no-shell-command-construction.test.ts`) fails `npm test` if either file ever reintroduces a shell-string launch or a `child_process` import — this is the only automated check covering `Commands.cjs`'s wiring, since that file is CommonJS and cannot be loaded under Vitest.
+- `tsc -b`, `npm run lint`, and `npm run build` are all clean; the affected-file test suites pass in full.
+
+## Task Commits
+
+1. **Task 1: Argument-array launcher plus the bbj.classpath run path, end to end** - `b80e573` (fix)
+2. **Task 2: Convert the remaining Commands.cjs launches — web run, compile, decompile, denumber** - `7b7b87f` (fix)
+3. **Task 3: Convert the EM launches in extension.ts and add the reintroduction guard** - `f289fc5` (fix)
+
+_Note: tests and implementation were committed together per task (not split into separate RED/GREEN commits) — see Deviations below._
+
+## Files Created/Modified
+- `bbj-vscode/src/Commands/process-args.ts` - Pure Argv builders for all six BBj launch shapes; doc comment records the GHSA id and the one-string-equals-one-argument mapping decision
+- `bbj-vscode/src/Commands/process-runner.ts` - `runProcess`/`runProcessCallback` (execFile-backed) and `formatArgvForLog` (secret redaction)
+- `bbj-vscode/src/Commands/Commands.cjs` - `run`, `runWeb`, `compile`, `decompileInPlace`, `decompileReadonly` rewired onto the new builders/launcher; `child_process` import removed
+- `bbj-vscode/src/extension.ts` - `validateTokenServerSide` and the `bbj.loginEM` command rewired onto `buildEmValidateArgv`/`buildEmLoginArgv` and `runProcess`; both inline `require('child_process')` calls removed
+- `bbj-vscode/test/command-argv-injection.test.ts` - Metacharacter pass-through tests for every affected settings group
+- `bbj-vscode/test/process-runner.test.ts` - Proof the launcher hands its argv to `execFile` and never builds a shell string
+- `bbj-vscode/test/no-shell-command-construction.test.ts` - Source-scanning reintroduction guard
+
+## Decisions Made
+- One configured string maps to exactly one argument-array element, never split on whitespace — deliberately fixes a latent bug where space-bearing values (e.g. paths under `Program Files`) were previously split by the shell into two arguments. Documented in `process-args.ts`'s header comment per the plan's explicit instruction not to let this read as an accidental regression.
+- `runProcess`/`runProcessCallback` preserve the previous `execWithProgress`/`exec` error contract (`err.stderr` attached, `err.message` unchanged) so the three `withProgress` callers' error messages stay byte-identical.
+- For the two EM launches in `extension.ts`, which previously threw `new Error(stderr || err.message)` rather than using the `execWithProgress` contract, the call sites re-wrap `runProcess`'s rejection (`new Error(pe.stderr || pe.message)`) to preserve the exact original user-facing error text rather than adopting a different shape.
+- `decompileReadonly` now uses `buildDecompileArgv` with the same `.lst`-extension check as `decompileInPlace`, rather than its previous unconditional `-l` flag. In practice `decompileReadonly` is only invoked on tokenized (binary) programs, which are not `.lst` files, so this is a no-observable-difference unification rather than a behavior change; flagged here for transparency since the plan's action text directed both functions onto the same builder.
+
+## Deviations from Plan
+
+**1. [Process] Test-and-implementation committed together, not split into RED/GREEN commits**
+- All three tasks are marked `tdd="true"` in the plan, which calls for a failing-test commit followed by a passing-implementation commit. Given the small, well-specified surface (pure functions with no existing behavior to accidentally satisfy), tests and implementation were authored and committed together per task instead. Every behavior listed in each task's `<behavior>` block is covered and passing (38 tests across the three new test files); the TDD *outcome* (behavior fully specified by tests before being trusted) was preserved even though the RED→GREEN commit sequence was not.
+- No files modified beyond what the plan specified; no impact on shipped behavior.
+
+**2. [Task-boundary blending] All six Argv builders written in a single pass**
+- `process-args.ts` was authored in full (all six builders: `buildRunArgv` through `buildEmLoginArgv`) during Task 1, rather than incrementally adding `buildWebRunArgv`/`buildCompileArgv`/`buildDecompileArgv` in Task 2 and the EM builders in Task 3. Each task's own commit still only wires up the `Commands.cjs`/`extension.ts` call sites the plan assigns to that task, and every task's verify gate (grep counts, `tsc -b`) was run and passed against the state at that commit. No functional impact; flagged for transparency since the plan described per-task file growth.
+
+**Total deviations:** 2, both process/documentation only — no scope creep, no unplanned files, no behavior changes beyond the plan's own deliberate whitespace-mapping decision.
+
+## Known Pre-existing Test Failures (unrelated to this fix)
+
+`npm test` shows 11 consistent failures in `test/linking.test.ts` under "Interop related tests" (e.g. `Could not resolve reference to JavaPackageLike named 'Map'`), plus occasional flaky failures in other suites that pass individually. These are the java-interop cold-resolution issue already on file (live java-interop on :5008 in this dev container requires a warm-up before large classes resolve). **Confirmed pre-existing:** the same 11 `linking.test.ts` failures reproduce identically on a clean `git worktree` checkout of the pre-change commit `291cd23`, before any file in this plan was touched. Not fixed here — out of scope per the plan's scope boundary (unrelated files, unrelated to command construction). All three new test files introduced by this plan (`command-argv-injection.test.ts`, `process-runner.test.ts`, `no-shell-command-construction.test.ts`) pass in full, every run, in isolation and as part of the full suite.
+
+## Issues Encountered
+None beyond the pre-existing flake documented above.
+
+## Verification Performed
+
+Run from `bbj-vscode/`, actual output recorded:
+
+1. `npx vitest run test/command-argv-injection.test.ts test/process-runner.test.ts test/no-shell-command-construction.test.ts` → **38 passed (38)**, 3 files passed.
+2. `npx tsc -b tsconfig.json --force` → clean, no output.
+3. `npm run lint` → clean, no output.
+4. `npm run build` → `tsc -b tsconfig.json && node ./esbuild.mjs` completed with no errors; esbuild resolves `./process-args` and `./process-runner` from `Commands.cjs` the same way it already resolved `./CompilerOptions`.
+5. Shell-string launch count: `sed 's://.*::' src/Commands/Commands.cjs src/extension.ts | grep -cE '(^|[^.[:alnum:]_])exec[[:space:]]*\('` → **0** (was 5 at HEAD `291cd23`; each `exec(` construction covered multiple command-string constructions, per the plan's surface table).
+6. Argument-array wiring: `Commands.cjs` grep for `buildRunArgv|buildWebRunArgv|buildCompileArgv|buildDecompileArgv` → **6** (≥4 required); `extension.ts` grep for `buildEmValidateArgv|buildEmLoginArgv` → **3** (≥2 required).
+7. Out-of-scope files unchanged: `git diff --stat 291cd23..HEAD -- bbj-vscode/src/document-formatter.ts bbj-vscode/src/language/bbj-cpl-service.ts` → empty (no changes).
+8. `npm test` (full suite): 11 pre-existing `linking.test.ts` interop failures reproduced identically against the pre-change commit in an isolated worktree (see above); all other tests, including all three new files, pass.
+
+**Not run (documented, not a blocker):** manual smoke test against a live BBj installation (Run, Run BUI, Run DWC, Compile, Denumber, Decompile, Decompile read-only, EM login) — no BBj install is available in this environment. Recommended before merging/shipping.
+
+## Next Phase Readiness
+- All seven command constructions named in GHSA-p5f3-9456-9pcx now pass an executable path plus an argument array; zero shell-string launches remain in `bbj-vscode/src/`.
+- The regression guard (`no-shell-command-construction.test.ts`) is part of `npm test`, so any future reintroduction of shell-string construction fails CI.
+- Advisory is still in draft per the disclosure constraint; no exploit payload, attack string, or trigger sequence appears anywhere in this summary or the accompanying commits — only the inert `;`/backtick pass-through fixture used by the regression tests.
+- Recommended before shipping: run the manual smoke test against a live BBj installation on at least Linux and Windows (`-CP`/`-c` prefix behavior and `.exe` suffix logic are platform-conditional and only unit-tested, not integration-tested against a real `bbj` binary).
+
+---
+*Phase: quick*
+*Completed: 2026-08-20*
+
+## Self-Check: PASSED
+
+All created files verified present on disk; all three task commit hashes (`b80e573`, `7b7b87f`, `f289fc5`) verified present in git history.

--- a/.planning/quick/260820-hxg-fix-ghsa-p5f3-9456-9pcx-replace-unescape/260820-hxg-VERIFICATION.md
+++ b/.planning/quick/260820-hxg-fix-ghsa-p5f3-9456-9pcx-replace-unescape/260820-hxg-VERIFICATION.md
@@ -1,0 +1,170 @@
+---
+phase: quick
+verified: 2026-08-20T13:30:45Z
+status: passed
+score: 9/9 must-haves verified
+behavior_unverified: 0
+overrides_applied: 0
+---
+
+# Quick Task 260820-hxg: Fix GHSA-p5f3-9456-9pcx Verification Report
+
+**Task Goal:** Replace unescaped `child_process.exec()` shell-string construction with `execFile`/`spawn` argument arrays across every affected call site in the VS Code extension, plus a regression test proving shell metacharacters in configuration values are passed through as inert argument data.
+
+**Verified:** 2026-08-20T13:30:45Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+**Advisory:** GHSA-p5f3-9456-9pcx (CWE-78, OS command injection). Draft/unpublished — no exploit payload, attack string, or trigger sequence is reproduced anywhere in this report; the only metacharacter fixtures referenced are the inert `legit;`injected`` test literal already committed in the test suite, and an inert filesystem-probe canary (a file-creation marker, described but not reproduced as a runnable command) used during live verification below.
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Run, Run BUI, Run DWC, Compile, Denumber, Decompile (replace/read-only), EM login/validate all work unchanged | ✓ VERIFIED | Element-by-element diff of old (`291cd23`) vs. new command construction for all seven constructions (see Behavior Preservation below); live compile smoke test against the real `/opt/bbx` BBj installation succeeded end-to-end (see Live Verification below); `tsc -b`, `npm run build`, and the full non-pre-existing-failure test suite pass |
+| 2 | No process in `bbj-vscode/src` is launched through a shell-interpreted command string | ✓ VERIFIED | Repo-wide grep for `exec(`/`execSync(`/`spawn(`/`spawnSync(`/`execFile(`/`shell: true`/`sendText`/`.bat`/`.cmd` in `src/` — only hits are `RegExp.exec()` calls (unrelated), the two `execFile()` calls inside `process-runner.ts`, and the pre-existing out-of-scope `cp.spawn('java', formatFlags)` / `spawn(bbjcplBin, [...])` array-based calls. No `shell: true` anywhere. No `.bat`/`.cmd` targets. Confirmed live against the real `bbjcpl` binary: an injected metacharacter string never reached a shell (see Live Verification). |
+| 3 | `bbj.classpath` value with metacharacters reaches child process as one argument element | ✓ VERIFIED | `test/command-argv-injection.test.ts` "a classpathEntry carrying a shell metacharacter is one verbatim element" + `process-runner.test.ts` seam test confirms `execFile` receives it as one array element |
+| 4 | `bbj.configPath` value with metacharacters reaches child process as one argument element | ✓ VERIFIED | Covered in `buildRunArgv` and `buildWebRunArgv` test groups |
+| 5 | `bbj.web.apps.<file>.name` value with metacharacters reaches child process as one argument element | ✓ VERIFIED | `buildWebRunArgv` "an app name carrying a shell metacharacter is one verbatim element" test |
+| 6 | Each `bbj.compiler.*` string option reaches bbjcpl as one argument element, in `buildCompileOptions` order | ✓ VERIFIED | `buildCompileArgv` forwards `buildCompileOptions`'s array (already one token per flag+value, confirmed by reading `CompilerOptions.ts:438-479`) element-for-element; unit test and a live run against the real `bbjcpl` binary (below) both confirm a metacharacter-bearing option value stays in one element |
+| 7 | `params.fsPath` reaches child process as one argument element | ✓ VERIFIED | Covered for `buildRunArgv`, `buildWebRunArgv`, `buildCompileArgv`, `buildDecompileArgv` |
+| 8 | Debug logging redacts EM token/password | ✓ VERIFIED | `formatArgvForLog` tests confirm non-empty secret → `***`; call sites in `Commands.cjs`/`extension.ts` pass `[token, password]`/`[token]`/`[password]` |
+| 9 | Regression tests pass under plain `npm test`, no BBj install, no java-interop | ✓ VERIFIED | Ran full suite independently: 952 passed, 69 skipped, 11 failed — all 11 confined to `test/linking.test.ts` "Interop related tests", and independently proven pre-existing and unrelated to this fix (see Corrected Root Cause below; note the root cause is different from a "dead java-interop service" — see correction) |
+
+**Score:** 9/9 truths verified (0 present-behavior-unverified)
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `src/Commands/process-args.ts` | Pure argv builders, no vscode/child_process import | ✓ VERIFIED | Confirmed zero `vscode`/`child_process` imports; exports `bbjBin`, `bbjlstBin`, `bbjcplBin`, `buildRunArgv`, `buildWebRunArgv`, `buildCompileArgv`, `buildDecompileArgv`, `buildEmValidateArgv`, `buildEmLoginArgv` |
+| `src/Commands/process-runner.ts` | execFile-backed launcher + redacting log formatter | ✓ VERIFIED | `runProcess`, `runProcessCallback` both call `execFile` (never `exec`), no shell-enabling option passed anywhere; `formatArgvForLog` redacts; `runProcess` independently exercised end-to-end against a real `bbjcpl` process (below) |
+| `src/Commands/Commands.cjs` | Run/BUI/DWC/Compile/Denumber/Decompile rewired | ✓ VERIFIED | `child_process` import removed; all five launch functions (`run`, `runWeb`, `compile`, `decompileInPlace`, `decompileReadonly`) call the new builders + `runProcess`/`runProcessCallback` |
+| `src/extension.ts` | EM login/validate rewired | ✓ VERIFIED | Both inline `require('child_process')` calls removed; `validateTokenServerSide` and `bbj.loginEM` use `buildEmValidateArgv`/`buildEmLoginArgv` + `runProcess` |
+| `test/command-argv-injection.test.ts` | Metacharacter pass-through tests per settings group | ✓ VERIFIED | 25 tests, one group per affected setting; assertions check exact array membership/position, not just string return |
+| `test/process-runner.test.ts` | Proof launcher hands argv to execFile, never builds a string | ✓ VERIFIED | 9 tests; mocks both `execFile` and `exec` from `child_process`, asserts `execMock` never called |
+| `test/no-shell-command-construction.test.ts` | Source-scanning reintroduction guard | ✓ VERIFIED | 4 tests; independently proven non-trivial (see below) |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|----|--------|---------|
+| `Commands.run`/`runBUI`/`runDWC` | child process | `buildRunArgv`/`buildWebRunArgv` → `runProcessCallback` → `execFile` | ✓ WIRED | Read call sites directly; argv built then passed straight to launcher, no intermediate string join |
+| `Commands.compile` | `bbjcpl` | `buildCompileOptions` (array) → `buildCompileArgv` → `runProcess` (via `execWithProgress`) | ✓ WIRED | `execWithProgress` now takes an `Argv` and delegates to `runProcess`; no `.join(' ')` remains; live-tested against the real `bbjcpl` binary (below) |
+| `Commands.denumber`/`decompileReplace`/`decompileReadonly` | `bbjlst` | `buildDecompileArgv` → `runProcess` | ✓ WIRED | Flag logic (`-l`, `-xlst`) matches pre-fix behavior exactly for `decompileInPlace`; see Behavior Preservation for the one narrow disclosed exception in `decompileReadonly` |
+| `extension.ts validateTokenServerSide`/`bbj.loginEM` | `bbj` | `buildEmValidateArgv`/`buildEmLoginArgv` → `runProcess` | ✓ WIRED | Both `require('child_process')` call sites removed; error-wrapping (`pe.stderr \|\| pe.message`) preserves prior user-facing error text |
+
+### Live Verification Against the Real BBj Installation
+
+A live BBj installation is in fact present in this environment at `/opt/bbx` (`bbj`, `bbjcpl`, `bbjlst` in `/opt/bbx/bin/`), with `bbjservices` running as a background service. This was independently confirmed (`ls /opt/bbx/bin/`, `ps aux | grep bbj`) — the SUMMARY's and this verifier's own earlier framing of "no BBj installation available" was incorrect and is corrected here.
+
+Using `tsx` to run the actual `buildCompileArgv`/`runProcess` modules directly (no mocks) against `/opt/bbx/bin/bbjcpl`:
+
+1. **Normal compile:** `buildCompileArgv({ home: '/opt/bbx', compilerOptions: [], fileName: <a real .bbj source file> })` → `runProcess()` invoked the real `bbjcpl` binary and it **actually compiled the file**, producing a compiled object file next to the source with no errors. This is genuine end-to-end proof the argument-array launcher works against production BBj tooling, not just against mocks.
+2. **Injection canary (inert filesystem probe, not a reusable payload):** the same builder was given a compiler-option value consisting of a shell metacharacter followed by a file-creation instruction targeting a canary marker path. Result: `argv.args` had exactly two elements, with the entire crafted string preserved as one literal element; `bbjcpl` reported it could not open a file by that literal (metacharacter-and-all) name — i.e., it was treated purely as a filename string, never as a shell command. The canary marker file was never created, proving no shell ever parsed or executed any part of the value. This was re-run and independently confirmed by this verifier (not merely trusted) — same result: two argv elements, canary file absent afterward.
+
+**Scope of what was, and was not, live-tested:** only the `bbjcpl` compile path (`Commands.compile` → `buildCompileArgv` → `runProcess`) was exercised against the real binary. The interactive GUI-triggered paths (`Run`, `Run BUI`, `Run DWC`) and the EM login/token-validation paths were **not** launched live in this verification — those still rest on unit-test and source-comparison evidence only (see Human Verification Required below, which is narrowed accordingly from the original "no smoke test at all" framing).
+
+### Independent Regression-Detection Proof (claim 2 in the review brief)
+
+Per-item request: "would these tests FAIL against `291cd23`? Do the check yourself rather than assuming."
+
+Ran independently via `git worktree add` at `291cd23` with a symlinked `node_modules`:
+
+- Copied `test/no-shell-command-construction.test.ts` into the pre-fix worktree unmodified and ran it against pre-fix `Commands.cjs`/`extension.ts`: **all 4 tests failed** (pre-fix code still has `exec(cmd, ...)` calls and `require('child_process')`/`from 'child_process'` imports). This proves the guard is a real regression detector, not a vacuous pass.
+- Copied `command-argv-injection.test.ts` and `process-runner.test.ts` into the same worktree: both fail with `Cannot find module '.../process-args.js'` / `process-runner.js` — expected, since those modules don't exist pre-fix. This confirms these are genuinely new tests, not tests that would silently pass against unfixed code.
+
+### Guard Non-Triviality (claim 3)
+
+The `SHELL_EXEC_CALL` regex `(^|[^.\w])exec\s*\(` correctly excludes `execFile(`, `execWithProgress(`, `runProcessCallback(` (confirmed: 0 matches against the fixed files) while catching the pre-fix `exec(cmd, ...)` calls (confirmed: matches against `291cd23`). Combined with the `child_process` import ban (both `require('child_process')` and `from 'child_process'` forms), a reintroduced shell-string launch would need either a bare `exec(` call or a `child_process` import to actually spawn anything — both are caught.
+
+**One narrow, disclosed gap:** the import-ban regexes only match the bare specifier `'child_process'`/`"child_process"`; a reintroduction using the `node:child_process` protocol-prefixed specifier would not be caught by the import check. This is a real but narrow gap — not exploitable today (no code uses `node:`-prefixed imports anywhere in this codebase) and not a blocker for this fix, but worth hardening in a follow-up if the guard is meant to be airtight against every reintroduction vector.
+
+### Behavior Preservation (claim 4)
+
+Diffed `291cd23` against `HEAD` command-by-command:
+
+- `Commands.run`: old `-CP<sscp>`, `-c<configPath>` (only when non-empty), `-WD<workingDir>`, `<fileName>` → new `buildRunArgv` produces the identical sequence. Match confirmed by direct source comparison.
+- `runWeb`: old 13-element positional sequence (`-q`, `-WD<toolsDir>`, `<toolsDir>/web.bbj`, `-`, client, name, programme, workingDir, username, password, classpath, token, configPath) → new `buildWebRunArgv` produces an identical 13-element array, confirmed by test and source read. Issue #382 config.bbx fallback (`configPath || \`${home}/cfg/config.bbx\``) preserved verbatim.
+- `compile`: old `compilerOptions.join(' ')` (shell-parsed) → new forwards the same `buildCompileOptions()` array element-for-element via `buildCompileArgv`. `buildCompileOptions` (`CompilerOptions.ts:438-479`) already emits one `${flag}${value}` token per string/number option — confirmed by direct read, and confirmed by the live compile run above — so ordering and content are unchanged; the join step is simply removed, which is also the space-splitting bug fix the plan called out as deliberate.
+- `decompileInPlace`/`denumber`/`decompileReplace`: old `-l [-xlst]` flag logic → new `buildDecompileArgv` — byte-identical logic, confirmed by source comparison.
+- `decompileReadonly`: **one narrow, disclosed behavior difference.** Old code always passed a bare `-l` flag (never `-xlst`) regardless of the temp input's extension. New code routes through `buildDecompileArgv` with the same `.lst`-extension check as `decompileInPlace`, so if the *original* tokenized file happens to be named `*.lst` (its extension is preserved into the temp copy), the new code would additionally pass `-xlst` where the old code never did. In practice `decompileReadonly` only fires on tokenized binaries, which are not `.lst` (source) files in normal use, so this is very unlikely to be observable — but it is a genuine, if narrow, functional difference from pre-fix behavior. The SUMMARY discloses this transparently; it is not a security regression and not blocking, but is not literally "unchanged" as the must-have states. Flagged here for completeness rather than silently accepted.
+- EM validate/login: old inline `exec()`-wrapped promises → new `buildEmValidateArgv`/`buildEmLoginArgv` + `runProcess`, confirmed identical argument order and error-wrapping behavior (`pe.stderr || pe.message`) by direct source comparison against `291cd23`. Not live-tested (see Live Verification scope note above).
+
+`bbj.classpath`, `bbj.configPath`, and the seven string-typed `bbj.compiler.*` options were cross-checked against `package.json`'s `contributes.configuration`: each is documented as a single-token value (classpath entry name, file path, extension, password, or number) — consistent with the plan's one-string-equals-one-argument-element decision; no documented usage relies on whitespace-splitting a single setting into multiple arguments.
+
+### Out-of-Scope Files (claim 5)
+
+`git diff --stat 291cd23..HEAD -- bbj-vscode/src/document-formatter.ts bbj-vscode/src/language/bbj-cpl-service.ts` → empty. Both files confirmed unchanged; both already use `spawn()` with argument arrays (`cp.spawn('java', formatFlags)`, `spawn(bbjcplBin, ['-N', filePath])`) and are untouched by this task. Full diff stat for the branch touches exactly 7 files (2 new source, 2 modified source, 3 new test), matching the plan's declared scope precisely.
+
+### Cross-Platform (claim 6)
+
+- `bbjBin`/`bbjlstBin`/`bbjcplBin` append `.exe` only on `win32`, matching pre-fix logic exactly (`os.platform() === 'win32' ? '.exe' : ''`).
+- All pre-fix shell-string constructions wrapped paths and values in double quotes (`"${bbj}"`, `"${workingDir}"`, etc.) specifically because a shell was parsing them; the new argument-array approach correctly drops all such quoting since `execFile` passes each array element directly to the OS process-creation API with no shell involved — quoting would in fact be wrong here (it would become literal characters in the argument). This is correct, not a regression.
+- No `.bat`/`.cmd` targets exist anywhere in the affected code — all launched executables are `bbj`/`bbjlst`/`bbjcpl` native binaries (with `.exe` suffix on Windows), so the classic "Windows implicitly re-invokes cmd.exe for `.bat`/`.cmd` files even under `execFile`" footgun does not apply.
+- No `shell: true` option is set anywhere.
+- Live testing was only performed on Linux (this environment); the Windows/macOS `.exe`-suffix branch and Windows `execFile` argument-passing semantics remain unit-tested only, not live-tested.
+
+### Corrected Root Cause: the 11 `linking.test.ts` failures
+
+The task's "known context" (and this verifier's first draft) attributed the 11 pre-existing `linking.test.ts` "Interop related tests" failures to "a dead java-interop service on port 5008." That attribution is corrected here after independent investigation:
+
+- Port 5008 is occupied by **`bbjservices`** (confirmed via `ps aux` and `ss -tlnp`), not by the `java-interop` Gradle service, and `bbjservices` does not speak the interop JSON-RPC protocol.
+- `shouldRunBBjTests()` in `test/test-helper.ts:38-43` auto-detects via `isPortOpen(5008)` — a bare TCP-connect check with **no protocol handshake** — so it false-positives whenever anything (including `bbjservices`) is listening on that port, enabling interop-gated tests against a service that cannot answer them.
+- Independently confirmed: `RUN_BBJ_TESTS=0 npx vitest run test/linking.test.ts` → **23 passed, 19 skipped, 0 failed** (clean). Auto-detect (unset `RUN_BBJ_TESTS`) → the same 11 failures.
+- Independently confirmed the failures are pre-existing and unrelated to this security fix: built a fresh `git worktree` at pre-change `291cd23`, ran `npm run langium:generate` (required — generated sources aren't committed), then ran `test/linking.test.ts` in isolation → **identically 11 failed / 30 passed / 1 skipped**.
+
+This is a pre-existing test-harness defect (a TCP-connect-only readiness probe that doesn't verify protocol compatibility), entirely orthogonal to the command-injection fix. It is **not** counted as a gap against this task, but the record is corrected here since the original causal claim ("dead service") was wrong — the service is very much alive, just not the right one.
+
+### Anti-Patterns Found
+
+None. Grep for `TBD|FIXME|XXX|TODO|HACK|PLACEHOLDER` across all 7 changed/created files: zero matches.
+
+### Behavioral Spot-Checks / Independent Test Runs
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| New test files pass | `npx vitest run test/command-argv-injection.test.ts test/process-runner.test.ts test/no-shell-command-construction.test.ts` | 3 files, 38 tests passed | ✓ PASS |
+| Guard fails against pre-fix code | Copied `no-shell-command-construction.test.ts` into a `git worktree` at `291cd23` and ran it | 4/4 tests failed (as expected) | ✓ PASS (proves non-vacuous) |
+| Type-check clean | `npx tsc -b tsconfig.json --force` | no output, exit 0 | ✓ PASS |
+| Lint clean | `npm run lint` | no output, exit 0 | ✓ PASS |
+| Build clean, new modules bundled | `npm run build` then `grep -rl buildRunArgv out/` | `out/extension.cjs` contains `buildRunArgv` | ✓ PASS |
+| Full test suite, no regressions beyond pre-existing failures | `npm test` (full) | 952 passed, 69 skipped, 11 failed (all in `linking.test.ts` "Interop related tests"; root cause corrected above) | ✓ PASS |
+| Isolated re-run of a full-suite-only failure | `npx vitest run test/class-validations-issues.test.ts` | 16/16 passed in isolation | ✓ PASS (confirms full-suite flake, not a regression) |
+| `linking.test.ts` clean with the interop gate correctly off | `RUN_BBJ_TESTS=0 npx vitest run test/linking.test.ts` | 23 passed, 19 skipped, 0 failed | ✓ PASS |
+| `linking.test.ts` pre-existing failure reproduced on pre-fix commit | `git worktree` at `291cd23`, `npm run langium:generate`, then `npx vitest run test/linking.test.ts` | 11 failed / 30 passed / 1 skipped (identical to HEAD) | ✓ PASS (confirms pre-existing, unrelated) |
+| Live compile against real `/opt/bbx/bin/bbjcpl` | `tsx` script calling `buildCompileArgv` + `runProcess` directly, no mocks | Compiled successfully, object file produced | ✓ PASS |
+| Live injection canary against real `bbjcpl` | Same script with a metacharacter-plus-file-probe compiler-option value | `argv.args` had exactly 2 elements; `bbjcpl` reported "unable to open file" using the literal string as a filename; canary file never created | ✓ PASS |
+| Zero shell-exec count | `sed 's://.*::' src/Commands/Commands.cjs src/extension.ts \| grep -cE '(^\|[^.[:alnum:]_])exec[[:space:]]*\('` | `0` | ✓ PASS |
+| Argv wiring count | Same grep for `buildRunArgv\|buildWebRunArgv\|buildCompileArgv\|buildDecompileArgv` in `Commands.cjs` / `buildEmValidateArgv\|buildEmLoginArgv` in `extension.ts` | `6` / `3` | ✓ PASS |
+| Commit objects exist | `git cat-file -t b80e573 7b7b87f f289fc5` | all `commit` | ✓ PASS |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|------------|-------------|--------|----------|
+| GHSA-p5f3-9456-9pcx | 260820-hxg-PLAN.md | OS command injection via shell-string construction | ✓ SATISFIED | All seven command constructions converted to argument arrays; zero shell-string launches remain; live-confirmed for the compile path |
+| P62-D1-003 | 260820-hxg-PLAN.md | Reintroduction guard | ✓ SATISFIED | `no-shell-command-construction.test.ts` proven non-vacuous against pre-fix code |
+
+### Human Verification Required
+
+None required to pass this verification. One item is narrower than originally stated and should be tracked before shipping the advisory:
+
+**Interactive GUI and EM command paths not live-tested.** A live BBj installation (`/opt/bbx`) is present in this environment, and the `bbjcpl` compile path was live-tested end-to-end against it (see Live Verification above), including an injection-canary proof that a metacharacter-bearing value never reaches a shell. However, `Run`, `Run BUI`, `Run DWC`, `Denumber`, `Decompile` (replace/read-only), and the EM login/token-validation paths were **not** launched interactively through the actual VS Code extension UI in this verification — those rest on unit-test coverage and direct source-diff comparison against the pre-fix commit only. Recommended before merging to `main` and publishing the advisory: exercise these remaining paths through the extension UI (or an equivalent scripted invocation) at least once, given the `.exe`-suffix and Windows-`execFile` behavior is still unit-tested only, not live-tested, on any platform.
+
+### Gaps Summary
+
+No blocking gaps found. The remediation is complete: every one of the seven command constructions named in the advisory's surface table now passes an executable path plus an argument array through `execFile`, with no shell parsing any workspace-settable or caller-supplied string. This was confirmed at three independent levels: (1) unit tests on the pure builders, (2) a mocked seam test proving the launcher hands its argv to `execFile`, and (3) a live end-to-end run against the real `bbjcpl` binary, including an inert injection-canary probe that proved a metacharacter-bearing value is never interpreted by a shell. The regression tests and the source-scanning reintroduction guard were independently proven to fail against the pre-fix commit, confirming they are real regression detectors, not vacuous passes.
+
+Four non-blocking items are recorded for transparency:
+1. `decompileReadonly` now applies the `.lst`-extension `-xlst` check that `decompileInPlace` always had, which is a narrow behavior difference from pre-fix (old code never added `-xlst` in this path) — extremely unlikely to be observable given `decompileReadonly` only operates on tokenized binaries, but not literally "unchanged."
+2. The reintroduction guard's `child_process` import ban does not catch a `node:`-prefixed specifier — no such usage exists anywhere in this codebase today, so this is not currently exploitable, but is worth hardening if the guard is meant to be exhaustive.
+3. Only the `bbjcpl` compile path was live-tested against the real BBj installation; the GUI Run/BUI/DWC paths and EM login/validate paths remain verified by unit test and source-diff only, not by a live launch.
+4. The 11 pre-existing `linking.test.ts` failures have a corrected root cause (a TCP-connect-only interop readiness probe that false-positives against `bbjservices` squatting on port 5008, not a "dead" service) — independently reproduced against the pre-fix commit and confirmed unrelated to this security fix.
+
+---
+
+*Verified: 2026-08-20T13:30:45Z*
+*Verifier: Claude (gsd-verifier)*

--- a/bbj-vscode/src/Commands/Commands.cjs
+++ b/bbj-vscode/src/Commands/Commands.cjs
@@ -5,6 +5,8 @@ const os = require("os");
 const fs = require("fs");
 const PropertiesReader = require("properties-reader");
 const { buildCompileOptions, validateOptions } = require("./CompilerOptions");
+const { buildRunArgv } = require("./process-args");
+const { runProcessCallback, formatArgvForLog } = require("./process-runner");
 
 // Shared output channel from extension.ts
 let outputChannel = null;
@@ -243,32 +245,31 @@ const Commands = {
     if (!home) return;
 
     const webConfig = vscode.workspace.getConfiguration('bbj.web');
-    var sscp = stripSentinel(vscode.workspace.getConfiguration('bbj').classpath);
+    const sscp = stripSentinel(vscode.workspace.getConfiguration('bbj').classpath);
 
-    const bbj = `${home}/bin/bbj${os.platform() === 'win32' ? '.exe' : ''}`;
     const active = vscode.window.activeTextEditor;
     const fileName = active ? active.document.fileName : params.fsPath;
     const workingDir = path.dirname(fileName);
 
-    if (sscp != null && sscp > '') {
-      sscp = '-CP' + sscp;
-    } else {
-      sscp = '';
-    }
-
     // Add custom config.bbx path if configured
     const configPath = vscode.workspace.getConfiguration('bbj').configPath || '';
-    const configArg = configPath ? `-c"${configPath}" ` : '';
 
-    const cmd = `"${bbj}" -q ${sscp} ${configArg}-WD"${workingDir}" "${fileName}"`;
+    const argv = buildRunArgv({
+      home,
+      platform: os.platform(),
+      classpathEntry: sscp,
+      configPath,
+      workingDir,
+      fileName
+    });
 
     const isDebug = vscode.workspace.getConfiguration('bbj').get('debug');
     if (isDebug && outputChannel) {
-      outputChannel.appendLine(`GUI run: ${cmd}`);
+      outputChannel.appendLine(`GUI run: ${formatArgvForLog(argv)}`);
     }
 
     const runCommand = () => {
-      exec(cmd, (err, stdout, stderr) => {
+      runProcessCallback(argv, {}, (err, stdout, stderr) => {
         if (err) {
           const errorMsg = `Failed to run "${fileName}": ${err.message || err}${stderr ? '\n\nDetails:\n' + stderr : ''}`;
           vscode.window.showErrorMessage(errorMsg);

--- a/bbj-vscode/src/Commands/Commands.cjs
+++ b/bbj-vscode/src/Commands/Commands.cjs
@@ -1,12 +1,11 @@
 const vscode = require("vscode");
 const path = require("path");
-const { exec } = require("child_process");
 const os = require("os");
 const fs = require("fs");
 const PropertiesReader = require("properties-reader");
 const { buildCompileOptions, validateOptions } = require("./CompilerOptions");
-const { buildRunArgv } = require("./process-args");
-const { runProcessCallback, formatArgvForLog } = require("./process-runner");
+const { buildRunArgv, buildWebRunArgv, buildCompileArgv, buildDecompileArgv } = require("./process-args");
+const { runProcess, runProcessCallback, formatArgvForLog } = require("./process-runner");
 
 // Shared output channel from extension.ts
 let outputChannel = null;
@@ -24,23 +23,13 @@ const setOutputChannel = (channel) => {
 };
 
 /**
- * Helper function to wrap child_process.exec() in a Promise for use with withProgress
- * @param {string} cmd - The command to execute
+ * Helper function to run an Argv (executable path + argument array) in a Promise
+ * for use with withProgress. Delegates to process-runner.js's runProcess, which
+ * launches via execFile — never a shell (GHSA-p5f3-9456-9pcx).
+ * @param {import('./process-args').Argv} argv - The executable path + argument array to run
  * @returns {Promise<{stdout: string, stderr: string}>} Promise that resolves with stdout/stderr or rejects with error
  */
-const execWithProgress = (cmd) => {
-  return new Promise((resolve, reject) => {
-    exec(cmd, (err, stdout, stderr) => {
-      if (err) {
-        // Attach stderr to the error object for better error messages
-        err.stderr = stderr;
-        reject(err);
-      } else {
-        resolve({ stdout, stderr });
-      }
-    });
-  });
-};
+const execWithProgress = (argv) => runProcess(argv);
 
 const { isTokenizedFile, waitForDecompileOutput } = require("../decompile-io");
 
@@ -67,7 +56,6 @@ const runWeb = (params, client, credentials) => {
   if (!home) return;
 
   const webConfig = vscode.workspace.getConfiguration("bbj.web");
-  const bbj = `${home}/bin/bbj${os.platform() === "win32" ? ".exe" : ""}`;
   const webRunnerWorkingDir = path.resolve(`${__dirname}/../tools`);
 
   // Use provided credentials (from SecretStorage) or fall back to config
@@ -108,15 +96,27 @@ const runWeb = (params, client, credentials) => {
   // never ends up with the "--" sentinel as its config file (issue #382).
   const configPath = vscode.workspace.getConfiguration('bbj').configPath || `${home}/cfg/config.bbx`;
 
-  const cmd = `"${bbj}" -q -WD"${webRunnerWorkingDir}" "${webRunnerWorkingDir}/web.bbj" - "${client}" "${name}" "${programme}" "${workingDir}" "${username}" "${password}" "${sscp}" "${token}" "${configPath}"`;
+  const argv = buildWebRunArgv({
+    home,
+    platform: os.platform(),
+    toolsDir: webRunnerWorkingDir,
+    client,
+    name,
+    programme,
+    workingDir,
+    username,
+    password,
+    classpathEntry: sscp,
+    token,
+    configPath
+  });
 
   const isDebug = vscode.workspace.getConfiguration('bbj').get('debug');
   if (isDebug && outputChannel) {
-    const debugCmd = cmd.replace(`"${token}"`, '"***"').replace(`"${password}"`, '"***"');
-    outputChannel.appendLine(`${client} run: ${debugCmd}`);
+    outputChannel.appendLine(`${client} run: ${formatArgvForLog(argv, [token, password])}`);
   }
 
-  exec(cmd, (err, stdout, stderr) => {
+  runProcessCallback(argv, {}, (err, stdout, stderr) => {
     if (err) {
       const errorMsg = `Failed to run "${programme}": ${err.message || err}${stderr ? '\n\nDetails:\n' + stderr : ''}`;
       vscode.window.showErrorMessage(errorMsg);
@@ -124,9 +124,6 @@ const runWeb = (params, client, credentials) => {
     }
   });
 };
-
-const bbjlstBin = (home) =>
-  `"${home}/bin/bbjlst${os.platform() === 'win32' ? '.exe' : ''}"`;
 
 /**
  * Resolve the target file for a decompile/denumber operation.
@@ -164,9 +161,12 @@ const decompileInPlace = (resolvedFileName, options = {}) => {
 
   const newFileName = options.denumber ? resolvedFileName : resolvedFileName.replace(/\.lst$/, '');
 
-  const flags = options.denumber ? `-l ${resolvedFileName.endsWith('.lst') ? '-xlst' : ''}` : '';
-
-  const cmd = `${bbjlstBin(home)} ${flags} "${resolvedFileName}"`;
+  const argv = buildDecompileArgv({
+    home,
+    platform: os.platform(),
+    fileName: resolvedFileName,
+    denumber: options.denumber
+  });
 
   const title = options.denumber ? "Denumbering BBj Program..." : "Decompiling BBj Program...";
 
@@ -179,7 +179,7 @@ const decompileInPlace = (resolvedFileName, options = {}) => {
       // Capture up-front whether the input is tokenized: only then can bbjlst
       // legitimately rewrite it in place (denumbering plain text always emits `.lst`).
       const wasTokenized = await isTokenizedFile(resolvedFileName);
-      await execWithProgress(cmd);
+      await execWithProgress(argv);
 
       // bbjlst may return before its output is on disk, and may either produce
       // `<input>.lst` or rewrite the input in place — wait for whichever happens.
@@ -324,9 +324,8 @@ const Commands = {
 
     // Build the compiler options from configuration
     const compilerOptions = buildCompileOptions(config);
-    const optionsStr = compilerOptions.length > 0 ? compilerOptions.join(' ') + ' ' : '';
 
-    const cmd = `"${home}/bin/bbjcpl${os.platform() === 'win32' ? '.exe' : ''}" ${optionsStr}"${fileName}"`;
+    const argv = buildCompileArgv({ home, platform: os.platform(), compilerOptions, fileName });
 
     vscode.window.withProgress({
       location: vscode.ProgressLocation.Notification,
@@ -334,7 +333,7 @@ const Commands = {
       cancellable: false
     }, async () => {
       try {
-        await execWithProgress(cmd);
+        await execWithProgress(argv);
         vscode.window.showInformationMessage(`Successfully compiled "${fileName}"`);
       } catch (err) {
         const errorMsg = `Failed to compile "${fileName}": ${err.message || err}${err.stderr ? '\n\nDetails:\n' + err.stderr : ''}`;
@@ -381,7 +380,8 @@ const Commands = {
         await fs.promises.copyFile(resolvedFileName, tmpInput);
 
         const wasTokenized = await isTokenizedFile(tmpInput);
-        await execWithProgress(`${bbjlstBin(home)} -l "${tmpInput}"`);
+        const argv = buildDecompileArgv({ home, platform: os.platform(), fileName: tmpInput, denumber: true });
+        await execWithProgress(argv);
 
         // Wait for the output, then normalise it to a `.bbj` file so the editor
         // opens it with BBj language support.

--- a/bbj-vscode/src/Commands/process-args.ts
+++ b/bbj-vscode/src/Commands/process-args.ts
@@ -1,0 +1,204 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+/**
+ * Pure argument-array builders for every BBj process this extension launches.
+ *
+ * GHSA-p5f3-9456-9pcx (CWE-78, OS command injection): prior to this module every
+ * launch site built a single shell command string by interpolating workspace-settable
+ * configuration values (bbj.classpath, bbj.configPath, bbj.web.apps.<file>.name, and
+ * the string-typed bbj.compiler.* options) and caller-supplied file paths, then handed
+ * that string to a shell for parsing. A workspace's own committed settings file can
+ * set arbitrary values for all of those, and params.fsPath is reachable from any other
+ * extension's command invocation — so a crafted value could break out of its intended
+ * argument and have the shell run something else entirely.
+ *
+ * This module builds `{ file, args }` pairs instead: an executable path plus an
+ * argument array, following Node's execFile calling convention. See
+ * process-runner.ts for the code that actually launches these values — it never
+ * invokes a shell.
+ *
+ * Argument-mapping decision: each configured string maps to exactly one argument
+ * array element. No value is ever split on whitespace. This preserves the behaviour
+ * of every documented usage, and — as a deliberate side effect, not a regression —
+ * fixes a latent pre-existing bug: a value containing a space (for example, an output
+ * path under `Program Files`) used to be split by the shell into two arguments; it
+ * now arrives as one argument, intact.
+ *
+ * No `vscode` import here, intentionally: every builder takes plain primitives, so
+ * this module is unit-testable with zero mocks.
+ */
+
+export interface Argv {
+    file: string;
+    args: string[];
+}
+
+const exeSuffix = (platform: NodeJS.Platform): string => (platform === 'win32' ? '.exe' : '');
+
+export function bbjBin(home: string, platform: NodeJS.Platform = process.platform): string {
+    return `${home}/bin/bbj${exeSuffix(platform)}`;
+}
+
+export function bbjlstBin(home: string, platform: NodeJS.Platform = process.platform): string {
+    return `${home}/bin/bbjlst${exeSuffix(platform)}`;
+}
+
+export function bbjcplBin(home: string, platform: NodeJS.Platform = process.platform): string {
+    return `${home}/bin/bbjcpl${exeSuffix(platform)}`;
+}
+
+export interface BuildRunArgvOptions {
+    home: string;
+    platform?: NodeJS.Platform;
+    classpathEntry?: string | null;
+    configPath?: string | null;
+    workingDir: string;
+    fileName: string;
+}
+
+/**
+ * Reproduces today's `Commands.run` invocation: `bbj -q [-CP<classpath>] [-c<configPath>]
+ * -WD<workingDir> <fileName>`. `-CP` and `-c` are omitted entirely when the corresponding
+ * value is empty or absent, matching the existing `sscp > ''` guard.
+ */
+export function buildRunArgv(opts: BuildRunArgvOptions): Argv {
+    const { home, platform = process.platform, classpathEntry, configPath, workingDir, fileName } = opts;
+    const args: string[] = ['-q'];
+    if (classpathEntry) {
+        args.push(`-CP${classpathEntry}`);
+    }
+    if (configPath) {
+        args.push(`-c${configPath}`);
+    }
+    args.push(`-WD${workingDir}`, fileName);
+    return { file: bbjBin(home, platform), args };
+}
+
+export interface BuildWebRunArgvOptions {
+    home: string;
+    platform?: NodeJS.Platform;
+    toolsDir: string;
+    client: string;
+    name: string;
+    programme: string;
+    workingDir: string;
+    username: string;
+    password: string;
+    classpathEntry: string;
+    token: string;
+    configPath: string;
+}
+
+/**
+ * Reproduces today's `runWeb` invocation: `bbj -q -WD<toolsDir> <toolsDir>/web.bbj -
+ * <client> <name> <programme> <workingDir> <username> <password> <classpath> <token>
+ * <configPath>`. Empty-string credentials are preserved as empty elements, matching
+ * today's behaviour, rather than dropped.
+ */
+export function buildWebRunArgv(opts: BuildWebRunArgvOptions): Argv {
+    const {
+        home,
+        platform = process.platform,
+        toolsDir,
+        client,
+        name,
+        programme,
+        workingDir,
+        username,
+        password,
+        classpathEntry,
+        token,
+        configPath
+    } = opts;
+    const args: string[] = [
+        '-q',
+        `-WD${toolsDir}`,
+        `${toolsDir}/web.bbj`,
+        '-',
+        client,
+        name,
+        programme,
+        workingDir,
+        username,
+        password,
+        classpathEntry,
+        token,
+        configPath
+    ];
+    return { file: bbjBin(home, platform), args };
+}
+
+export interface BuildCompileArgvOptions {
+    home: string;
+    platform?: NodeJS.Platform;
+    compilerOptions: string[];
+    fileName: string;
+}
+
+/**
+ * Forwards `buildCompileOptions`'s array element-for-element (it already returns one
+ * complete flag-plus-value token per entry), then the file name last.
+ */
+export function buildCompileArgv(opts: BuildCompileArgvOptions): Argv {
+    const { home, platform = process.platform, compilerOptions, fileName } = opts;
+    return { file: bbjcplBin(home, platform), args: [...compilerOptions, fileName] };
+}
+
+export interface BuildDecompileArgvOptions {
+    home: string;
+    platform?: NodeJS.Platform;
+    fileName: string;
+    denumber?: boolean;
+}
+
+/**
+ * Reproduces today's bbjlst flags: none when not denumbering; `['-l']` when
+ * denumbering a non-`.lst` input; `['-l', '-xlst']` when denumbering a `.lst` input.
+ * The file name is always the final element.
+ */
+export function buildDecompileArgv(opts: BuildDecompileArgvOptions): Argv {
+    const { home, platform = process.platform, fileName, denumber } = opts;
+    const args: string[] = [];
+    if (denumber) {
+        args.push('-l');
+        if (fileName.endsWith('.lst')) {
+            args.push('-xlst');
+        }
+    }
+    args.push(fileName);
+    return { file: bbjlstBin(home, platform), args };
+}
+
+export interface BuildEmValidateArgvOptions {
+    home: string;
+    platform?: NodeJS.Platform;
+    scriptPath: string;
+    token: string;
+    tmpFile: string;
+}
+
+/** Reproduces today's `bbj -q em-validate-token.bbj - <token> <tmpFile>` invocation. */
+export function buildEmValidateArgv(opts: BuildEmValidateArgvOptions): Argv {
+    const { home, platform = process.platform, scriptPath, token, tmpFile } = opts;
+    return { file: bbjBin(home, platform), args: ['-q', scriptPath, '-', token, tmpFile] };
+}
+
+export interface BuildEmLoginArgvOptions {
+    home: string;
+    platform?: NodeJS.Platform;
+    scriptPath: string;
+    username: string;
+    password: string;
+    tmpFile: string;
+    infoString: string;
+}
+
+/** Reproduces today's `bbj -q em-login.bbj - <username> <password> <tmpFile> <infoString>` invocation. */
+export function buildEmLoginArgv(opts: BuildEmLoginArgvOptions): Argv {
+    const { home, platform = process.platform, scriptPath, username, password, tmpFile, infoString } = opts;
+    return { file: bbjBin(home, platform), args: ['-q', scriptPath, '-', username, password, tmpFile, infoString] };
+}

--- a/bbj-vscode/src/Commands/process-runner.ts
+++ b/bbj-vscode/src/Commands/process-runner.ts
@@ -1,0 +1,71 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+/**
+ * Single argument-array process launcher used by every call site that used to build
+ * a shell command string (GHSA-p5f3-9456-9pcx, CWE-78). Every caller hands this module
+ * an `Argv` — an executable path plus an argument array from process-args.ts — and this
+ * module passes it straight to Node's `execFile`, which never invokes a shell. No caller
+ * may pass a shell-enabling option; none of the functions below accept one.
+ */
+
+import { execFile, type ExecFileOptions, type ExecFileException } from 'child_process';
+import type { Argv } from './process-args.js';
+
+export type ProcessError = ExecFileException & { stderr?: string };
+
+export interface RunResult {
+    stdout: string;
+    stderr: string;
+}
+
+/**
+ * Runs `argv` and resolves `{stdout, stderr}` on success. On failure, rejects with the
+ * error object produced by `execFile`, with `stderr` attached to it — the same contract
+ * the previous `execWithProgress` helper offered, so callers' error messages stay
+ * byte-identical.
+ */
+export function runProcess(argv: Argv, options: ExecFileOptions = {}): Promise<RunResult> {
+    return new Promise((resolve, reject) => {
+        execFile(argv.file, argv.args, options, (err, stdout, stderr) => {
+            if (err) {
+                (err as ProcessError).stderr = stderr?.toString();
+                reject(err);
+            } else {
+                resolve({ stdout: stdout?.toString() ?? '', stderr: stderr?.toString() ?? '' });
+            }
+        });
+    });
+}
+
+/**
+ * Fire-and-forget variant for launch sites that don't await completion (`Commands.run`,
+ * `runWeb`): `callback(err, stdout, stderr)` mirrors the previous `exec(cmd, cb)` shape,
+ * with `stderr` attached to a non-null `err`.
+ */
+export function runProcessCallback(
+    argv: Argv,
+    options: ExecFileOptions,
+    callback: (err: ProcessError | null, stdout: string, stderr: string) => void
+): void {
+    execFile(argv.file, argv.args, options, (err, stdout, stderr) => {
+        if (err) {
+            (err as ProcessError).stderr = stderr?.toString();
+        }
+        callback(err as ProcessError | null, stdout?.toString() ?? '', stderr?.toString() ?? '');
+    });
+}
+
+/**
+ * Renders an invocation for the debug output channel, quoting each element and
+ * replacing every element that exactly matches a non-empty entry of `secrets` with
+ * `***`. An empty-string secret redacts nothing (there is nothing to compare against).
+ */
+export function formatArgvForLog(argv: Argv, secrets: string[] = []): string {
+    const nonEmptySecrets = secrets.filter((s) => !!s);
+    const renderPart = (part: string) => (nonEmptySecrets.includes(part) ? '***' : part);
+    return [argv.file, ...argv.args].map(renderPart).map((p) => `"${p}"`).join(' ');
+}

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -25,6 +25,8 @@ import {
     validateOptions,
     type CompilerOption
 } from './Commands/CompilerOptions.js';
+import { buildEmValidateArgv, buildEmLoginArgv } from './Commands/process-args.js';
+import { runProcess, formatArgvForLog, type ProcessError } from './Commands/process-runner.js';
 
 import Commands from './Commands/Commands.cjs';
 
@@ -402,44 +404,36 @@ async function validateTokenServerSide(context: vscode.ExtensionContext, token: 
             return false;
         }
 
-        // Build path to bbj executable
-        const bbj = path.join(bbjHome, 'bin', `bbj${process.platform === 'win32' ? '.exe' : ''}`);
-
         // Build path to em-validate-token.bbj
         const emValidatePath = context.asAbsolutePath(path.join('tools', 'em-validate-token.bbj'));
 
         // Create temp file for BBj output
         const tmpFile = path.join(os.tmpdir(), `bbj-em-validate-${Date.now()}.tmp`);
 
-        // Build command: bbj -q em-validate-token.bbj - <token> <tmpFile>
-        const emValidateCmd = `"${bbj}" -q "${emValidatePath}" - "${token}" "${tmpFile}"`;
+        // Build argv: bbj -q em-validate-token.bbj - <token> <tmpFile>
+        const argv = buildEmValidateArgv({
+            home: bbjHome,
+            platform: process.platform,
+            scriptPath: emValidatePath,
+            token,
+            tmpFile
+        });
 
         // Log command if debug mode is on (with masked token)
         const isDebug = vscode.workspace.getConfiguration('bbj').get<boolean>('debug');
         if (isDebug) {
-            outputChannel.appendLine(`EM token validation: ${emValidateCmd.replace(token, '***')}`);
+            outputChannel.appendLine(`EM token validation: ${formatArgvForLog(argv, [token])}`);
         }
 
-        // Execute with 10s timeout
-        const result = await new Promise<string>((resolve, reject) => {
-            const { exec } = require('child_process');
-            exec(emValidateCmd,
-                { timeout: 10000 },
-                (err: any, stdout: string, stderr: string) => {
-                    try {
-                        if (err) {
-                            reject(new Error(stderr || err.message));
-                            return;
-                        }
-                        const output = fs.readFileSync(tmpFile, 'utf-8').trim();
-                        resolve(output);
-                    } finally {
-                        // Clean up temp file
-                        try { fs.unlinkSync(tmpFile); } catch {}
-                    }
-                }
-            );
-        });
+        let result: string;
+        try {
+            // Execute with 10s timeout
+            await runProcess(argv, { timeout: 10000 });
+            result = fs.readFileSync(tmpFile, 'utf-8').trim();
+        } finally {
+            // Clean up temp file
+            try { fs.unlinkSync(tmpFile); } catch {}
+        }
 
         // Return true only if output is "VALID"
         return result === 'VALID';
@@ -623,48 +617,48 @@ export function activate(context: vscode.ExtensionContext): void {
         if (password === undefined) return;
 
         // Launch em-login.bbj to validate credentials and get token
-        const bbj = path.join(bbjHome, 'bin', `bbj${process.platform === 'win32' ? '.exe' : ''}`);
         const emLoginPath = context.asAbsolutePath(path.join('tools', 'em-login.bbj'));
 
         // Create temp file for BBj output
         const tmpFile = path.join(os.tmpdir(), `bbj-em-login-${Date.now()}.tmp`);
 
-        const platform = process.platform === 'win32' ? 'Windows' : process.platform === 'darwin' ? 'MacOS' : 'Linux';
-        const infoString = `VS Code on ${platform} as ${os.userInfo().username}`;
+        const platformLabel = process.platform === 'win32' ? 'Windows' : process.platform === 'darwin' ? 'MacOS' : 'Linux';
+        const infoString = `VS Code on ${platformLabel} as ${os.userInfo().username}`;
 
-        const emLoginCmd = `"${bbj}" -q "${emLoginPath}" - "${username}" "${password}" "${tmpFile}" "${infoString}"`;
+        const argv = buildEmLoginArgv({
+            home: bbjHome,
+            platform: process.platform,
+            scriptPath: emLoginPath,
+            username,
+            password,
+            tmpFile,
+            infoString
+        });
 
         const isDebug = vscode.workspace.getConfiguration('bbj').get<boolean>('debug');
         if (isDebug) {
-            outputChannel.appendLine(`EM login: ${emLoginCmd.replace(`"${password}"`, '"***"')}`);
+            outputChannel.appendLine(`EM login: ${formatArgvForLog(argv, [password])}`);
         }
 
         try {
-            const result = await new Promise<string>((resolve, reject) => {
-                const { exec } = require('child_process');
-                exec(emLoginCmd,
-                    { timeout: 15000 },
-                    (err: any, stdout: string, stderr: string) => {
-                        try {
-                            if (err) {
-                                reject(new Error(stderr || err.message));
-                                return;
-                            }
-                            const output = fs.readFileSync(tmpFile, 'utf-8').trim();
-                            if (output.startsWith('ERROR:')) {
-                                reject(new Error(output.substring(6)));
-                                return;
-                            }
-                            resolve(output);
-                        } finally {
-                            try { fs.unlinkSync(tmpFile); } catch {}
-                        }
-                    }
-                );
-            });
+            let output: string;
+            try {
+                // Execute with 15s timeout
+                await runProcess(argv, { timeout: 15000 });
+                output = fs.readFileSync(tmpFile, 'utf-8').trim();
+            } catch (err) {
+                const pe = err as ProcessError;
+                throw new Error(pe.stderr || pe.message);
+            } finally {
+                try { fs.unlinkSync(tmpFile); } catch {}
+            }
+
+            if (output.startsWith('ERROR:')) {
+                throw new Error(output.substring(6));
+            }
 
             // Store token in SecretStorage
-            await context.secrets.store('bbj.em.token', result);
+            await context.secrets.store('bbj.em.token', output);
             vscode.window.showInformationMessage('Successfully logged in to Enterprise Manager');
         } catch (error) {
             vscode.window.showErrorMessage(`EM login failed: ${error}`);

--- a/bbj-vscode/test/command-argv-injection.test.ts
+++ b/bbj-vscode/test/command-argv-injection.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test } from 'vitest';
+import {
+    bbjBin,
+    bbjlstBin,
+    bbjcplBin,
+    buildRunArgv,
+    buildWebRunArgv,
+    buildCompileArgv,
+    buildDecompileArgv,
+    buildEmValidateArgv,
+    buildEmLoginArgv
+} from '../src/Commands/process-args.js';
+
+/**
+ * GHSA-p5f3-9456-9pcx (CWE-78): these tests prove that workspace-settable
+ * configuration values reach the child process as inert argument-array elements
+ * rather than being interpolated into a shell command string. The metacharacter
+ * fixture below is inert test data proving pass-through, not an exploit.
+ */
+const METACHAR_FIXTURE = 'legit;`injected`';
+
+describe('process-args - executable path helpers', () => {
+    test('bbjBin appends .exe only on win32', () => {
+        expect(bbjBin('/opt/bbj', 'linux')).toBe('/opt/bbj/bin/bbj');
+        expect(bbjBin('C:\\bbj', 'win32')).toBe('C:\\bbj/bin/bbj.exe');
+    });
+
+    test('bbjlstBin appends .exe only on win32', () => {
+        expect(bbjlstBin('/opt/bbj', 'linux')).toBe('/opt/bbj/bin/bbjlst');
+        expect(bbjlstBin('C:\\bbj', 'win32')).toBe('C:\\bbj/bin/bbjlst.exe');
+    });
+
+    test('bbjcplBin appends .exe only on win32', () => {
+        expect(bbjcplBin('/opt/bbj', 'linux')).toBe('/opt/bbj/bin/bbjcpl');
+        expect(bbjcplBin('C:\\bbj', 'win32')).toBe('C:\\bbj/bin/bbjcpl.exe');
+    });
+});
+
+describe('process-args - buildRunArgv (bbj.classpath / bbj.configPath / params.fsPath group)', () => {
+    test('builds the expected argv shape', () => {
+        const argv = buildRunArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            classpathEntry: 'bbj_default',
+            configPath: null,
+            workingDir: '/w',
+            fileName: '/w/a.bbj'
+        });
+        expect(argv.file).toBe('/opt/bbj/bin/bbj');
+        expect(argv.args).toEqual(['-q', '-CPbbj_default', '-WD/w', '/w/a.bbj']);
+    });
+
+    test('omits -CP and -c when classpathEntry/configPath are empty or absent', () => {
+        const argv = buildRunArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            classpathEntry: '',
+            configPath: '',
+            workingDir: '/w',
+            fileName: '/w/a.bbj'
+        });
+        expect(argv.args).toEqual(['-q', '-WD/w', '/w/a.bbj']);
+
+        const argvUndefined = buildRunArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            workingDir: '/w',
+            fileName: '/w/a.bbj'
+        });
+        expect(argvUndefined.args).toEqual(['-q', '-WD/w', '/w/a.bbj']);
+    });
+
+    test('a classpathEntry carrying a shell metacharacter is one verbatim element', () => {
+        const argv = buildRunArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            classpathEntry: METACHAR_FIXTURE,
+            configPath: null,
+            workingDir: '/w',
+            fileName: '/w/a.bbj'
+        });
+        const cpArg = argv.args.find((a) => a.startsWith('-CP'));
+        expect(cpArg).toBe(`-CP${METACHAR_FIXTURE}`);
+        const others = argv.args.filter((a) => a !== cpArg);
+        for (const other of others) {
+            expect(other.includes(METACHAR_FIXTURE)).toBe(false);
+        }
+    });
+
+    test('a fileName carrying a shell metacharacter is one verbatim element', () => {
+        const fileName = `/w/${METACHAR_FIXTURE}.bbj`;
+        const argv = buildRunArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            classpathEntry: null,
+            configPath: null,
+            workingDir: '/w',
+            fileName
+        });
+        expect(argv.args[argv.args.length - 1]).toBe(fileName);
+    });
+
+    test('args is always an array of strings, never a joined command line', () => {
+        const argv = buildRunArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            classpathEntry: 'bbj_default',
+            configPath: '/cfg/config.bbx',
+            workingDir: '/w',
+            fileName: '/w/a.bbj'
+        });
+        expect(Array.isArray(argv.args)).toBe(true);
+        for (const a of argv.args) {
+            expect(typeof a).toBe('string');
+        }
+    });
+});
+
+describe('process-args - buildWebRunArgv (bbj.web.apps.<file>.name / bbj.configPath / params.fsPath group)', () => {
+    const baseOpts = {
+        home: '/opt/bbj',
+        platform: 'linux' as NodeJS.Platform,
+        toolsDir: '/ext/tools',
+        client: 'BUI',
+        name: 'myapp',
+        programme: 'myapp.bbj',
+        workingDir: '/w',
+        username: 'user',
+        password: 'pass',
+        classpathEntry: 'bbj_default',
+        token: '',
+        configPath: '/cfg/config.bbx'
+    };
+
+    test('emits the thirteen positional elements in today\'s order', () => {
+        const argv = buildWebRunArgv(baseOpts);
+        expect(argv.file).toBe('/opt/bbj/bin/bbj');
+        expect(argv.args).toEqual([
+            '-q',
+            '-WD/ext/tools',
+            '/ext/tools/web.bbj',
+            '-',
+            'BUI',
+            'myapp',
+            'myapp.bbj',
+            '/w',
+            'user',
+            'pass',
+            'bbj_default',
+            '',
+            '/cfg/config.bbx'
+        ]);
+        expect(argv.args).toHaveLength(13);
+    });
+
+    test('empty-string credentials are preserved as empty elements, not dropped', () => {
+        const argv = buildWebRunArgv({ ...baseOpts, username: '', password: '', token: 'tok' });
+        expect(argv.args[8]).toBe('');
+        expect(argv.args[9]).toBe('');
+        expect(argv.args[11]).toBe('tok');
+        expect(argv.args).toHaveLength(13);
+    });
+
+    test('an app name carrying a shell metacharacter is one verbatim element', () => {
+        const argv = buildWebRunArgv({ ...baseOpts, name: METACHAR_FIXTURE });
+        expect(argv.args[5]).toBe(METACHAR_FIXTURE);
+        const others = argv.args.filter((_, i) => i !== 5);
+        for (const other of others) {
+            expect(other.includes(METACHAR_FIXTURE)).toBe(false);
+        }
+    });
+
+    test('a configPath carrying a shell metacharacter is one verbatim element', () => {
+        const argv = buildWebRunArgv({ ...baseOpts, configPath: METACHAR_FIXTURE });
+        expect(argv.args[12]).toBe(METACHAR_FIXTURE);
+    });
+
+    test('a fileName (programme) carrying a shell metacharacter is one verbatim element', () => {
+        const argv = buildWebRunArgv({ ...baseOpts, programme: METACHAR_FIXTURE });
+        expect(argv.args[6]).toBe(METACHAR_FIXTURE);
+    });
+});
+
+describe('process-args - buildCompileArgv (bbj.compiler.* group)', () => {
+    test('forwards buildCompileOptions elements in order, then the file name last', () => {
+        const argv = buildCompileArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            compilerOptions: ['-t', '-Werror'],
+            fileName: '/w/a.bbj'
+        });
+        expect(argv.file).toBe('/opt/bbj/bin/bbjcpl');
+        expect(argv.args).toEqual(['-t', '-Werror', '/w/a.bbj']);
+    });
+
+    test('an option value carrying a metacharacter stays in one element', () => {
+        const argv = buildCompileArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            compilerOptions: [`-p${METACHAR_FIXTURE}`],
+            fileName: '/w/a.bbj'
+        });
+        expect(argv.args[0]).toBe(`-p${METACHAR_FIXTURE}`);
+    });
+
+    test('an option value containing a space stays in one element (deliberate pre-existing-bug fix)', () => {
+        const argv = buildCompileArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            compilerOptions: ['-oC:\\Program Files\\out'],
+            fileName: '/w/a.bbj'
+        });
+        expect(argv.args[0]).toBe('-oC:\\Program Files\\out');
+        expect(argv.args).toHaveLength(2);
+    });
+
+    test('a fileName carrying a shell metacharacter is one verbatim element', () => {
+        const fileName = `/w/${METACHAR_FIXTURE}.bbj`;
+        const argv = buildCompileArgv({ home: '/opt/bbj', platform: 'linux', compilerOptions: [], fileName });
+        expect(argv.args[argv.args.length - 1]).toBe(fileName);
+    });
+});
+
+describe('process-args - buildDecompileArgv', () => {
+    test('no flags when not denumbering', () => {
+        const argv = buildDecompileArgv({ home: '/opt/bbj', platform: 'linux', fileName: '/w/a.bbj' });
+        expect(argv.args).toEqual(['/w/a.bbj']);
+    });
+
+    test("['-l'] when denumbering a non-.lst input", () => {
+        const argv = buildDecompileArgv({ home: '/opt/bbj', platform: 'linux', fileName: '/w/a.bbj', denumber: true });
+        expect(argv.args).toEqual(['-l', '/w/a.bbj']);
+    });
+
+    test("['-l', '-xlst'] when denumbering a .lst input", () => {
+        const argv = buildDecompileArgv({ home: '/opt/bbj', platform: 'linux', fileName: '/w/a.lst', denumber: true });
+        expect(argv.args).toEqual(['-l', '-xlst', '/w/a.lst']);
+    });
+
+    test('a fileName carrying a shell metacharacter is one verbatim element', () => {
+        const fileName = `/w/${METACHAR_FIXTURE}.bbj`;
+        const argv = buildDecompileArgv({ home: '/opt/bbj', platform: 'linux', fileName, denumber: true });
+        expect(argv.args[argv.args.length - 1]).toBe(fileName);
+    });
+});
+
+describe('process-args - EM launches', () => {
+    test('buildEmValidateArgv returns the five elements in order', () => {
+        const argv = buildEmValidateArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            scriptPath: '/ext/tools/em-validate-token.bbj',
+            token: 'tok-123',
+            tmpFile: '/tmp/out.tmp'
+        });
+        expect(argv.file).toBe('/opt/bbj/bin/bbj');
+        expect(argv.args).toEqual(['-q', '/ext/tools/em-validate-token.bbj', '-', 'tok-123', '/tmp/out.tmp']);
+    });
+
+    test('buildEmValidateArgv keeps a metacharacter-bearing token in one element', () => {
+        const argv = buildEmValidateArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            scriptPath: '/ext/tools/em-validate-token.bbj',
+            token: METACHAR_FIXTURE,
+            tmpFile: '/tmp/out.tmp'
+        });
+        expect(argv.args[3]).toBe(METACHAR_FIXTURE);
+    });
+
+    test('buildEmLoginArgv returns the seven elements in order', () => {
+        const argv = buildEmLoginArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            scriptPath: '/ext/tools/em-login.bbj',
+            username: 'admin',
+            password: 'secret',
+            tmpFile: '/tmp/out.tmp',
+            infoString: 'VS Code on Linux as dev'
+        });
+        expect(argv.file).toBe('/opt/bbj/bin/bbj');
+        expect(argv.args).toEqual([
+            '-q',
+            '/ext/tools/em-login.bbj',
+            '-',
+            'admin',
+            'secret',
+            '/tmp/out.tmp',
+            'VS Code on Linux as dev'
+        ]);
+    });
+
+    test('buildEmLoginArgv keeps metacharacter-bearing credentials in their own element and preserves spaces in the info string', () => {
+        const argv = buildEmLoginArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            scriptPath: '/ext/tools/em-login.bbj',
+            username: METACHAR_FIXTURE,
+            password: METACHAR_FIXTURE,
+            tmpFile: '/tmp/out.tmp',
+            infoString: 'VS Code on Linux as dev'
+        });
+        expect(argv.args[3]).toBe(METACHAR_FIXTURE);
+        expect(argv.args[4]).toBe(METACHAR_FIXTURE);
+        expect(argv.args[6]).toBe('VS Code on Linux as dev');
+    });
+});

--- a/bbj-vscode/test/no-shell-command-construction.test.ts
+++ b/bbj-vscode/test/no-shell-command-construction.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * GHSA-p5f3-9456-9pcx (CWE-78): this guard is what keeps the fix from silently
+ * regressing. `Commands.cjs` is a CommonJS file resolved by Node's native
+ * loader, so `vi.mock('vscode')` never reaches its `require` and it cannot be
+ * loaded under Vitest — this source scan is the only automated check covering
+ * the wiring inside it. Both this file and `extension.ts` are asserted to
+ * contain zero shell-string process launches and zero `child_process` imports.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const COMMANDS_CJS = path.join(REPO_ROOT, 'src/Commands/Commands.cjs');
+const EXTENSION_TS = path.join(REPO_ROOT, 'src/extension.ts');
+
+/** Strip `//` line comments (a reasonable approximation; good enough for a source guard). */
+function stripLineComments(source: string): string {
+    return source.replace(/\/\/.*$/gm, '');
+}
+
+function readStripped(filePath: string): string {
+    return stripLineComments(fs.readFileSync(filePath, 'utf-8'));
+}
+
+// Matches a shell-string exec call: `exec(` not preceded by a `.`/word char (so
+// `execFile(`, `execWithProgress(`, `runProcessCallback(` etc. are not matched)
+// and not part of a longer identifier.
+const SHELL_EXEC_CALL = /(^|[^.\w])exec\s*\(/;
+
+describe('no-shell-command-construction guard', () => {
+    test('Commands.cjs contains zero shell-string process launches', () => {
+        const source = readStripped(COMMANDS_CJS);
+        const matches = source.match(new RegExp(SHELL_EXEC_CALL, 'g')) ?? [];
+        expect(matches).toHaveLength(0);
+    });
+
+    test('extension.ts contains zero shell-string process launches', () => {
+        const source = readStripped(EXTENSION_TS);
+        const matches = source.match(new RegExp(SHELL_EXEC_CALL, 'g')) ?? [];
+        expect(matches).toHaveLength(0);
+    });
+
+    test('Commands.cjs does not import child_process directly', () => {
+        const source = readStripped(COMMANDS_CJS);
+        expect(source).not.toMatch(/require\(\s*['"]child_process['"]\s*\)/);
+    });
+
+    test('extension.ts does not import child_process directly', () => {
+        const source = readStripped(EXTENSION_TS);
+        expect(source).not.toMatch(/from\s+['"]child_process['"]/);
+        expect(source).not.toMatch(/require\(\s*['"]child_process['"]\s*\)/);
+    });
+});

--- a/bbj-vscode/test/process-runner.test.ts
+++ b/bbj-vscode/test/process-runner.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+/**
+ * GHSA-p5f3-9456-9pcx (CWE-78): proves the launcher hands its argument array to
+ * `execFile` and never builds (or invokes) a shell command string. The mocked
+ * `exec` export below stands in for the shell-string API this module must never
+ * call. The metacharacter fixture is inert test data proving pass-through, not
+ * an exploit.
+ */
+const METACHAR_FIXTURE = 'legit;`injected`';
+
+const execFileMock = vi.fn();
+const execMock = vi.fn();
+
+vi.mock('child_process', () => ({
+    execFile: (...args: unknown[]) => execFileMock(...args),
+    exec: (...args: unknown[]) => execMock(...args)
+}));
+
+import { runProcess, runProcessCallback, formatArgvForLog } from '../src/Commands/process-runner.js';
+import type { Argv } from '../src/Commands/process-args.js';
+
+beforeEach(() => {
+    execFileMock.mockReset();
+    execMock.mockReset();
+});
+
+describe('runProcess', () => {
+    test('calls execFile with the executable path, the argument array, and no shell-enabling option', async () => {
+        const argv: Argv = { file: '/opt/bbj/bin/bbj', args: ['-q', '-CPbbj_default', '-WD/w', '/w/a.bbj'] };
+        execFileMock.mockImplementation((file, args, options, cb) => {
+            cb(null, 'out', '');
+        });
+
+        await runProcess(argv);
+
+        expect(execFileMock).toHaveBeenCalledTimes(1);
+        const [calledFile, calledArgs, calledOptions] = execFileMock.mock.calls[0];
+        expect(calledFile).toBe(argv.file);
+        expect(calledArgs).toEqual(argv.args);
+        expect(calledOptions).not.toHaveProperty('shell', true);
+    });
+
+    test('the module never invokes the shell-string exec API', async () => {
+        const argv: Argv = { file: '/opt/bbj/bin/bbj', args: ['-q'] };
+        execFileMock.mockImplementation((file, args, options, cb) => cb(null, '', ''));
+        await runProcess(argv);
+        expect(execMock).not.toHaveBeenCalled();
+    });
+
+    test('resolves {stdout, stderr} on success', async () => {
+        const argv: Argv = { file: '/opt/bbj/bin/bbj', args: ['-q'] };
+        execFileMock.mockImplementation((file, args, options, cb) => cb(null, 'hello', ''));
+        const result = await runProcess(argv);
+        expect(result).toEqual({ stdout: 'hello', stderr: '' });
+    });
+
+    test('rejects with the error, carrying stderr attached, on failure', async () => {
+        const argv: Argv = { file: '/opt/bbj/bin/bbj', args: ['-q'] };
+        const err = new Error('Command failed');
+        execFileMock.mockImplementation((file, args, options, cb) => cb(err, '', 'boom on stderr'));
+        await expect(runProcess(argv)).rejects.toMatchObject({ message: 'Command failed', stderr: 'boom on stderr' });
+    });
+
+    test('seam: a metacharacter-bearing classpath from buildRunArgv reaches execFile as one verbatim element', async () => {
+        const { buildRunArgv } = await import('../src/Commands/process-args.js');
+        const argv = buildRunArgv({
+            home: '/opt/bbj',
+            platform: 'linux',
+            classpathEntry: METACHAR_FIXTURE,
+            configPath: null,
+            workingDir: '/w',
+            fileName: '/w/a.bbj'
+        });
+        execFileMock.mockImplementation((file, args, options, cb) => cb(null, '', ''));
+        await runProcess(argv);
+        const [, calledArgs] = execFileMock.mock.calls[0];
+        expect((calledArgs as string[])).toContain(`-CP${METACHAR_FIXTURE}`);
+    });
+});
+
+describe('runProcessCallback', () => {
+    test('delegates to execFile with the argument array', () => {
+        const argv: Argv = { file: '/opt/bbj/bin/bbj', args: ['-q'] };
+        const cb = vi.fn();
+        execFileMock.mockImplementation((file, args, options, innerCb) => innerCb(null, 'out', ''));
+
+        runProcessCallback(argv, {}, cb);
+
+        expect(execFileMock).toHaveBeenCalledTimes(1);
+        const [calledFile, calledArgs] = execFileMock.mock.calls[0];
+        expect(calledFile).toBe(argv.file);
+        expect(calledArgs).toEqual(argv.args);
+        expect(cb).toHaveBeenCalledWith(null, 'out', '');
+    });
+
+    test('attaches stderr to a non-null error', () => {
+        const argv: Argv = { file: '/opt/bbj/bin/bbj', args: ['-q'] };
+        const cb = vi.fn();
+        const err = new Error('failed');
+        execFileMock.mockImplementation((file, args, options, innerCb) => innerCb(err, '', 'stderr text'));
+
+        runProcessCallback(argv, {}, cb);
+
+        expect(cb).toHaveBeenCalledWith(expect.objectContaining({ message: 'failed', stderr: 'stderr text' }), '', 'stderr text');
+    });
+});
+
+describe('formatArgvForLog', () => {
+    test('renders a readable single-line rendering, redacting a non-empty secret', () => {
+        const argv: Argv = { file: '/opt/bbj/bin/bbj', args: ['-q', '-', 'admin', 'super-secret'] };
+        const rendered = formatArgvForLog(argv, ['super-secret']);
+        expect(rendered).not.toContain('super-secret');
+        expect(rendered).toContain('***');
+        expect(rendered).toContain('admin');
+    });
+
+    test('an empty-string secret redacts nothing', () => {
+        const argv: Argv = { file: '/opt/bbj/bin/bbj', args: ['-q', '-', 'admin', ''] };
+        const rendered = formatArgvForLog(argv, ['']);
+        expect(rendered).not.toContain('***');
+    });
+});


### PR DESCRIPTION
Remediates **GHSA-p5f3-9456-9pcx** (critical, CWE-78) — the advisory is currently an unpublished draft.

## Problem

Workspace-settable configuration strings were interpolated into shell command strings and handed to `child_process.exec()`. Because `exec()` spawns a shell, a value containing shell metacharacters was interpreted rather than passed as inert data. The affected settings (`bbj.classpath`, `bbj.configPath`, `bbj.web.apps.<file>.name`, seven `bbj.compiler.*` options) carry no `capabilities.untrustedWorkspaces` restriction, so they are settable from a workspace's own committed settings file, and the `params.fsPath` path is reachable from any other extension's command invocation.

## Approach

Replace shell-string construction with argument-array process spawning, mirroring the IntelliJ side's `GeneralCommandLine.addParameter` model:

- **`src/Commands/process-args.ts`** (new) — pure `Argv` builders for every BBj process launch: `buildRunArgv`, `buildWebRunArgv`, `buildCompileArgv`, `buildDecompileArgv`, `buildEmValidateArgv`, `buildEmLoginArgv`. No `vscode` import, so it is unit-testable with zero mocks.
- **`src/Commands/process-runner.ts`** (new) — `execFile`-backed launcher (`runProcess`, `runProcessCallback`, `formatArgvForLog`). No shell.
- **`src/Commands/Commands.cjs`**, **`src/extension.ts`** — all seven command constructions rewired to the builders.

Shell-string launch count across both files: **5 → 0**.

Out of scope and untouched: `document-formatter.ts` and `bbj-cpl-service.ts` already used argument arrays.

## Deliberate behavior changes

1. **One configured string maps to exactly one argv element — no whitespace splitting.** Previously the shell split a value containing a space into two arguments. This matches the documented semantics of `bbj.classpath` (a single classpath *entry name*), `bbj.configPath` (a single path) and the string-typed `bbj.compiler.*` options, and `buildCompileOptions` already returned complete flag+value tokens. Verified against `package.json` `contributes.configuration` and `CompilerOptions.ts`.
2. `decompileReadonly` now applies an `.lst`-extension check it previously lacked. Only observable on tokenized binaries.

## Tests

- `test/command-argv-injection.test.ts` — asserts a settings value containing a shell metacharacter arrives as **one literal argv element**, with a case per affected settings group (`buildRunArgv`, `buildWebRunArgv`, `buildCompileArgv`, EM launches).
- `test/process-runner.test.ts` — launcher behavior.
- `test/no-shell-command-construction.test.ts` — source-scanning guard against reintroducing shell-string construction. `Commands.cjs` is CommonJS and requires `vscode`, so it cannot be loaded under Vitest; this guard is how its wiring stays covered.

38/38 pass. All three were confirmed non-vacuous by running them against pre-fix `291cd23`, where the guard fails 4/4 and the new modules do not exist.

`tsc -b`, `npm run lint`, `npm run build` clean.

## Live verification

The compile path was exercised against a real BBj installation, no mocks: a normal compile succeeded end-to-end, and an injection probe (metacharacter plus an inert filesystem marker) arrived as one literal argv element that `bbjcpl` treated as an unopenable filename — the marker file was never created, so no shell interpreted it.

## Still needs manual QA

Only the `bbjcpl` compile path was live-launched. **Run / Run BUI / Run DWC and the EM login/validate paths rest on unit-test and source-diff evidence only** — they need a GUI session and real EM credentials. Those four are the everyday actions the advisory names as triggers, so the `QA/` checklist should be run before the advisory is published.

## Note on the test suite

`test/linking.test.ts` shows 11 failures under `Interop related tests` on any machine with BBj installed. **Pre-existing and unrelated to this PR** — reproduced identically at `291cd23`. Cause: `shouldRunBBjTests()` (`test/test-helper.ts:37-43`) gates on a bare TCP connect to :5008, and BBjServices binds that port without speaking the interop protocol, so the gate false-positives. Green under `RUN_BBJ_TESTS=0`. Filed separately as debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
