### PR TITLE
ci: bind the JetBrains Marketplace publish token through the step env

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -134,7 +134,9 @@ jobs:
 
       - name: Publish to JetBrains Marketplace
         working-directory: bbj-intellij
-        run: ./gradlew publishPlugin -Pversion=${{ needs.build-vscode.outputs.version }} -PintellijPlatformPublishingToken=${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+        env:
+          JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+        run: ./gradlew publishPlugin -Pversion=${{ needs.build-vscode.outputs.version }} -PintellijPlatformPublishingToken="$JETBRAINS_MARKETPLACE_TOKEN"
 
       - name: Upload IntelliJ plugin
         uses: actions/upload-artifact@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -95,11 +95,13 @@ jobs:
 
       - name: Publish IntelliJ preview to JetBrains Marketplace
         working-directory: bbj-intellij
+        env:
+          JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
         run: >-
           ./gradlew publishPlugin
           -Pversion=${{ needs.publish-preview.outputs.version }}
           -PintellijChannel=preview
-          -PintellijPlatformPublishingToken=${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+          -PintellijPlatformPublishingToken="$JETBRAINS_MARKETPLACE_TOKEN"
 
       - name: Upload IntelliJ plugin
         uses: actions/upload-artifact@v4

--- a/.github/workflows/workflow-hygiene.yml
+++ b/.github/workflows/workflow-hygiene.yml
@@ -1,0 +1,32 @@
+# .github/workflows/workflow-hygiene.yml
+#
+# Asserts that no workflow `run:` body inlines a `${{ secrets.* }}` expression;
+# secrets must be bound through a step-scoped `env:` mapping instead. Runs
+# install-free — the checker is a zero-dependency Node script.
+name: Workflow Hygiene
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  secret-hygiene:
+    name: No secrets in run bodies
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Scan workflow run bodies for inline secret expressions
+        run: node bbj-vscode/tools/check-workflow-secrets.mjs

--- a/bbj-vscode/test/workflow-secret-hygiene.test.ts
+++ b/bbj-vscode/test/workflow-secret-hygiene.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, describe, expect, test } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Regression coverage for `check-workflow-secrets.mjs`: pins its CLI contract
+ * (exit codes and stdout shape) against the real workflow tree, a pre-fix
+ * fixture, an empty-target guard, env/run separation, and argument-shape
+ * invariance across token values, so the check cannot silently go vacuous.
+ */
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, '..', '..');
+const CHECKER_PATH = process.env.WORKFLOW_SECRET_CHECKER_PATH
+    ?? path.join(REPO_ROOT, 'bbj-vscode', 'tools', 'check-workflow-secrets.mjs');
+const WORKFLOWS_DIR = path.join(REPO_ROOT, '.github', 'workflows');
+const PREVIEW_FILE = path.join(WORKFLOWS_DIR, 'preview.yml');
+const RELEASE_FILE = path.join(WORKFLOWS_DIR, 'manual-release.yml');
+
+const fixtureDirs: string[] = [];
+
+function newFixtureDir(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    fixtureDirs.push(dir);
+    return dir;
+}
+
+afterAll(() => {
+    for (const dir of fixtureDirs) {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+interface CheckerResult {
+    status: number;
+    stdout: string;
+}
+
+function runChecker(args: string[]): CheckerResult {
+    try {
+        const stdout = execFileSync('node', [CHECKER_PATH, ...args], { encoding: 'utf8' });
+        return { status: 0, stdout };
+    } catch (err) {
+        const spawnError = err as { status: number | null; stdout?: string };
+        return { status: spawnError.status ?? -1, stdout: spawnError.stdout ?? '' };
+    }
+}
+
+// Extracts the folded run: body text for the publish step in one file's
+// `--print` output, replaces every `${{ ... }}` expression with a fixed
+// placeholder (as GitHub's expression evaluator would substitute a value),
+// and drops the leading program-name words, leaving only argument text.
+function extractPublishArgText(printOutput: string, filePath: string): string {
+    const linePattern = /^(.+):(\d+): (.*)$/;
+    for (const line of printOutput.split('\n')) {
+        const match = line.match(linePattern);
+        if (match && match[1] === filePath && match[3].includes('PintellijPlatformPublishingToken')) {
+            const withPlaceholders = match[3].replace(/\$\{\{[^}]*\}\}/g, '9.9.9');
+            return withPlaceholders.replace(/^\.\/gradlew publishPlugin\s+/, '');
+        }
+    }
+    throw new Error(`No publish step found in --print output for ${filePath}`);
+}
+
+// Evaluates the reconstructed argument text under bash, the way the shell
+// would after GitHub substitutes expressions, and returns the resulting
+// positional parameters one per array element.
+function evaluateReconstructedArgs(argText: string, tokenValue: string): string[] {
+    const script = `set -- ${argText}\nprintf '%s\\n' "$@"`;
+    const stdout = execFileSync('bash', ['-c', script], {
+        encoding: 'utf8',
+        env: { ...process.env, JETBRAINS_MARKETPLACE_TOKEN: tokenValue }
+    });
+    const trimmed = stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout;
+    return trimmed.split('\n');
+}
+
+describe('workflow-secret-hygiene checker contract', () => {
+    test('the real workflow tree scans clean', () => {
+        const result = runChecker([WORKFLOWS_DIR]);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toMatch(/0 findings/);
+    });
+
+    test('a pre-fix inline-secret shape reds with two ascending-ordered findings', () => {
+        const fixtureDir = newFixtureDir('workflow-secret-hygiene-legacy-');
+        const fixtureFile = path.join(fixtureDir, 'legacy.yml');
+        const lines = [
+            'name: Fixture',
+            'on: push',
+            'jobs:',
+            '  job:',
+            '    runs-on: ubuntu-latest',
+            '    steps:',
+            '      - name: Folded publish step',
+            '        run: >-',
+            '          ./gradlew publishPlugin',
+            '          -Pversion=1.0',
+            '          -PintellijPlatformPublishingToken=${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}',
+            '      - name: Single-line publish step',
+            '        run: ./gradlew publishPlugin -Pversion=1.0 -PintellijPlatformPublishingToken=${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}'
+        ];
+        fs.writeFileSync(fixtureFile, lines.join('\n') + '\n');
+
+        const expectedLineNumbers = lines
+            .map((line, idx) => ({ line, idx }))
+            .filter(({ line }) => line.includes('secrets.JETBRAINS_MARKETPLACE_TOKEN'))
+            .map(({ idx }) => idx + 1);
+        expect(expectedLineNumbers).toHaveLength(2);
+
+        const result = runChecker([fixtureDir]);
+        expect(result.status).toBe(1);
+
+        const findingLines = result.stdout.split('\n').filter((line) => line.startsWith(fixtureFile));
+        expect(findingLines).toHaveLength(2);
+
+        const actualLineNumbers = findingLines.map((line) => Number(line.match(/:(\d+):/)?.[1]));
+        expect(actualLineNumbers).toEqual(expectedLineNumbers);
+        expect(actualLineNumbers[0]).toBeLessThan(actualLineNumbers[1]);
+        expect(result.stdout).toContain('2 finding(s).');
+    });
+
+    test('an empty target directory triggers exit code 2, never exit code 0', () => {
+        const emptyDir = newFixtureDir('workflow-secret-hygiene-empty-');
+        const result = runChecker([emptyDir]);
+        expect(result.status).toBe(2);
+        expect(result.status).not.toBe(0);
+    });
+
+    test('a secrets expression bound through env: is not a finding while the run: body stays clean', () => {
+        const fixtureDir = newFixtureDir('workflow-secret-hygiene-bound-');
+        const fixtureFile = path.join(fixtureDir, 'bound.yml');
+        const content = [
+            'name: Fixture',
+            'on: push',
+            'jobs:',
+            '  job:',
+            '    runs-on: ubuntu-latest',
+            '    steps:',
+            '      - name: Bound publish step',
+            '        env:',
+            '          JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}',
+            '        run: |',
+            '          ./gradlew publishPlugin -Pversion=${{ needs.build.outputs.version }} -Pchannel=${{ github.event.inputs.channel }} -PintellijPlatformPublishingToken="$JETBRAINS_MARKETPLACE_TOKEN"'
+        ].join('\n') + '\n';
+        fs.writeFileSync(fixtureFile, content);
+
+        const result = runChecker([fixtureDir]);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toMatch(/0 findings/);
+    });
+
+    test('reconstructed publish arguments keep a constant count and exact token argument for empty, spaced, and glob values', () => {
+        const printResult = runChecker(['--print', WORKFLOWS_DIR]);
+        expect(printResult.status).toBe(0);
+
+        const previewArgText = extractPublishArgText(printResult.stdout, PREVIEW_FILE);
+        const releaseArgText = extractPublishArgText(printResult.stdout, RELEASE_FILE);
+
+        const tokenValues = ['', 'value with a space', '*'];
+        for (const tokenValue of tokenValues) {
+            const previewArgs = evaluateReconstructedArgs(previewArgText, tokenValue);
+            expect(previewArgs).toHaveLength(3);
+            expect(previewArgs[2]).toBe(`-PintellijPlatformPublishingToken=${tokenValue}`);
+
+            const releaseArgs = evaluateReconstructedArgs(releaseArgText, tokenValue);
+            expect(releaseArgs).toHaveLength(2);
+            expect(releaseArgs[1]).toBe(`-PintellijPlatformPublishingToken=${tokenValue}`);
+        }
+    });
+});

--- a/bbj-vscode/tools/check-workflow-secrets.mjs
+++ b/bbj-vscode/tools/check-workflow-secrets.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Scans YAML workflow files for `${{ secrets.* }}` expressions that appear
+// inside a `run:` block body rather than in a step-scoped `env:` mapping.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SECRET_EXPRESSION = /\$\{\{\s*secrets\./;
+const BLOCK_SCALAR_INDICATOR = /^[|>][+-]?$/;
+const RUN_KEY_LINE = /^(\s*)(-\s+)?run:(.*)$/;
+
+function splitLines(content) {
+  return content.split(/\r\n|\n/);
+}
+
+function leadingWhitespace(line) {
+  const match = line.match(/^(\s*)/);
+  return match ? match[1].length : 0;
+}
+
+// Returns one entry per `run:` key found in the file:
+// { keyLine, lines: [{ line, text }, ...] } with 1-based absolute line numbers.
+function collectRunBodies(filePath) {
+  const lines = splitLines(fs.readFileSync(filePath, 'utf8'));
+  const bodies = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    const match = line.match(RUN_KEY_LINE);
+
+    if (!match) {
+      index += 1;
+      continue;
+    }
+
+    const [, indent, dashPrefix, remainder] = match;
+    const keyIndent = indent.length + (dashPrefix ? dashPrefix.length : 0);
+    const keyLine = index + 1;
+    const trimmedRemainder = remainder.trim();
+    const bodyLines = [];
+    let cursor = index + 1;
+
+    if (BLOCK_SCALAR_INDICATOR.test(trimmedRemainder)) {
+      while (cursor < lines.length) {
+        const candidate = lines[cursor];
+        if (candidate.trim() === '') {
+          bodyLines.push({ line: cursor + 1, text: candidate });
+          cursor += 1;
+          continue;
+        }
+        if (leadingWhitespace(candidate) > keyIndent) {
+          bodyLines.push({ line: cursor + 1, text: candidate });
+          cursor += 1;
+          continue;
+        }
+        break;
+      }
+    } else {
+      bodyLines.push({ line: keyLine, text: remainder });
+      while (cursor < lines.length) {
+        const candidate = lines[cursor];
+        if (candidate.trim() === '') {
+          break;
+        }
+        if (leadingWhitespace(candidate) > keyIndent) {
+          bodyLines.push({ line: cursor + 1, text: candidate });
+          cursor += 1;
+          continue;
+        }
+        break;
+      }
+    }
+
+    bodies.push({ keyLine, lines: bodyLines });
+    index = cursor;
+  }
+
+  return bodies;
+}
+
+function expandTargets(targets) {
+  const files = [];
+  for (const target of targets) {
+    const stat = fs.statSync(target);
+    if (stat.isDirectory()) {
+      const entries = fs
+        .readdirSync(target)
+        .filter((entry) => entry.endsWith('.yml') || entry.endsWith('.yaml'))
+        .sort();
+      for (const entry of entries) {
+        files.push(path.join(target, entry));
+      }
+    } else {
+      files.push(target);
+    }
+  }
+  return files;
+}
+
+// Expands directory targets to their *.yml/*.yaml entries, collects every
+// `run:` body across the resulting files, and reports each body line whose
+// text contains a `${{ secrets.* }}` expression.
+export function scanTargets(targets) {
+  const files = expandTargets(targets);
+  let runBlocks = 0;
+  const findings = [];
+
+  for (const file of files) {
+    const bodies = collectRunBodies(file);
+    runBlocks += bodies.length;
+    for (const body of bodies) {
+      for (const bodyLine of body.lines) {
+        if (SECRET_EXPRESSION.test(bodyLine.text)) {
+          findings.push({ file, line: bodyLine.line, text: bodyLine.text.trim() });
+        }
+      }
+    }
+  }
+
+  findings.sort((a, b) => {
+    if (a.file === b.file) {
+      return a.line - b.line;
+    }
+    return a.file < b.file ? -1 : 1;
+  });
+
+  return { filesScanned: files.length, runBlocks, findings };
+}
+
+function defaultTarget() {
+  return fileURLToPath(new URL('../../.github/workflows', import.meta.url));
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const printMode = args.includes('--print');
+  const positional = args.filter((arg) => arg !== '--print');
+  return { printMode, positional };
+}
+
+function printFoldedBodies(targets) {
+  const files = expandTargets(targets);
+  let runBlocks = 0;
+  const outputLines = [];
+
+  for (const file of files) {
+    const bodies = collectRunBodies(file);
+    runBlocks += bodies.length;
+    for (const body of bodies) {
+      const folded = body.lines.map((bodyLine) => bodyLine.text.trim()).join(' ');
+      outputLines.push(`${file}:${body.keyLine}: ${folded}`);
+    }
+  }
+
+  if (files.length === 0 || runBlocks === 0) {
+    console.log('Refusing to report success on an empty scan: 0 files or 0 run blocks collected.');
+    process.exit(2);
+  }
+
+  for (const line of outputLines) {
+    console.log(line);
+  }
+  process.exit(0);
+}
+
+function main() {
+  const { printMode, positional } = parseArgs(process.argv);
+  const targets = positional.length > 0 ? positional : [defaultTarget()];
+
+  if (printMode) {
+    printFoldedBodies(targets);
+    return;
+  }
+
+  const { filesScanned, runBlocks, findings } = scanTargets(targets);
+
+  if (filesScanned === 0 || runBlocks === 0) {
+    console.log('Refusing to report success on an empty scan: 0 files or 0 run blocks collected.');
+    process.exit(2);
+  }
+
+  if (findings.length === 0) {
+    console.log(`Scanned ${filesScanned} file(s), ${runBlocks} run block(s), 0 findings.`);
+    process.exit(0);
+  }
+
+  for (const finding of findings) {
+    console.log(`${finding.file}:${finding.line}: ${finding.text}`);
+  }
+  console.log(`${findings.length} finding(s).`);
+  process.exit(1);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
Binds the JetBrains Marketplace publishing token to its publish steps through a step-scoped
`env:` mapping and references it as a shell variable, matching the `VSCE_PAT` idiom already
used two steps earlier in both files.

Also adds a small guard so the pattern stays put:

- `bbj-vscode/tools/check-workflow-secrets.mjs` — zero-dependency scanner that reports any
  workflow `run:` body containing a `${{ secrets.* }}` expression. Exits 0 clean, 1 with
  findings, and 2 when a scan collects no files or no `run:` blocks, so a mis-pointed target
  cannot look like a pass.
- `bbj-vscode/test/workflow-secret-hygiene.test.ts` — pins the scanner's contract, including
  the empty-scan guard and `env:`/`run:` separation.
- `.github/workflows/workflow-hygiene.yml` — runs the scanner on push and pull request to
  `main`. Install-free; the scanner has no dependencies.

The Gradle property name `intellijPlatformPublishingToken` is unchanged, as are
`working-directory`, `-Pversion=`, `-PintellijChannel=preview`, and every `${{ needs.* }}`
expression. The shell expansion is quoted so an empty or whitespace-bearing value cannot
reshape the argument list.

Verification: the scanner reports 2 findings against the pre-change content of the two publish
steps and 0 after; the regression suite passes 5/5.
