### PR TITLE
feat(intellij): verify the downloaded Node.js archive against its published checksum

### DIFF
--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/BbjNodeDownloader.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/BbjNodeDownloader.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.io.HttpRequests;
 import com.intellij.util.system.CpuArch;
+import com.basis.bbj.intellij.lsp.NodeArchiveVerifier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -129,6 +130,15 @@ public final class BbjNodeDownloader {
         Path tempFile = Files.createTempFile("node-download-", platform.archiveExtension());
         try {
             download(tempFile, downloadUrl, indicator);
+
+            String archiveFileName = downloadUrl.substring(downloadUrl.lastIndexOf('/') + 1);
+            indicator.setFraction(0.4);
+            indicator.setText("Verifying Node.js archive...");
+            NodeArchiveVerifier.Result verification = NodeArchiveVerifier.verify(
+                    archiveFileName, tempFile, NodeArchiveVerifier.PINNED_DIGESTS, NodeArchiveVerifier.REAL_FILES);
+            if (!verification.isVerified()) {
+                throw new IOException(verification.failureMessage());
+            }
 
             indicator.setFraction(0.7);
             indicator.setText("Extracting Node.js binary...");

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/BbjNodeDownloader.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/BbjNodeDownloader.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.io.HttpRequests;
 import com.intellij.util.system.CpuArch;
 import com.basis.bbj.intellij.lsp.NodeArchiveVerifier;
+import com.basis.bbj.intellij.lsp.NodeInstallIntegrity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,10 +41,11 @@ public final class BbjNodeDownloader {
     }
 
     /**
-     * Gets the cached Node.js path if it exists and is executable.
-     * This method is fast and synchronous — safe to call from any thread.
-     * Note: as a side effect, this creates the plugin's Node.js data directory
-     * if it does not already exist.
+     * Gets the cached Node.js path if it exists, is executable, and its recorded install-time
+     * digest still describes it. This method is fast and synchronous — safe to call from any
+     * thread. Note: as a side effect, this creates the plugin's Node.js data directory if it
+     * does not already exist. An absent or disagreeing digest record reads as not cached, so the
+     * caller re-downloads and re-verifies rather than trusting an unrecorded file.
      *
      * @return Path to cached node executable, or null if not cached
      */
@@ -52,7 +54,8 @@ public final class BbjNodeDownloader {
             Path nodeDataDir = getNodeDataDirectory();
             Path nodePath = nodeDataDir.resolve(Platform.current().nodeExecutableName());
 
-            if (Files.exists(nodePath) && Files.isExecutable(nodePath)) {
+            if (Files.exists(nodePath) && Files.isExecutable(nodePath)
+                    && NodeInstallIntegrity.SESSION.matchesRecordedDigest(nodePath, NodeArchiveVerifier.REAL_FILES)) {
                 return nodePath;
             }
         } catch (IOException e) {
@@ -209,6 +212,9 @@ public final class BbjNodeDownloader {
         if (platform != Platform.WINDOWS) {
             targetPath.toFile().setExecutable(true);
         }
+
+        // Record the installed executable's digest so getCachedNodePath() can re-check it
+        NodeInstallIntegrity.SESSION.record(targetPath, NodeArchiveVerifier.REAL_FILES);
     }
 
     private static void cleanup(@NotNull Path tempExtractDir) {

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/NodeArchiveVerifier.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/NodeArchiveVerifier.java
@@ -1,0 +1,195 @@
+package com.basis.bbj.intellij.lsp;
+
+/**
+ * Verifies a downloaded Node.js distribution archive against a source-pinned SHA-256 digest
+ * for its exact file name, before that archive is trusted enough to extract.
+ */
+public final class NodeArchiveVerifier {
+
+    private NodeArchiveVerifier() {
+    }
+
+    /**
+     * Why a verification attempt refused an archive.
+     */
+    public enum Reason {
+        UNKNOWN_DISTRIBUTION,
+        DIGEST_MISMATCH
+    }
+
+    /**
+     * The trust anchor: maps an archive file name to its expected SHA-256 digest, or
+     * {@code null} if the name is not recognised. Injectable so a test can supply a fixed
+     * table without touching the production pins.
+     */
+    public interface DigestSource {
+        String expectedSha256(String archiveFileName);
+    }
+
+    /**
+     * A reader over an archive's bytes, injectable so a test can assert the reader was never
+     * consulted when a name has no pinned entry.
+     */
+    public interface ByteSource {
+        java.io.InputStream open(java.nio.file.Path file) throws java.io.IOException;
+    }
+
+    /**
+     * The production {@link ByteSource}, backed by {@code java.nio.file.Files}.
+     */
+    public static final ByteSource REAL_FILES = new ByteSource() {
+        @Override
+        public java.io.InputStream open(java.nio.file.Path file) throws java.io.IOException {
+            return java.nio.file.Files.newInputStream(file);
+        }
+    };
+
+    /**
+     * The pinned trust anchor for Node.js {@code v20.18.1}, transcribed from
+     * {@code https://nodejs.org/dist/v20.18.1/SHASUMS256.txt} on 2026-08-21. These values ship
+     * inside the signed plugin artifact rather than arriving over the same channel as the
+     * archive they verify, so a later reader can re-derive them from the URL above rather than
+     * trust them blindly.
+     */
+    private static final java.util.Map<String, String> PINNED_TABLE = java.util.Map.of(
+            "node-v20.18.1-darwin-arm64.tar.gz", "9e92ce1032455a9cc419fe71e908b27ae477799371b45a0844eedb02279922a4",
+            "node-v20.18.1-darwin-x64.tar.gz", "c5497dd17c8875b53712edaf99052f961013cedc203964583fc0cfc0aaf93581",
+            "node-v20.18.1-linux-arm64.tar.gz", "73cd297378572e0bc9dfc187c5ec8cca8d43aee6a596c10ebea1ed5f9ec682b6",
+            "node-v20.18.1-linux-x64.tar.gz", "259e5a8bf2e15ecece65bd2a47153262eda71c0b2c9700d5e703ce4951572784",
+            "node-v20.18.1-win-arm64.zip", "7c03744df29e81c34043a956969b3afc34171d3ab85e25fc737eb1860222444f",
+            "node-v20.18.1-win-x64.zip", "56e5aacdeee7168871721b75819ccacf2367de8761b78eaceacdecd41e04ca03"
+    );
+
+    /**
+     * The production {@link DigestSource}, backed by {@link #PINNED_TABLE}.
+     */
+    public static final DigestSource PINNED_DIGESTS = new DigestSource() {
+        @Override
+        public String expectedSha256(String archiveFileName) {
+            return PINNED_TABLE.get(archiveFileName);
+        }
+    };
+
+    /**
+     * The archive file names this class carries a pinned digest for. Used to couple the
+     * declared Node.js version to the pinned table, so a version bump without new pins fails
+     * the build rather than skipping the check.
+     */
+    public static java.util.Set<String> pinnedArchiveNames() {
+        return PINNED_TABLE.keySet();
+    }
+
+    /**
+     * The outcome of a verification attempt: either the archive's digest matched its pinned
+     * entry, or it did not — and if it did not, why. Guarded accessors throw
+     * {@link IllegalStateException} when read on the branch where they are meaningless, so a
+     * caller cannot accidentally read a digest off a refused result by accident.
+     */
+    public static final class Result {
+
+        private final boolean verified;
+        private final String archiveFileName;
+        private final Reason reason;
+        private final String expectedDigest;
+        private final String actualDigest;
+
+        private Result(boolean verified, String archiveFileName, Reason reason,
+                        String expectedDigest, String actualDigest) {
+            this.verified = verified;
+            this.archiveFileName = archiveFileName;
+            this.reason = reason;
+            this.expectedDigest = expectedDigest;
+            this.actualDigest = actualDigest;
+        }
+
+        static Result verified(String archiveFileName, String digest) {
+            return new Result(true, archiveFileName, null, digest, digest);
+        }
+
+        static Result refused(String archiveFileName, Reason reason, String expected, String actual) {
+            return new Result(false, archiveFileName, reason, expected, actual);
+        }
+
+        public boolean isVerified() {
+            return verified;
+        }
+
+        public Reason reason() {
+            if (verified) {
+                throw new IllegalStateException("reason() is only meaningful when refused");
+            }
+            return reason;
+        }
+
+        public String expectedDigest() {
+            if (verified) {
+                throw new IllegalStateException("expectedDigest() is only meaningful when refused");
+            }
+            return expectedDigest;
+        }
+
+        public String actualDigest() {
+            return actualDigest;
+        }
+
+        public String failureMessage() {
+            if (verified) {
+                throw new IllegalStateException("failureMessage() is only meaningful when refused");
+            }
+            return "Archive \"" + archiveFileName + "\" failed verification: expected digest \""
+                    + expectedDigest + "\", computed \"" + actualDigest + "\".";
+        }
+    }
+
+    /**
+     * Computes the SHA-256 digest of {@code file}, read through {@code bytes}, rendered as
+     * lower-case hexadecimal. {@code NoSuchAlgorithmException} cannot occur for SHA-256 on any
+     * conformant JDK; it is wrapped in {@link IllegalStateException} rather than widening this
+     * method's signature.
+     */
+    public static String sha256Hex(java.nio.file.Path file, ByteSource bytes) throws java.io.IOException {
+        java.security.MessageDigest digest;
+        try {
+            digest = java.security.MessageDigest.getInstance("SHA-256");
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is required to be available on every conformant JDK", e);
+        }
+        try (java.io.InputStream in = bytes.open(file)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        return java.util.HexFormat.of().formatHex(digest.digest());
+    }
+
+    /**
+     * Verifies {@code archive} against the pinned digest for {@code archiveFileName}. The pin
+     * is looked up first; a name with no pinned entry is refused with
+     * {@link Reason#UNKNOWN_DISTRIBUTION} immediately, without opening the file at all, so an
+     * unrecognised version, platform or architecture refuses rather than skipping the check.
+     * Only then is the archive's digest computed and compared, insensitive to hex letter case
+     * and to surrounding whitespace in the pinned value, using constant-shape comparison rather
+     * than {@code String.equals}.
+     */
+    public static Result verify(String archiveFileName, java.nio.file.Path archive,
+                                 DigestSource digests, ByteSource bytes) throws java.io.IOException {
+        String pinned = digests.expectedSha256(archiveFileName);
+        if (pinned == null) {
+            return Result.refused(archiveFileName, Reason.UNKNOWN_DISTRIBUTION, null, null);
+        }
+        String normalizedExpected = pinned.trim().toLowerCase(java.util.Locale.ROOT);
+        String actual = sha256Hex(archive, bytes);
+        String normalizedActual = actual.trim().toLowerCase(java.util.Locale.ROOT);
+
+        boolean matches = java.security.MessageDigest.isEqual(
+                normalizedExpected.getBytes(java.nio.charset.StandardCharsets.US_ASCII),
+                normalizedActual.getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+
+        if (!matches) {
+            return Result.refused(archiveFileName, Reason.DIGEST_MISMATCH, normalizedExpected, normalizedActual);
+        }
+        return Result.verified(archiveFileName, normalizedActual);
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/NodeInstallIntegrity.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/NodeInstallIntegrity.java
@@ -1,0 +1,117 @@
+package com.basis.bbj.intellij.lsp;
+
+/**
+ * Records the SHA-256 digest of an installed Node.js executable beside it at install time, and
+ * re-checks that record on the cache-hit path so a file merely sitting at the resolved cache
+ * path is not trusted on the strength of its existence and executable bit alone. An absent,
+ * unreadable or disagreeing record degrades to "not cached" rather than to an error or to trust,
+ * so installations that predate this change keep working by re-downloading.
+ */
+public final class NodeInstallIntegrity {
+
+    NodeInstallIntegrity() {
+    }
+
+    /**
+     * The single production instance, holding the per-session memo. Production code always
+     * calls through this instance; tests construct their own so no case can leak memo state
+     * into another, and no reset hook exists here for that reason.
+     */
+    public static final NodeInstallIntegrity SESSION = new NodeInstallIntegrity();
+
+    /**
+     * The suffix appended to an executable's file name to name its digest record, always in the
+     * same directory as the executable itself.
+     */
+    public static final String SIDECAR_SUFFIX = ".sha256";
+
+    /**
+     * The path of the digest record for {@code executable}: the executable's own file name with
+     * {@link #SIDECAR_SUFFIX} appended, resolved as a sibling so it always lives beside the file
+     * it describes.
+     */
+    public static java.nio.file.Path sidecarFor(java.nio.file.Path executable) {
+        return executable.resolveSibling(executable.getFileName().toString() + SIDECAR_SUFFIX);
+    }
+
+    /**
+     * A fingerprint of a file's identity at the moment its digest was last confirmed, cheap to
+     * compare against a fresh {@code stat} so repeated calls need not re-read file contents.
+     */
+    private record Stamp(String path, long size, long lastModifiedMillis) {
+    }
+
+    /**
+     * The most recent confirmed match, if any. Volatile because {@link #matchesRecordedDigest}
+     * is documented as callable from any thread; a stale read costs at most one extra hash, never
+     * a wrong answer, since a positive memo is only ever written after a successful comparison.
+     */
+    private volatile Stamp verified;
+
+    /**
+     * Computes the digest of {@code executable}, read through {@code bytes}, and writes it as a
+     * single lower-case hexadecimal line to {@link #sidecarFor(java.nio.file.Path)}, overwriting
+     * any prior record. Called after the executable has been copied into place and made
+     * executable, so the recorded value describes the file in its final installed state. Also
+     * primes the memo so the very next cache-hit call for this file does no rehash.
+     */
+    public void record(java.nio.file.Path executable, NodeArchiveVerifier.ByteSource bytes)
+            throws java.io.IOException {
+        String digest = NodeArchiveVerifier.sha256Hex(executable, bytes);
+        java.nio.file.Path sidecar = sidecarFor(executable);
+        java.nio.file.Files.writeString(sidecar, digest + System.lineSeparator());
+        java.io.File file = executable.toFile();
+        verified = new Stamp(executable.toAbsolutePath().toString(), file.length(), file.lastModified());
+    }
+
+    /**
+     * Whether {@code executable} still matches the digest recorded for it by
+     * {@link #record(java.nio.file.Path, NodeArchiveVerifier.ByteSource)}. Declares no checked
+     * exception and never throws: an absent sidecar, an unreadable one, an empty or malformed
+     * one, a directory where a file was expected, a missing executable, or any other
+     * {@link java.io.IOException} or {@link RuntimeException} encountered while checking all
+     * resolve to {@code false}. A {@code false} return means "treat as not cached" — the caller
+     * falls back to a fresh download and verification — it never means "trust it anyway" and it
+     * never means "fail". After the first successful comparison for a given absolute path, size
+     * and last-modified time, repeated calls return {@code true} without touching file contents
+     * again, so this method is safe and cheap to call from any thread.
+     */
+    public boolean matchesRecordedDigest(java.nio.file.Path executable, NodeArchiveVerifier.ByteSource bytes) {
+        try {
+            java.io.File file = executable.toFile();
+            String absolutePath = executable.toAbsolutePath().toString();
+            long size = file.length();
+            long lastModified = file.lastModified();
+
+            Stamp memo = verified;
+            if (memo != null
+                    && memo.path().equals(absolutePath)
+                    && memo.size() == size
+                    && memo.lastModifiedMillis() == lastModified) {
+                return true;
+            }
+
+            java.nio.file.Path sidecar = sidecarFor(executable);
+            String recorded = java.nio.file.Files.readString(sidecar).trim();
+            if (!recorded.matches("[0-9a-fA-F]{64}")) {
+                return false;
+            }
+            String normalizedRecorded = recorded.toLowerCase(java.util.Locale.ROOT);
+
+            String actual = NodeArchiveVerifier.sha256Hex(executable, bytes);
+            String normalizedActual = actual.toLowerCase(java.util.Locale.ROOT);
+
+            boolean matches = java.security.MessageDigest.isEqual(
+                    normalizedRecorded.getBytes(java.nio.charset.StandardCharsets.US_ASCII),
+                    normalizedActual.getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+
+            if (matches) {
+                verified = new Stamp(absolutePath, size, lastModified);
+                return true;
+            }
+            return false;
+        } catch (java.io.IOException | RuntimeException e) {
+            return false;
+        }
+    }
+}

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjNodeDownloaderSourceGuardTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjNodeDownloaderSourceGuardTest.java
@@ -1,0 +1,109 @@
+package com.basis.bbj.intellij.lsp;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class BbjNodeDownloaderSourceGuardTest {
+
+    private static final Path GUARDED_SOURCE = Paths.get(
+            "src", "main", "java", "com", "basis", "bbj", "intellij", "BbjNodeDownloader.java")
+            .toAbsolutePath();
+
+    private static String readGuardedSource() {
+        Path resolved = GUARDED_SOURCE;
+        if (!Files.exists(resolved)) {
+            fail("Guarded source file not found at " + resolved);
+        }
+        try {
+            return Files.readString(resolved);
+        } catch (IOException e) {
+            throw new UncheckedIOExceptionForTest(resolved, e);
+        }
+    }
+
+    private static final class UncheckedIOExceptionForTest extends RuntimeException {
+        UncheckedIOExceptionForTest(Path resolved, IOException cause) {
+            super("Failed to read " + resolved, cause);
+        }
+    }
+
+    @Test
+    void verificationCallPrecedesTheExtractionCall() {
+        String text = readGuardedSource();
+        int verifyIndex = text.indexOf("NodeArchiveVerifier.verify(");
+        int extractIndex = text.indexOf("extract(platform");
+        assertTrue(verifyIndex >= 0, "NodeArchiveVerifier.verify( is not present in the downloader file");
+        assertTrue(extractIndex >= 0, "extract(platform is not present in the downloader file");
+        assertTrue(verifyIndex < extractIndex,
+                "NodeArchiveVerifier.verify( must precede the extraction call");
+    }
+
+    @Test
+    void theExtractionCallSiteAppearsExactlyOnce() {
+        String text = readGuardedSource();
+        assertEquals(1, countOccurrences(text, "extract(platform"));
+    }
+
+    @Test
+    void verificationCallPrecedesTheInstallCall() {
+        String text = readGuardedSource();
+        int verifyIndex = text.indexOf("NodeArchiveVerifier.verify(");
+        int installIndex = text.indexOf("install(platform");
+        assertTrue(verifyIndex >= 0, "NodeArchiveVerifier.verify( is not present in the downloader file");
+        assertTrue(installIndex >= 0, "install(platform is not present in the downloader file");
+        assertTrue(verifyIndex < installIndex,
+                "NodeArchiveVerifier.verify( must precede the install call");
+    }
+
+    @Test
+    void everyPlatformAndArchitectureTheFileCanProduceHasAPinnedDigest() {
+        String text = readGuardedSource();
+        String marker = "NODE_VERSION = \"";
+        int versionStart = text.indexOf(marker);
+        assertTrue(versionStart >= 0, "NODE_VERSION = \" is not present in the downloader file");
+        versionStart += marker.length();
+        int versionEnd = text.indexOf('"', versionStart);
+        assertTrue(versionEnd >= 0, "NODE_VERSION declaration is not properly quoted");
+        String version = text.substring(versionStart, versionEnd);
+
+        String[] platforms = {"darwin", "linux", "win"};
+        String[] archs = {"arm64", "x64"};
+        for (String platform : platforms) {
+            for (String arch : archs) {
+                String extension = platform.equals("win") ? ".zip" : ".tar.gz";
+                String archiveFileName = "node-" + version + "-" + platform + "-" + arch + extension;
+                assertTrue(NodeArchiveVerifier.pinnedArchiveNames().contains(archiveFileName),
+                        "No pinned digest for " + archiveFileName
+                                + " — bumping NODE_VERSION requires adding pins for every combination");
+            }
+        }
+    }
+
+    @Test
+    void theFileNamesExactlyTheThreePlatformLiteralsAndTwoArchitectureLiterals() {
+        String text = readGuardedSource();
+        assertEquals(1, countOccurrences(text, "return \"darwin\";"));
+        assertEquals(1, countOccurrences(text, "return \"linux\";"));
+        assertEquals(1, countOccurrences(text, "return \"win\";"));
+        assertEquals(1, countOccurrences(text, "return \"arm64\";"));
+        assertEquals(1, countOccurrences(text, "return \"x64\";"));
+    }
+
+    private static int countOccurrences(String text, String literal) {
+        int count = 0;
+        int index = 0;
+        while ((index = text.indexOf(literal, index)) != -1) {
+            count++;
+            index += literal.length();
+        }
+        return count;
+    }
+}

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjNodeDownloaderSourceGuardTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjNodeDownloaderSourceGuardTest.java
@@ -97,6 +97,36 @@ class BbjNodeDownloaderSourceGuardTest {
         assertEquals(1, countOccurrences(text, "return \"x64\";"));
     }
 
+    @Test
+    void theCacheHitPathConsultsTheRecordedDigestBeforeReturning() {
+        String text = readGuardedSource();
+        int executableIndex = text.indexOf("Files.isExecutable(nodePath)");
+        int matchesIndex = text.indexOf("matchesRecordedDigest(");
+        int returnIndex = text.indexOf("return nodePath;");
+        assertTrue(executableIndex >= 0, "Files.isExecutable(nodePath) is not present in the downloader file");
+        assertTrue(matchesIndex >= 0, "matchesRecordedDigest( is not present in the downloader file");
+        assertTrue(returnIndex >= 0, "return nodePath; is not present in the downloader file");
+        assertTrue(executableIndex < matchesIndex,
+                "Files.isExecutable(nodePath) must precede matchesRecordedDigest(");
+        assertTrue(matchesIndex < returnIndex,
+                "matchesRecordedDigest( must precede the cached-path return");
+        assertEquals(1, countOccurrences(text, "return nodePath;"),
+                "there must be exactly one, guarded return of the cached path");
+    }
+
+    @Test
+    void theInstalledDigestIsRecordedAfterTheCopy() {
+        String text = readGuardedSource();
+        int copyIndex = text.indexOf("Files.copy(");
+        int recordIndex = text.indexOf("SESSION.record(");
+        assertTrue(copyIndex >= 0, "Files.copy( is not present in the downloader file");
+        assertTrue(recordIndex >= 0, "SESSION.record( is not present in the downloader file");
+        assertTrue(copyIndex < recordIndex,
+                "SESSION.record( must come after Files.copy( so it describes the installed file");
+        assertEquals(1, countOccurrences(text, "SESSION.record("),
+                "the sidecar must be written exactly once, for the installed file");
+    }
+
     private static int countOccurrences(String text, String literal) {
         int count = 0;
         int index = 0;

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/NodeArchiveVerifierTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/NodeArchiveVerifierTest.java
@@ -1,0 +1,264 @@
+package com.basis.bbj.intellij.lsp;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NodeArchiveVerifierTest {
+
+    private static final String KNOWN_NAME = "node-v20.18.1-linux-x64.tar.gz";
+    private static final String UNKNOWN_NAME = "node-v20.18.1-solaris-sparc64.tar.gz";
+    private static final Pattern LOWER_HEX_64 = Pattern.compile("^[0-9a-f]{64}$");
+
+    /**
+     * A {@link NodeArchiveVerifier.ByteSource} that delegates to {@code Files.newInputStream}
+     * but counts invocations, so a case can assert the file was never opened.
+     */
+    private static final class RecordingByteSource implements NodeArchiveVerifier.ByteSource {
+        private final AtomicInteger invocationCount = new AtomicInteger();
+
+        int invocations() {
+            return invocationCount.get();
+        }
+
+        @Override
+        public InputStream open(Path file) throws IOException {
+            invocationCount.incrementAndGet();
+            return Files.newInputStream(file);
+        }
+    }
+
+    /**
+     * A {@link NodeArchiveVerifier.DigestSource} backed by a fixed map supplied by the test,
+     * returning {@code null} for anything else — each case pins exactly what it means to pin.
+     */
+    private static final class FixedDigestSource implements NodeArchiveVerifier.DigestSource {
+        private final Map<String, String> pins;
+
+        FixedDigestSource(Map<String, String> pins) {
+            this.pins = pins;
+        }
+
+        @Override
+        public String expectedSha256(String archiveFileName) {
+            return pins.get(archiveFileName);
+        }
+    }
+
+    private static String realSha256(Path file) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+        try (InputStream in = Files.newInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    @Test
+    void aFileWhoseRealDigestIsPinnedForItsNameVerifies(@TempDir Path tempDir) throws IOException {
+        Path archive = tempDir.resolve(KNOWN_NAME);
+        Files.write(archive, "known good archive bytes".getBytes(StandardCharsets.UTF_8));
+        String expected = realSha256(archive);
+        FixedDigestSource digests = new FixedDigestSource(Map.of(KNOWN_NAME, expected));
+
+        NodeArchiveVerifier.Result result = NodeArchiveVerifier.verify(
+                KNOWN_NAME, archive, digests, NodeArchiveVerifier.REAL_FILES);
+
+        assertTrue(result.isVerified(), "a matching digest must verify");
+        assertEquals(expected, result.actualDigest(), "actualDigest() must equal the computed digest");
+    }
+
+    @Test
+    void aFileWithOneByteAlteredIsRefusedWithDigestMismatch(@TempDir Path tempDir) throws IOException {
+        Path goodArchive = tempDir.resolve("good.tar.gz");
+        Files.write(goodArchive, "known good archive bytes".getBytes(StandardCharsets.UTF_8));
+        String expected = realSha256(goodArchive);
+
+        Path alteredArchive = tempDir.resolve(KNOWN_NAME);
+        byte[] bytes = Files.readAllBytes(goodArchive);
+        bytes[0] = (byte) (bytes[0] ^ 0xFF);
+        Files.write(alteredArchive, bytes);
+
+        FixedDigestSource digests = new FixedDigestSource(Map.of(KNOWN_NAME, expected));
+
+        NodeArchiveVerifier.Result result = NodeArchiveVerifier.verify(
+                KNOWN_NAME, alteredArchive, digests, NodeArchiveVerifier.REAL_FILES);
+
+        assertFalse(result.isVerified(), "an altered archive must not verify");
+        assertEquals(NodeArchiveVerifier.Reason.DIGEST_MISMATCH, result.reason());
+        assertNotEquals(result.expectedDigest(), result.actualDigest(),
+                "expectedDigest() and actualDigest() must differ on a mismatch");
+        // actualDigest() remains legal to read on the refused branch.
+        assertEquals(64, result.actualDigest().length());
+    }
+
+    @Test
+    void aZeroByteFileIsRefusedAgainstAKnownPin(@TempDir Path tempDir) throws IOException {
+        Path archive = tempDir.resolve(KNOWN_NAME);
+        Files.write(archive, new byte[0]);
+        FixedDigestSource digests = new FixedDigestSource(
+                Map.of(KNOWN_NAME, "9999999999999999999999999999999999999999999999999999999999999999"));
+
+        NodeArchiveVerifier.Result result = NodeArchiveVerifier.verify(
+                KNOWN_NAME, archive, digests, NodeArchiveVerifier.REAL_FILES);
+
+        assertFalse(result.isVerified(), "a zero-byte archive must not verify against an unrelated pin");
+        assertEquals(NodeArchiveVerifier.Reason.DIGEST_MISMATCH, result.reason());
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", result.actualDigest(),
+                "the empty-input SHA-256 digest is well known and must match the computed digest exactly");
+    }
+
+    @Test
+    void anUnrecognisedArchiveNameIsRefusedWithoutConsultingTheReader(@TempDir Path tempDir) throws IOException {
+        Path archive = tempDir.resolve(UNKNOWN_NAME);
+        Files.write(archive, "irrelevant".getBytes(StandardCharsets.UTF_8));
+        RecordingByteSource reader = new RecordingByteSource();
+        FixedDigestSource digests = new FixedDigestSource(Map.of(KNOWN_NAME, "irrelevant-pin"));
+
+        NodeArchiveVerifier.Result result = NodeArchiveVerifier.verify(
+                UNKNOWN_NAME, archive, digests, reader);
+
+        assertFalse(result.isVerified(), "an unrecognised archive name must not verify");
+        assertEquals(NodeArchiveVerifier.Reason.UNKNOWN_DISTRIBUTION, result.reason());
+        assertEquals(0, reader.invocations(),
+                "the reader must never be consulted when there is no pinned entry for the name");
+    }
+
+    @Test
+    void aPinSuppliedInUpperCaseWithSurroundingWhitespaceStillMatches(@TempDir Path tempDir) throws IOException {
+        Path archive = tempDir.resolve(KNOWN_NAME);
+        Files.write(archive, "known good archive bytes".getBytes(StandardCharsets.UTF_8));
+        String expected = realSha256(archive);
+        String differentlyFormatted = "  " + expected.toUpperCase(java.util.Locale.ROOT) + "  \n";
+        FixedDigestSource digests = new FixedDigestSource(Map.of(KNOWN_NAME, differentlyFormatted));
+
+        NodeArchiveVerifier.Result result = NodeArchiveVerifier.verify(
+                KNOWN_NAME, archive, digests, NodeArchiveVerifier.REAL_FILES);
+
+        assertTrue(result.isVerified(),
+                "a pin transcribed in upper case with surrounding whitespace must still match the same bytes");
+    }
+
+    @Test
+    void expectedDigestOnAVerifiedResultThrows(@TempDir Path tempDir) throws IOException {
+        Path archive = tempDir.resolve(KNOWN_NAME);
+        Files.write(archive, "known good archive bytes".getBytes(StandardCharsets.UTF_8));
+        String expected = realSha256(archive);
+        FixedDigestSource digests = new FixedDigestSource(Map.of(KNOWN_NAME, expected));
+
+        NodeArchiveVerifier.Result result = NodeArchiveVerifier.verify(
+                KNOWN_NAME, archive, digests, NodeArchiveVerifier.REAL_FILES);
+
+        assertTrue(result.isVerified());
+        assertThrows(IllegalStateException.class, result::expectedDigest,
+                "expectedDigest() is only meaningful when refused");
+        assertThrows(IllegalStateException.class, result::reason,
+                "reason() is only meaningful when refused");
+        assertThrows(IllegalStateException.class, result::failureMessage,
+                "failureMessage() is only meaningful when refused");
+    }
+
+    @Test
+    void failureMessageNamesTheArchiveFileNameTheExpectedValueAndTheComputedValue(@TempDir Path tempDir)
+            throws IOException {
+        Path goodArchive = tempDir.resolve("good.tar.gz");
+        Files.write(goodArchive, "known good archive bytes".getBytes(StandardCharsets.UTF_8));
+        String expected = realSha256(goodArchive);
+
+        Path alteredArchive = tempDir.resolve(KNOWN_NAME);
+        byte[] bytes = Files.readAllBytes(goodArchive);
+        bytes[0] = (byte) (bytes[0] ^ 0xFF);
+        Files.write(alteredArchive, bytes);
+        String actual = realSha256(alteredArchive);
+
+        FixedDigestSource digests = new FixedDigestSource(Map.of(KNOWN_NAME, expected));
+
+        NodeArchiveVerifier.Result result = NodeArchiveVerifier.verify(
+                KNOWN_NAME, alteredArchive, digests, NodeArchiveVerifier.REAL_FILES);
+
+        String message = result.failureMessage();
+        assertTrue(message.contains(KNOWN_NAME), "failureMessage() must name the archive file name");
+        assertTrue(message.contains(expected), "failureMessage() must name the expected digest");
+        assertTrue(message.contains(actual), "failureMessage() must name the computed digest");
+    }
+
+    @Test
+    void anIoFailureOpeningTheArchivePropagatesAsIoException(@TempDir Path tempDir) {
+        Path missing = tempDir.resolve(KNOWN_NAME);
+        // Deliberately not created — Files.newInputStream on a missing file throws IOException.
+        FixedDigestSource digests = new FixedDigestSource(Map.of(KNOWN_NAME, "irrelevant-pin"));
+
+        assertThrows(IOException.class, () -> NodeArchiveVerifier.verify(
+                KNOWN_NAME, missing, digests, NodeArchiveVerifier.REAL_FILES),
+                "an I/O failure opening the archive must propagate rather than being converted "
+                        + "into a verified result");
+    }
+
+    @Nested
+    class ProductionConstants {
+
+        @Test
+        void pinnedArchiveNamesHasExactlySixEntries() {
+            assertEquals(6, NodeArchiveVerifier.pinnedArchiveNames().size());
+        }
+
+        @Test
+        void pinnedArchiveNamesContainsEachOfTheSixDeclaredFileNames() {
+            Set<String> names = NodeArchiveVerifier.pinnedArchiveNames();
+            assertTrue(names.contains("node-v20.18.1-darwin-arm64.tar.gz"));
+            assertTrue(names.contains("node-v20.18.1-darwin-x64.tar.gz"));
+            assertTrue(names.contains("node-v20.18.1-linux-arm64.tar.gz"));
+            assertTrue(names.contains("node-v20.18.1-linux-x64.tar.gz"));
+            assertTrue(names.contains("node-v20.18.1-win-arm64.zip"));
+            assertTrue(names.contains("node-v20.18.1-win-x64.zip"));
+        }
+
+        @Test
+        void pinnedArchiveNamesReturnsAnUnmodifiableSet() {
+            Set<String> names = NodeArchiveVerifier.pinnedArchiveNames();
+            assertThrows(UnsupportedOperationException.class, () -> names.add("node-v99.99.99-linux-x64.tar.gz"));
+        }
+
+        @Test
+        void pinnedDigestsReturnsNullForAnUnknownName() {
+            assertNull(NodeArchiveVerifier.PINNED_DIGESTS.expectedSha256(UNKNOWN_NAME));
+        }
+
+        @Test
+        void everyPinnedValueIs64LowerCaseHexCharacters() {
+            for (String name : NodeArchiveVerifier.pinnedArchiveNames()) {
+                String value = NodeArchiveVerifier.PINNED_DIGESTS.expectedSha256(name);
+                assertTrue(LOWER_HEX_64.matcher(value).matches(),
+                        "pinned value for " + name + " must be 64 lower-case hex characters, was: " + value);
+            }
+        }
+    }
+}

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/NodeInstallIntegrityTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/NodeInstallIntegrityTest.java
@@ -1,0 +1,167 @@
+package com.basis.bbj.intellij.lsp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Offline, deterministic coverage of {@link NodeInstallIntegrity}'s cache-hit contract: the
+ * matching, absent, disagreeing, malformed, missing-file, directory-in-place-of-file and memo
+ * cases. Every fixture is a small file under {@link TempDir}; none of these tests attempt to
+ * reproduce a real Node.js binary's size.
+ */
+class NodeInstallIntegrityTest {
+
+    @TempDir
+    Path tempDir;
+
+    private static Path writeExecutable(Path dir, String name, byte[] bytes) throws IOException {
+        Path executable = dir.resolve(name);
+        Files.write(executable, bytes);
+        return executable;
+    }
+
+    @Test
+    void afterRecordingAFreshInstanceMatchesTheRecordedDigestAndTheSidecarHoldsALowerCase64CharacterHexLine()
+            throws IOException {
+        Path executable = writeExecutable(tempDir, "node", "some node binary bytes".getBytes(StandardCharsets.UTF_8));
+
+        new NodeInstallIntegrity().record(executable, NodeArchiveVerifier.REAL_FILES);
+
+        boolean matches = new NodeInstallIntegrity().matchesRecordedDigest(executable, NodeArchiveVerifier.REAL_FILES);
+        assertTrue(matches, "a freshly recorded digest must match on a fresh instance");
+
+        Path sidecar = NodeInstallIntegrity.sidecarFor(executable);
+        assertTrue(Files.exists(sidecar), "record() must create the sidecar file");
+        String line = Files.readString(sidecar).trim();
+        assertEquals(64, line.length(), "the sidecar must hold exactly 64 hex characters");
+        assertTrue(line.matches("[0-9a-f]{64}"), "the sidecar must be lower-case hexadecimal, was: " + line);
+    }
+
+    @Test
+    void withNoSidecarPresentMatchesRecordedDigestReturnsFalseAndThrowsNothing() throws IOException {
+        Path executable = writeExecutable(tempDir, "node", "no sidecar for this one".getBytes(StandardCharsets.UTF_8));
+
+        boolean matches = assertDoesNotThrow(
+                () -> new NodeInstallIntegrity().matchesRecordedDigest(executable, NodeArchiveVerifier.REAL_FILES),
+                "an absent sidecar must not throw");
+        assertFalse(matches, "an absent sidecar must read as not cached");
+    }
+
+    @Test
+    void withASidecarRecordingTheDigestOfDifferentBytesMatchesRecordedDigestReturnsFalse() throws IOException {
+        Path executable = writeExecutable(tempDir, "node", "the real installed bytes".getBytes(StandardCharsets.UTF_8));
+        Path other = writeExecutable(tempDir, "other", "entirely different bytes".getBytes(StandardCharsets.UTF_8));
+        new NodeInstallIntegrity().record(other, NodeArchiveVerifier.REAL_FILES);
+        // Move the "other" digest onto the executable's sidecar so it records the wrong digest.
+        Files.copy(NodeInstallIntegrity.sidecarFor(other), NodeInstallIntegrity.sidecarFor(executable));
+
+        boolean matches = new NodeInstallIntegrity().matchesRecordedDigest(executable, NodeArchiveVerifier.REAL_FILES);
+        assertFalse(matches, "a sidecar recording a different file's digest must not match");
+    }
+
+    @Test
+    void malformedSidecarsAllDegradeToNotCachedWithoutThrowing() throws IOException {
+        Path executable = writeExecutable(tempDir, "node", "bytes for the malformed-sidecar cases".getBytes(StandardCharsets.UTF_8));
+        Path sidecar = NodeInstallIntegrity.sidecarFor(executable);
+
+        String[] malformedContents = {
+                "",
+                "   \n\t  ",
+                "a".repeat(63),
+                "a".repeat(65),
+                "g".repeat(64), // not hex
+        };
+        for (String content : malformedContents) {
+            Files.writeString(sidecar, content);
+            boolean matches = assertDoesNotThrow(
+                    () -> new NodeInstallIntegrity().matchesRecordedDigest(executable, NodeArchiveVerifier.REAL_FILES),
+                    "a malformed sidecar (\"" + content + "\") must not throw");
+            assertFalse(matches, "a malformed sidecar (\"" + content + "\") must read as not cached");
+        }
+    }
+
+    @Test
+    void whenTheExecutableItselfDoesNotExistMatchesRecordedDigestReturnsFalseAndThrowsNothing() throws IOException {
+        Path executable = tempDir.resolve("node");
+        Path sidecar = NodeInstallIntegrity.sidecarFor(executable);
+        Files.writeString(sidecar, "a".repeat(64));
+
+        boolean matches = assertDoesNotThrow(
+                () -> new NodeInstallIntegrity().matchesRecordedDigest(executable, NodeArchiveVerifier.REAL_FILES),
+                "a missing executable must not throw");
+        assertFalse(matches, "a missing executable must read as not cached");
+    }
+
+    @Test
+    void whenTheSidecarPathIsADirectoryMatchesRecordedDigestReturnsFalseAndThrowsNothing() throws IOException {
+        Path executable = writeExecutable(tempDir, "node", "bytes".getBytes(StandardCharsets.UTF_8));
+        Path sidecar = NodeInstallIntegrity.sidecarFor(executable);
+        Files.createDirectory(sidecar);
+
+        boolean matches = assertDoesNotThrow(
+                () -> new NodeInstallIntegrity().matchesRecordedDigest(executable, NodeArchiveVerifier.REAL_FILES),
+                "a sidecar that is a directory must not throw");
+        assertFalse(matches, "a sidecar that is a directory must read as not cached");
+    }
+
+    @Test
+    void afterTheFilesBytesChangeAFreshInstanceNoLongerMatchesEvenWithAValidSidecarPresent() throws IOException {
+        Path executable = writeExecutable(tempDir, "node", "original bytes".getBytes(StandardCharsets.UTF_8));
+        new NodeInstallIntegrity().record(executable, NodeArchiveVerifier.REAL_FILES);
+
+        Files.write(executable, "rewritten bytes, different digest".getBytes(StandardCharsets.UTF_8));
+
+        boolean matches = new NodeInstallIntegrity().matchesRecordedDigest(executable, NodeArchiveVerifier.REAL_FILES);
+        assertFalse(matches, "a fresh instance must recompute and detect the changed content");
+    }
+
+    @Test
+    void aSecondCallOnTheSameInstanceWithTheFileUnchangedReturnsTrueAgainViaTheMemo() throws IOException {
+        Path executable = writeExecutable(tempDir, "node", "stable bytes".getBytes(StandardCharsets.UTF_8));
+        NodeInstallIntegrity integrity = new NodeInstallIntegrity();
+        integrity.record(executable, NodeArchiveVerifier.REAL_FILES);
+
+        assertTrue(integrity.matchesRecordedDigest(executable, NodeArchiveVerifier.REAL_FILES),
+                "first call must match");
+        assertTrue(integrity.matchesRecordedDigest(executable, NodeArchiveVerifier.REAL_FILES),
+                "second call on the same instance with the file unchanged must also match");
+    }
+
+    @Test
+    void sidecarForPlacesTheRecordBesideTheExecutableAndDerivesItsNameFromTheExecutablesFileName() {
+        Path node = tempDir.resolve("node");
+        Path nodeExe = tempDir.resolve("node.exe");
+
+        Path nodeSidecar = NodeInstallIntegrity.sidecarFor(node);
+        Path nodeExeSidecar = NodeInstallIntegrity.sidecarFor(nodeExe);
+
+        assertEquals(tempDir.resolve("node.sha256"), nodeSidecar, "node's sidecar must be node.sha256");
+        assertEquals(tempDir.resolve("node.exe.sha256"), nodeExeSidecar, "node.exe's sidecar must be node.exe.sha256");
+        assertTrue(nodeSidecar.getParent().equals(node.getParent()), "the sidecar must live beside the executable");
+    }
+
+    @Test
+    void recordOverwritesAnExistingSidecarRatherThanAppendingToIt() throws IOException {
+        Path executable = writeExecutable(tempDir, "node", "first version of the bytes".getBytes(StandardCharsets.UTF_8));
+        NodeInstallIntegrity integrity = new NodeInstallIntegrity();
+        integrity.record(executable, NodeArchiveVerifier.REAL_FILES);
+        String firstDigest = Files.readString(NodeInstallIntegrity.sidecarFor(executable)).trim();
+
+        Files.write(executable, "second, different version of the bytes".getBytes(StandardCharsets.UTF_8));
+        integrity.record(executable, NodeArchiveVerifier.REAL_FILES);
+        String secondContent = Files.readString(NodeInstallIntegrity.sidecarFor(executable)).trim();
+
+        assertEquals(64, secondContent.length(), "the sidecar must hold exactly one 64-character digest, not an appended pair");
+        assertTrue(!secondContent.equals(firstDigest), "the recorded digest must reflect the new bytes");
+    }
+}


### PR DESCRIPTION
The IntelliJ plugin downloads a Node.js distribution archive to host the language server.

It now compares the archive's SHA-256 digest against the digest the Node.js project publishes for that exact version, platform and architecture — transcribed into the plugin source — before extracting it, and refuses to extract or install on a disagreement.

The installed executable's digest is recorded beside it and re-checked on the cache-hit path, with an absent or disagreeing record treated as "not cached" so existing installations simply re-download.

Offline JUnit tests cover it, which `buildPlugin` already gates.
