### PR TITLE
Pass Enterprise Manager credentials and tokens via environment instead of command-line arguments

### DIFF
--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjEMLoginAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjEMLoginAction.java
@@ -93,8 +93,9 @@ public final class BbjEMLoginAction extends AnAction {
 
         // Launch em-login.bbj
         try {
-            // Create temp file for BBj output
-            Path tmpFile = Files.createTempFile("bbj-em-login-", ".tmp");
+            // Create temp file for BBj output, owner-only for its whole life: em-login.bbj
+            // truncates and writes in place, which preserves the mode set here.
+            Path tmpFile = BbjProcessSecretEnv.createOwnerOnlyFile("bbj-em-login-", ".tmp");
 
             // Client info for EM token payload
             String platform;

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjEMLoginAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjEMLoginAction.java
@@ -1,6 +1,7 @@
 package com.basis.bbj.intellij.actions;
 
 import com.basis.bbj.intellij.BbjSettings;
+import com.basis.bbj.intellij.lsp.BbjProcessSecretEnv;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.execution.process.ProcessOutput;
@@ -95,21 +96,21 @@ public final class BbjEMLoginAction extends AnAction {
             // Create temp file for BBj output
             Path tmpFile = Files.createTempFile("bbj-em-login-", ".tmp");
 
-            GeneralCommandLine cmd = new GeneralCommandLine(bbjPath.toString());
-            cmd.addParameter("-q");
-            cmd.addParameter(emLoginPath);
-            cmd.addParameter("-");
-            cmd.addParameter(username);
-            cmd.addParameter(password);
-            cmd.addParameter(tmpFile.toString());
-
             // Client info for EM token payload
             String platform;
             if (os.contains("win")) platform = "Windows";
             else if (os.contains("mac")) platform = "MacOS";
             else platform = "Linux";
             String productName = ApplicationNamesInfo.getInstance().getFullProductName();
-            cmd.addParameter(productName + " on " + platform + " as " + System.getProperty("user.name"));
+            String infoString = productName + " on " + platform + " as " + System.getProperty("user.name");
+
+            // Build the invocation: the username and password travel on the environment
+            // (BbjProcessSecretEnv), never as a parameter.
+            BbjProcessSecretEnv.Invocation invocation =
+                    BbjProcessSecretEnv.emLogin(emLoginPath, username, password, tmpFile.toString(), infoString);
+            GeneralCommandLine cmd = new GeneralCommandLine(bbjPath.toString());
+            cmd.addParameters(invocation.parameters());
+            cmd.withEnvironment(invocation.environment());
 
             CapturingProcessHandler handler = new CapturingProcessHandler(cmd);
             ProcessOutput output = handler.runProcess(15000); // 15s timeout

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunActionBase.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunActionBase.java
@@ -1,6 +1,7 @@
 package com.basis.bbj.intellij.actions;
 
 import com.basis.bbj.intellij.BbjSettings;
+import com.basis.bbj.intellij.lsp.BbjProcessSecretEnv;
 import com.basis.bbj.intellij.ui.BbjServerService;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
@@ -294,13 +295,13 @@ public abstract class BbjRunActionBase extends AnAction {
             // Create temp file for BBj output
             Path tmpFile = Files.createTempFile("bbj-em-validate-", ".tmp");
             try {
-                // Build command: bbj -q em-validate-token.bbj - <token> <tmpFile>
+                // Build command: bbj -q em-validate-token.bbj - <tmpFile>; the token
+                // travels on the environment (BbjProcessSecretEnv), never as a parameter.
+                BbjProcessSecretEnv.Invocation invocation =
+                        BbjProcessSecretEnv.emValidateToken(emValidatePath, token, tmpFile.toString());
                 GeneralCommandLine cmd = new GeneralCommandLine(bbjPath);
-                cmd.addParameter("-q");
-                cmd.addParameter(emValidatePath);
-                cmd.addParameter("-");
-                cmd.addParameter(token);
-                cmd.addParameter(tmpFile.toString());
+                cmd.addParameters(invocation.parameters());
+                cmd.withEnvironment(invocation.environment());
 
                 // Execute with 10s timeout
                 com.intellij.execution.process.CapturingProcessHandler handler =

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunActionBase.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunActionBase.java
@@ -292,8 +292,8 @@ public abstract class BbjRunActionBase extends AnAction {
                 return false;
             }
 
-            // Create temp file for BBj output
-            Path tmpFile = Files.createTempFile("bbj-em-validate-", ".tmp");
+            // Create temp file for BBj output, owner-only for its whole life
+            Path tmpFile = BbjProcessSecretEnv.createOwnerOnlyFile("bbj-em-validate-", ".tmp");
             try {
                 // Build command: bbj -q em-validate-token.bbj - <tmpFile>; the token
                 // travels on the environment (BbjProcessSecretEnv), never as a parameter.

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunBuiAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunBuiAction.java
@@ -2,6 +2,7 @@ package com.basis.bbj.intellij.actions;
 
 import com.basis.bbj.intellij.BbjIcons;
 import com.basis.bbj.intellij.BbjSettings;
+import com.basis.bbj.intellij.lsp.BbjProcessSecretEnv;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
@@ -108,26 +109,17 @@ public final class BbjRunBuiAction extends BbjRunActionBase {
         BbjSettings.State state = BbjSettings.getInstance().getState();
         String classpath = (state.classpathEntry != null && !"--".equals(state.classpathEntry)) ? state.classpathEntry : "";
 
-        // Get config path - only add if configured (web.bbj handles absent ARGV(9) gracefully)
+        // Get config path - only add if configured (web.bbj handles absent ARGV(6) gracefully)
         String configPath = getConfigPath();
 
-        // Build command line: bbj -q -WD<webRunnerDir> <webBbjPath> - "BUI" <name> <programme> <workingDir> "" "" <classpath> <token> <configPath>
+        // Build command line: bbj -q -WD<webRunnerDir> <webBbjPath> - "BUI" <name> <programme>
+        // <workingDir> <classpath> [<configPath>]; the token travels on the environment
+        // (BbjProcessSecretEnv), never as a parameter.
+        BbjProcessSecretEnv.Invocation invocation = BbjProcessSecretEnv.webRun(
+                webRunnerDir, webBbjPath, "BUI", name, programme, workingDir, classpath, token, configPath);
         GeneralCommandLine cmd = new GeneralCommandLine(bbjPath);
-        cmd.addParameter("-q");
-        cmd.addParameter("-WD" + webRunnerDir);
-        cmd.addParameter(webBbjPath);
-        cmd.addParameter("-");
-        cmd.addParameter("BUI");
-        cmd.addParameter(name);
-        cmd.addParameter(programme);
-        cmd.addParameter(workingDir);
-        cmd.addParameter("");  // username placeholder
-        cmd.addParameter("");  // password placeholder
-        cmd.addParameter(classpath);
-        cmd.addParameter(token);
-        if (!configPath.isEmpty()) {
-            cmd.addParameter(configPath);
-        }
+        cmd.addParameters(invocation.parameters());
+        cmd.withEnvironment(invocation.environment());
 
         cmd.setWorkDirectory(webRunnerDir);
 

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunDwcAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunDwcAction.java
@@ -2,6 +2,7 @@ package com.basis.bbj.intellij.actions;
 
 import com.basis.bbj.intellij.BbjIcons;
 import com.basis.bbj.intellij.BbjSettings;
+import com.basis.bbj.intellij.lsp.BbjProcessSecretEnv;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
@@ -108,26 +109,17 @@ public final class BbjRunDwcAction extends BbjRunActionBase {
         BbjSettings.State state = BbjSettings.getInstance().getState();
         String classpath = (state.classpathEntry != null && !"--".equals(state.classpathEntry)) ? state.classpathEntry : "";
 
-        // Get config path - only add if configured (web.bbj handles absent ARGV(9) gracefully)
+        // Get config path - only add if configured (web.bbj handles absent ARGV(6) gracefully)
         String configPath = getConfigPath();
 
-        // Build command line: bbj -q -WD<webRunnerDir> <webBbjPath> - "DWC" <name> <programme> <workingDir> "" "" <classpath> <token> <configPath>
+        // Build command line: bbj -q -WD<webRunnerDir> <webBbjPath> - "DWC" <name> <programme>
+        // <workingDir> <classpath> [<configPath>]; the token travels on the environment
+        // (BbjProcessSecretEnv), never as a parameter.
+        BbjProcessSecretEnv.Invocation invocation = BbjProcessSecretEnv.webRun(
+                webRunnerDir, webBbjPath, "DWC", name, programme, workingDir, classpath, token, configPath);
         GeneralCommandLine cmd = new GeneralCommandLine(bbjPath);
-        cmd.addParameter("-q");
-        cmd.addParameter("-WD" + webRunnerDir);
-        cmd.addParameter(webBbjPath);
-        cmd.addParameter("-");
-        cmd.addParameter("DWC");
-        cmd.addParameter(name);
-        cmd.addParameter(programme);
-        cmd.addParameter(workingDir);
-        cmd.addParameter("");  // username placeholder
-        cmd.addParameter("");  // password placeholder
-        cmd.addParameter(classpath);
-        cmd.addParameter(token);
-        if (!configPath.isEmpty()) {
-            cmd.addParameter(configPath);
-        }
+        cmd.addParameters(invocation.parameters());
+        cmd.withEnvironment(invocation.environment());
 
         cmd.setWorkDirectory(webRunnerDir);
 

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnv.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnv.java
@@ -1,7 +1,15 @@
 package com.basis.bbj.intellij.lsp;
 
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Builds the parameter list and environment map for BBj processes that carry Enterprise
@@ -46,5 +54,70 @@ public final class BbjProcessSecretEnv {
                 List.of("-q", scriptPath, "-", outputFile),
                 Map.of(TOKEN_VAR, token)
         );
+    }
+
+    /**
+     * Builds the invocation for {@code em-login.bbj}: the username travels on
+     * {@link #USERNAME_VAR} and the password on {@link #PASSWORD_VAR} in the returned
+     * environment map; the returned parameter list carries only the quiet flag, the
+     * script path, the {@code -} separator, the output file and the info string —
+     * never the username or the password. Both keys are always written, even when a
+     * value is empty, so an inherited parent-environment variable of the same name can
+     * never be read in place of the intended value.
+     */
+    // TASK-1-SKELETON: reproduces pre-fix behaviour (secrets in parameters, nothing in
+    // the environment) so the new unit tests compile and observe RED. Task 2 replaces
+    // this body with the real environment-channel implementation.
+    public static Invocation emLogin(
+            String scriptPath, String username, String password, String outputFile, String infoString) {
+        return new Invocation(
+                List.of("-q", scriptPath, "-", username, password, outputFile, infoString),
+                Map.of()
+        );
+    }
+
+    /**
+     * Builds the invocation for {@code web.bbj}: the username, password and token
+     * travel on {@link #USERNAME_VAR}, {@link #PASSWORD_VAR} and {@link #TOKEN_VAR} in
+     * the returned environment map; the returned parameter list never carries any of
+     * the three. All three keys are always written, even when a value is empty, so an
+     * inherited parent-environment variable of the same name can never be read in
+     * place of the intended value. The config path is appended as a positional
+     * argument only when it is non-empty, matching {@code web.bbj}'s tolerance of an
+     * absent final position.
+     */
+    // TASK-1-SKELETON: reproduces pre-fix behaviour (secrets in parameters, nothing in
+    // the environment) so the new unit tests compile and observe RED. Task 2 replaces
+    // this body with the real environment-channel implementation.
+    public static Invocation webRun(
+            String webRunnerDir, String webBbjPath, String client, String name, String programme,
+            String workingDir, String classpath, String token, String configPath) {
+        List<String> parameters = new ArrayList<>(List.of(
+                "-q", "-WD" + webRunnerDir, webBbjPath, "-",
+                client, name, programme, workingDir, "", "", classpath, token
+        ));
+        if (!configPath.isEmpty()) {
+            parameters.add(configPath);
+        }
+        return new Invocation(parameters, Map.of());
+    }
+
+    /**
+     * Creates a new empty temporary file, named {@code prefix<random>suffix} in the
+     * platform default temporary-file directory, that is owner-only for its whole
+     * life: no group or other principal can read or write it at any point between
+     * creation and deletion. On a filesystem whose default provider reports POSIX
+     * attribute-view support, the file is created with exactly the owner-read and
+     * owner-write permission bits set at creation time — there is no window in which
+     * the file exists with a broader mode. On a filesystem without POSIX support (for
+     * example, Windows), this falls back to a plain temporary-file creation in the
+     * per-user temporary directory, which is already ACL-restricted to the owning
+     * account; this is a reasoned position, not an equivalent guarantee.
+     */
+    // TASK-1-SKELETON: reproduces pre-fix behaviour (no permission attributes applied)
+    // so the new unit tests compile and observe RED. Task 3 replaces this body with
+    // the real owner-only implementation.
+    public static Path createOwnerOnlyFile(String prefix, String suffix) throws IOException {
+        return Files.createTempFile(prefix, suffix);
     }
 }

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnv.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnv.java
@@ -1,0 +1,50 @@
+package com.basis.bbj.intellij.lsp;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds the parameter list and environment map for BBj processes that carry Enterprise
+ * Manager credentials and tokens. Passing a secret through this class's factory methods
+ * never places it in the returned parameter list; it is carried instead in the returned
+ * environment map, so it does not appear in the child process's argument vector — apply
+ * the environment via {@code GeneralCommandLine.withEnvironment(...)}, which merges these
+ * entries over the inherited parent environment.
+ */
+public final class BbjProcessSecretEnv {
+
+    private BbjProcessSecretEnv() {
+    }
+
+    public static final String USERNAME_VAR = "BBJ_EM_USERNAME";
+    public static final String PASSWORD_VAR = "BBJ_EM_PASSWORD";
+    public static final String TOKEN_VAR = "BBJ_EM_TOKEN";
+
+    /**
+     * An invocation: the parameter list to pass to the process, and the environment map
+     * to apply alongside it. Both collections are stored as unmodifiable copies, so a
+     * caller cannot mutate either after construction. Secrets carried in
+     * {@code environment} never appear in {@code parameters}.
+     */
+    public record Invocation(List<String> parameters, Map<String, String> environment) {
+        public Invocation {
+            parameters = List.copyOf(parameters);
+            environment = Map.copyOf(environment);
+        }
+    }
+
+    /**
+     * Builds the invocation for {@code em-validate-token.bbj}: the token travels on
+     * {@link #TOKEN_VAR} in the returned environment map; the returned parameter list
+     * carries only the quiet flag, the script path, the {@code -} separator and the
+     * output file — never the token. {@code TOKEN_VAR} is always written, even when
+     * {@code token} is empty, so an inherited parent-environment variable of the same
+     * name can never be read in place of the intended value.
+     */
+    public static Invocation emValidateToken(String scriptPath, String token, String outputFile) {
+        return new Invocation(
+                List.of("-q", scriptPath, "-", outputFile),
+                Map.of(TOKEN_VAR, token)
+        );
+    }
+}

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnv.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnv.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
@@ -110,10 +111,16 @@ public final class BbjProcessSecretEnv {
      * per-user temporary directory, which is already ACL-restricted to the owning
      * account; this is a reasoned position, not an equivalent guarantee.
      */
-    // TASK-1-SKELETON: reproduces pre-fix behaviour (no permission attributes applied)
-    // so the new unit tests compile and observe RED. Task 3 replaces this body with
-    // the real owner-only implementation.
     public static Path createOwnerOnlyFile(String prefix, String suffix) throws IOException {
+        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            FileAttribute<Set<PosixFilePermission>> ownerOnly = PosixFilePermissions.asFileAttribute(
+                    Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+            return Files.createTempFile(prefix, suffix, ownerOnly);
+        }
+        // No POSIX attribute view: fall back to the platform default temporary-file
+        // creation. On Windows this resolves under the per-user temporary directory,
+        // which is already ACL-restricted to the owning account — a reasoned position,
+        // not an equivalent guarantee.
         return Files.createTempFile(prefix, suffix);
     }
 }

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnv.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnv.java
@@ -65,14 +65,11 @@ public final class BbjProcessSecretEnv {
      * value is empty, so an inherited parent-environment variable of the same name can
      * never be read in place of the intended value.
      */
-    // TASK-1-SKELETON: reproduces pre-fix behaviour (secrets in parameters, nothing in
-    // the environment) so the new unit tests compile and observe RED. Task 2 replaces
-    // this body with the real environment-channel implementation.
     public static Invocation emLogin(
             String scriptPath, String username, String password, String outputFile, String infoString) {
         return new Invocation(
-                List.of("-q", scriptPath, "-", username, password, outputFile, infoString),
-                Map.of()
+                List.of("-q", scriptPath, "-", outputFile, infoString),
+                Map.of(USERNAME_VAR, username, PASSWORD_VAR, password)
         );
     }
 
@@ -86,20 +83,19 @@ public final class BbjProcessSecretEnv {
      * argument only when it is non-empty, matching {@code web.bbj}'s tolerance of an
      * absent final position.
      */
-    // TASK-1-SKELETON: reproduces pre-fix behaviour (secrets in parameters, nothing in
-    // the environment) so the new unit tests compile and observe RED. Task 2 replaces
-    // this body with the real environment-channel implementation.
     public static Invocation webRun(
             String webRunnerDir, String webBbjPath, String client, String name, String programme,
             String workingDir, String classpath, String token, String configPath) {
         List<String> parameters = new ArrayList<>(List.of(
                 "-q", "-WD" + webRunnerDir, webBbjPath, "-",
-                client, name, programme, workingDir, "", "", classpath, token
+                client, name, programme, workingDir, classpath
         ));
         if (!configPath.isEmpty()) {
             parameters.add(configPath);
         }
-        return new Invocation(parameters, Map.of());
+        return new Invocation(parameters, Map.of(
+                USERNAME_VAR, "", PASSWORD_VAR, "", TOKEN_VAR, token
+        ));
     }
 
     /**

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnvTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnvTest.java
@@ -260,4 +260,41 @@ class BbjProcessSecretEnvTest {
             java.nio.file.Files.deleteIfExists(created);
         }
     }
+
+    @Test
+    void thePermissionSetSurvivesATruncatingReopenAndWriteJustLikeEmLoginBbjsOpenSequence() throws IOException {
+        boolean posixSupported = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+        Assumptions.assumeTrue(posixSupported,
+                "this filesystem does not support POSIX file attribute views — permission bits do not apply");
+
+        Path created = BbjProcessSecretEnv.createOwnerOnlyFile("bbj-em-login-", ".tmp");
+        try {
+            // Mirrors em-login.bbj's open(ch,mode="O_CREATE,O_TRUNC") against an
+            // already-existing file: truncate in place and write, never delete-and-recreate.
+            try (var channel = java.nio.file.Files.newByteChannel(created,
+                    java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.TRUNCATE_EXISTING)) {
+                channel.write(java.nio.ByteBuffer.wrap("tok-abc-123".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+            }
+            Set<PosixFilePermission> permissions = java.nio.file.Files.getPosixFilePermissions(created);
+            assertEquals(
+                    Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+                    permissions,
+                    "the permission set must survive a truncating reopen and write unchanged");
+        } finally {
+            java.nio.file.Files.deleteIfExists(created);
+        }
+    }
+
+    @Test
+    void twoSuccessiveCallsReturnDistinctPaths() throws IOException {
+        Path first = BbjProcessSecretEnv.createOwnerOnlyFile("bbj-em-login-", ".tmp");
+        Path second = BbjProcessSecretEnv.createOwnerOnlyFile("bbj-em-login-", ".tmp");
+        try {
+            assertFalse(first.equals(second),
+                    "two successive calls must return distinct paths, so concurrent logins cannot collide on one file");
+        } finally {
+            java.nio.file.Files.deleteIfExists(first);
+            java.nio.file.Files.deleteIfExists(second);
+        }
+    }
 }

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnvTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnvTest.java
@@ -1,7 +1,12 @@
 package com.basis.bbj.intellij.lsp;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -15,6 +20,10 @@ class BbjProcessSecretEnvTest {
 
     private static final String SCRIPT_PATH = "/ext/lib/tools/em-validate-token.bbj";
     private static final String OUTPUT_FILE = "/tmp/bbj-em-validate-123.tmp";
+
+    private static final String EM_LOGIN_SCRIPT_PATH = "/ext/lib/tools/em-login.bbj";
+    private static final String WEB_BBJ_PATH = "/ext/lib/tools/web.bbj";
+    private static final String WEB_RUNNER_DIR = "/ext/lib/tools";
 
     @Test
     void emValidateTokenPlacesTheTokenInTheEnvironmentUnderTheAgreedKey() {
@@ -88,5 +97,167 @@ class BbjProcessSecretEnvTest {
                 BbjProcessSecretEnv.PASSWORD_VAR,
                 BbjProcessSecretEnv.TOKEN_VAR));
         assertEquals(3, keys.size(), "USERNAME_VAR, PASSWORD_VAR and TOKEN_VAR must be three distinct strings");
+    }
+
+    // --- emLogin ---
+
+    @Test
+    void emLoginPlacesTheUsernameAndPasswordUnderTheAgreedKeys() {
+        BbjProcessSecretEnv.Invocation invocation = BbjProcessSecretEnv.emLogin(
+                EM_LOGIN_SCRIPT_PATH, "admin", "s3cr3t", OUTPUT_FILE, "info-string");
+
+        assertEquals("admin", invocation.environment().get(BbjProcessSecretEnv.USERNAME_VAR));
+        assertEquals("s3cr3t", invocation.environment().get(BbjProcessSecretEnv.PASSWORD_VAR));
+    }
+
+    @Test
+    void emLoginWritesBothKeysEvenWhenTheValuesAreEmpty() {
+        BbjProcessSecretEnv.Invocation invocation =
+                BbjProcessSecretEnv.emLogin(EM_LOGIN_SCRIPT_PATH, "", "", OUTPUT_FILE, "info-string");
+
+        assertTrue(invocation.environment().containsKey(BbjProcessSecretEnv.USERNAME_VAR),
+                "BBJ_EM_USERNAME must be written even when the username is empty");
+        assertTrue(invocation.environment().containsKey(BbjProcessSecretEnv.PASSWORD_VAR),
+                "BBJ_EM_PASSWORD must be written even when the password is empty");
+        assertEquals("", invocation.environment().get(BbjProcessSecretEnv.USERNAME_VAR));
+        assertEquals("", invocation.environment().get(BbjProcessSecretEnv.PASSWORD_VAR));
+    }
+
+    @Test
+    void emLoginsParametersContainNeitherTheUsernameNorThePassword() {
+        String username = "admin";
+        String password = "s3cr3t";
+        BbjProcessSecretEnv.Invocation invocation =
+                BbjProcessSecretEnv.emLogin(EM_LOGIN_SCRIPT_PATH, username, password, OUTPUT_FILE, "info-string");
+
+        for (String parameter : invocation.parameters()) {
+            assertFalse(parameter.equals(username), "a parameter equals the username verbatim: " + parameter);
+            assertFalse(parameter.equals(password), "a parameter equals the password verbatim: " + parameter);
+        }
+    }
+
+    @Test
+    void emLoginsParametersAreExactlyTheFiveExpectedElementsInOrder() {
+        BbjProcessSecretEnv.Invocation invocation = BbjProcessSecretEnv.emLogin(
+                EM_LOGIN_SCRIPT_PATH, "admin", "s3cr3t", OUTPUT_FILE, "info-string");
+
+        assertEquals(List.of("-q", EM_LOGIN_SCRIPT_PATH, "-", OUTPUT_FILE, "info-string"), invocation.parameters());
+    }
+
+    @Test
+    void aCredentialWithNonAsciiAndShellSignificantCharactersIsCarriedByteIdenticallyByEmLogin() {
+        String username = "adm-ïn-$(rm -rf ~)-`whoami`-;&|<>\"'中文";
+        BbjProcessSecretEnv.Invocation invocation =
+                BbjProcessSecretEnv.emLogin(EM_LOGIN_SCRIPT_PATH, username, "s3cr3t", OUTPUT_FILE, "info-string");
+
+        assertEquals(username, invocation.environment().get(BbjProcessSecretEnv.USERNAME_VAR));
+    }
+
+    // --- webRun ---
+
+    @Test
+    void webRunPlacesTheUsernamePasswordAndTokenUnderTheAgreedKeys() {
+        BbjProcessSecretEnv.Invocation invocation = BbjProcessSecretEnv.webRun(
+                WEB_RUNNER_DIR, WEB_BBJ_PATH, "BUI", "name", "programme.bbj", "/wd",
+                "cp1;cp2", "tok-abc-123", "");
+
+        assertEquals("cp1;cp2", invocation.parameters().get(8));
+        assertEquals("tok-abc-123", invocation.environment().get(BbjProcessSecretEnv.TOKEN_VAR));
+    }
+
+    @Test
+    void webRunWritesAllThreeKeysEvenWhenEmpty() {
+        BbjProcessSecretEnv.Invocation invocation = BbjProcessSecretEnv.webRun(
+                WEB_RUNNER_DIR, WEB_BBJ_PATH, "BUI", "name", "programme.bbj", "/wd", "", "", "");
+
+        assertTrue(invocation.environment().containsKey(BbjProcessSecretEnv.USERNAME_VAR),
+                "BBJ_EM_USERNAME must be written even when empty");
+        assertTrue(invocation.environment().containsKey(BbjProcessSecretEnv.PASSWORD_VAR),
+                "BBJ_EM_PASSWORD must be written even when empty");
+        assertTrue(invocation.environment().containsKey(BbjProcessSecretEnv.TOKEN_VAR),
+                "BBJ_EM_TOKEN must be written even when empty");
+    }
+
+    @Test
+    void webRunsParametersContainNoneOfTheThreeSecrets() {
+        String username = "admin";
+        String password = "s3cr3t";
+        String token = "tok-abc-123";
+        BbjProcessSecretEnv.Invocation invocation = BbjProcessSecretEnv.webRun(
+                WEB_RUNNER_DIR, WEB_BBJ_PATH, "BUI", "name", "programme.bbj", "/wd",
+                "cp1;cp2", token, "");
+        // username/password never enter webRun's parameter-affecting arguments at all —
+        // they are supplied only implicitly via the environment map default handling
+        // inside webRun, never as a positional argument.
+
+        for (String parameter : invocation.parameters()) {
+            assertFalse(parameter.equals(token), "a parameter equals the token verbatim: " + parameter);
+            assertFalse(parameter.contains(token), "a parameter contains the token as a substring: " + parameter);
+            assertFalse(parameter.equals(username), "a parameter equals the username verbatim: " + parameter);
+            assertFalse(parameter.equals(password), "a parameter equals the password verbatim: " + parameter);
+        }
+    }
+
+    @Test
+    void webRunsParametersAreExactlyTheExpectedElementsInOrderWithoutConfigPath() {
+        BbjProcessSecretEnv.Invocation invocation = BbjProcessSecretEnv.webRun(
+                WEB_RUNNER_DIR, WEB_BBJ_PATH, "BUI", "name", "programme.bbj", "/wd",
+                "cp1;cp2", "tok-abc-123", "");
+
+        assertEquals(List.of(
+                "-q", "-WD" + WEB_RUNNER_DIR, WEB_BBJ_PATH, "-",
+                "BUI", "name", "programme.bbj", "/wd", "cp1;cp2"
+        ), invocation.parameters());
+    }
+
+    @Test
+    void webRunsParametersAppendTheConfigPathOnlyWhenNonEmpty() {
+        BbjProcessSecretEnv.Invocation invocation = BbjProcessSecretEnv.webRun(
+                WEB_RUNNER_DIR, WEB_BBJ_PATH, "DWC", "name", "programme.bbj", "/wd",
+                "cp1;cp2", "tok-abc-123", "/etc/bbj/config.bbx");
+
+        assertEquals(List.of(
+                "-q", "-WD" + WEB_RUNNER_DIR, WEB_BBJ_PATH, "-",
+                "DWC", "name", "programme.bbj", "/wd", "cp1;cp2", "/etc/bbj/config.bbx"
+        ), invocation.parameters());
+    }
+
+    @Test
+    void aTokenWithNonAsciiAndShellSignificantCharactersIsCarriedByteIdenticallyByWebRun() {
+        String token = "tökén-$(rm -rf ~)-`whoami`-;&|<>\"'中文";
+        BbjProcessSecretEnv.Invocation invocation = BbjProcessSecretEnv.webRun(
+                WEB_RUNNER_DIR, WEB_BBJ_PATH, "BUI", "name", "programme.bbj", "/wd", "cp1;cp2", token, "");
+
+        assertEquals(token, invocation.environment().get(BbjProcessSecretEnv.TOKEN_VAR));
+    }
+
+    // --- createOwnerOnlyFile ---
+
+    @Test
+    void createOwnerOnlyFileReturnsAPathThatExists() throws IOException {
+        Path created = BbjProcessSecretEnv.createOwnerOnlyFile("bbj-em-login-", ".tmp");
+        try {
+            assertTrue(java.nio.file.Files.exists(created), "createOwnerOnlyFile must create the file it returns");
+        } finally {
+            java.nio.file.Files.deleteIfExists(created);
+        }
+    }
+
+    @Test
+    void createOwnerOnlyFilesPermissionSetIsExactlyOwnerReadPlusOwnerWriteOnPosix() throws IOException {
+        boolean posixSupported = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+        Assumptions.assumeTrue(posixSupported,
+                "this filesystem does not support POSIX file attribute views — permission bits do not apply");
+
+        Path created = BbjProcessSecretEnv.createOwnerOnlyFile("bbj-em-login-", ".tmp");
+        try {
+            Set<PosixFilePermission> permissions = java.nio.file.Files.getPosixFilePermissions(created);
+            assertEquals(
+                    Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+                    permissions,
+                    "createOwnerOnlyFile must create a file with exactly owner-read plus owner-write permissions");
+        } finally {
+            java.nio.file.Files.deleteIfExists(created);
+        }
     }
 }

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnvTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnvTest.java
@@ -1,0 +1,92 @@
+package com.basis.bbj.intellij.lsp;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BbjProcessSecretEnvTest {
+
+    private static final String SCRIPT_PATH = "/ext/lib/tools/em-validate-token.bbj";
+    private static final String OUTPUT_FILE = "/tmp/bbj-em-validate-123.tmp";
+
+    @Test
+    void emValidateTokenPlacesTheTokenInTheEnvironmentUnderTheAgreedKey() {
+        String token = "tok-abc-123";
+        BbjProcessSecretEnv.Invocation invocation =
+                BbjProcessSecretEnv.emValidateToken(SCRIPT_PATH, token, OUTPUT_FILE);
+
+        assertEquals(token, invocation.environment().get(BbjProcessSecretEnv.TOKEN_VAR));
+    }
+
+    @Test
+    void emValidateTokensParametersContainNoElementEqualToOrContainingTheToken() {
+        String token = "tok-abc-123";
+        BbjProcessSecretEnv.Invocation invocation =
+                BbjProcessSecretEnv.emValidateToken(SCRIPT_PATH, token, OUTPUT_FILE);
+
+        for (String parameter : invocation.parameters()) {
+            assertFalse(parameter.equals(token), "a parameter equals the token verbatim: " + parameter);
+            assertFalse(parameter.contains(token), "a parameter contains the token as a substring: " + parameter);
+        }
+    }
+
+    @Test
+    void emValidateTokenReturnsExactlyTheFourExpectedParametersInOrder() {
+        BbjProcessSecretEnv.Invocation invocation =
+                BbjProcessSecretEnv.emValidateToken(SCRIPT_PATH, "tok-abc-123", OUTPUT_FILE);
+
+        assertEquals(List.of("-q", SCRIPT_PATH, "-", OUTPUT_FILE), invocation.parameters());
+    }
+
+    @Test
+    void emValidateTokenWritesTheTokenKeyEvenWhenTheTokenIsEmpty() {
+        BbjProcessSecretEnv.Invocation invocation =
+                BbjProcessSecretEnv.emValidateToken(SCRIPT_PATH, "", OUTPUT_FILE);
+
+        assertTrue(invocation.environment().containsKey(BbjProcessSecretEnv.TOKEN_VAR),
+                "BBJ_EM_TOKEN must be written even when the token is empty");
+        assertEquals("", invocation.environment().get(BbjProcessSecretEnv.TOKEN_VAR));
+    }
+
+    @Test
+    void aTokenWithNonAsciiAndShellSignificantCharactersIsCarriedByteIdenticallyInTheEnvironment() {
+        String token = "tökén-$(rm -rf ~)-`whoami`-;&|<>\"'中文";
+        BbjProcessSecretEnv.Invocation invocation =
+                BbjProcessSecretEnv.emValidateToken(SCRIPT_PATH, token, OUTPUT_FILE);
+
+        assertEquals(token, invocation.environment().get(BbjProcessSecretEnv.TOKEN_VAR));
+    }
+
+    @Test
+    void invocationParametersAreUnmodifiable() {
+        BbjProcessSecretEnv.Invocation invocation =
+                BbjProcessSecretEnv.emValidateToken(SCRIPT_PATH, "tok-abc-123", OUTPUT_FILE);
+
+        assertThrows(UnsupportedOperationException.class, () -> invocation.parameters().add("extra"));
+    }
+
+    @Test
+    void invocationEnvironmentIsUnmodifiable() {
+        BbjProcessSecretEnv.Invocation invocation =
+                BbjProcessSecretEnv.emValidateToken(SCRIPT_PATH, "tok-abc-123", OUTPUT_FILE);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> invocation.environment().put("EXTRA", "value"));
+    }
+
+    @Test
+    void theThreeKeyConstantsAreThreeDistinctStrings() {
+        Set<String> keys = new HashSet<>(Set.of(
+                BbjProcessSecretEnv.USERNAME_VAR,
+                BbjProcessSecretEnv.PASSWORD_VAR,
+                BbjProcessSecretEnv.TOKEN_VAR));
+        assertEquals(3, keys.size(), "USERNAME_VAR, PASSWORD_VAR and TOKEN_VAR must be three distinct strings");
+    }
+}

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjSecretArgvSourceGuardTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjSecretArgvSourceGuardTest.java
@@ -23,16 +23,23 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 class BbjSecretArgvSourceGuardTest {
 
-    private static final Path RUN_ACTION_BASE = guardedSource("BbjRunActionBase.java");
-    private static final Path EM_LOGIN_ACTION = guardedSource("BbjEMLoginAction.java");
-    private static final Path RUN_BUI_ACTION = guardedSource("BbjRunBuiAction.java");
-    private static final Path RUN_DWC_ACTION = guardedSource("BbjRunDwcAction.java");
+    private static final Path RUN_ACTION_BASE = guardedActionSource("BbjRunActionBase.java");
+    private static final Path EM_LOGIN_ACTION = guardedActionSource("BbjEMLoginAction.java");
+    private static final Path RUN_BUI_ACTION = guardedActionSource("BbjRunBuiAction.java");
+    private static final Path RUN_DWC_ACTION = guardedActionSource("BbjRunDwcAction.java");
+
+    private static final Path BBJ_PROCESS_SECRET_ENV = Paths.get(
+            "src", "main", "java", "com", "basis", "bbj", "intellij", "lsp", "BbjProcessSecretEnv.java")
+            .toAbsolutePath();
 
     /** The four secret-bearing call sites, guarded identically. */
     private static final List<Path> ALL_GUARDED_ACTION_FILES =
             List.of(RUN_ACTION_BASE, EM_LOGIN_ACTION, RUN_BUI_ACTION, RUN_DWC_ACTION);
 
-    private static Path guardedSource(String fileName) {
+    /** {@code createOwnerOnlyFile} must precede process-handler construction in these two. */
+    private static final List<Path> OWNER_ONLY_FILE_CALLERS = List.of(EM_LOGIN_ACTION, RUN_ACTION_BASE);
+
+    private static Path guardedActionSource(String fileName) {
         return Paths.get(
                 "src", "main", "java", "com", "basis", "bbj", "intellij", "actions", fileName)
                 .toAbsolutePath();
@@ -154,12 +161,55 @@ class BbjSecretArgvSourceGuardTest {
                 }));
     }
 
-    // The createOwnerOnlyFile-precedence guard (BbjEMLoginAction.java and
-    // BbjRunActionBase.java each obtain their output file through createOwnerOnlyFile,
-    // preceding process-handler construction) is added in Task 3, which is the task
-    // that touches BbjRunActionBase.java — see BbjSecretArgvSourceGuardTest's Task 3
-    // additions below this class's Task-1/Task-2 baseline, per this plan's own file
-    // scoping (Task 2's <files> excludes BbjRunActionBase.java).
+    // --- Task 3: the token file is owner-only for its whole life ---
+
+    @Test
+    void emLoginAndRunActionBaseObtainTheirOutputFileThroughCreateOwnerOnlyFile() {
+        assertAll("createOwnerOnlyFile referenced",
+                OWNER_ONLY_FILE_CALLERS.stream().map(source -> () -> {
+                    String text = readGuardedSource(source);
+                    assertTrue(countOccurrences(text, "createOwnerOnlyFile") >= 1,
+                            "createOwnerOnlyFile is not referenced in " + source);
+                }));
+    }
+
+    @Test
+    void theCreateOwnerOnlyFileReferencePrecedesTheProcessHandlerConstructionInEachCaller() {
+        // Both callers build their command through CapturingProcessHandler at the
+        // relevant call site (BbjRunActionBase also constructs an unrelated
+        // OSProcessHandler elsewhere in actionPerformed(), for the main run flow —
+        // deliberately excluded here so that unrelated earlier construction cannot
+        // make this precedence check pass or fail for the wrong reason).
+        assertAll("createOwnerOnlyFile precedes process-handler construction",
+                OWNER_ONLY_FILE_CALLERS.stream().map(source -> () -> {
+                    String text = readGuardedSource(source);
+                    int createOwnerOnlyIndex = text.indexOf("createOwnerOnlyFile");
+                    int processHandlerIndex = text.indexOf("CapturingProcessHandler(");
+                    assertTrue(createOwnerOnlyIndex >= 0, "createOwnerOnlyFile is not present in " + source);
+                    assertTrue(processHandlerIndex >= 0,
+                            "no CapturingProcessHandler construction is present in " + source);
+                    assertTrue(createOwnerOnlyIndex < processHandlerIndex,
+                            "createOwnerOnlyFile must precede the CapturingProcessHandler construction in " + source);
+                }));
+    }
+
+    /**
+     * {@code java.nio.file.Files.createTempFile} already defaults to an owner-only
+     * mode on this JDK's POSIX provider, independent of the process umask — so a
+     * behavioural assertion against the returned permission set alone cannot
+     * distinguish the hardened implementation from the pre-fix skeleton (both pass).
+     * This guard makes the hardening an explicit, verifiable source property instead
+     * of an accidental default: {@code createOwnerOnlyFile} must set the permission
+     * at creation time via {@code PosixFilePermissions.asFileAttribute}, not rely on
+     * the JDK's undocumented implementation default.
+     */
+    @Test
+    void createOwnerOnlyFileSetsPosixPermissionsExplicitlyAtCreationTime() {
+        String text = readGuardedSource(BBJ_PROCESS_SECRET_ENV);
+        assertTrue(countOccurrences(text, "PosixFilePermissions.asFileAttribute") >= 1,
+                "createOwnerOnlyFile must set its permissions explicitly at creation time via "
+                        + "PosixFilePermissions.asFileAttribute, not rely on the JDK's implementation default");
+    }
 
     private static int countOccurrences(String text, String literal) {
         int count = 0;

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjSecretArgvSourceGuardTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjSecretArgvSourceGuardTest.java
@@ -1,0 +1,86 @@
+package com.basis.bbj.intellij.lsp;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * GHSA-33x9-cpwv-xcv2 / GHSA-xxp5-vv2w-42q8: this guard is what keeps the environment-
+ * channel fix from silently regressing back to a secret-bearing {@code addParameter}
+ * call. Scoped in this plan to {@code BbjRunActionBase.java}, the highest-frequency
+ * exposure of the four call sites (runs on every run and every validate invocation).
+ */
+class BbjSecretArgvSourceGuardTest {
+
+    private static final Path GUARDED_SOURCE = Paths.get(
+            "src", "main", "java", "com", "basis", "bbj", "intellij", "actions", "BbjRunActionBase.java")
+            .toAbsolutePath();
+
+    private static String readGuardedSource() {
+        Path resolved = GUARDED_SOURCE;
+        if (!Files.exists(resolved)) {
+            fail("Guarded source file not found at " + resolved);
+        }
+        try {
+            return Files.readString(resolved);
+        } catch (IOException e) {
+            throw new UncheckedIOExceptionForTest(resolved, e);
+        }
+    }
+
+    private static final class UncheckedIOExceptionForTest extends RuntimeException {
+        UncheckedIOExceptionForTest(Path resolved, IOException cause) {
+            super("Failed to read " + resolved, cause);
+        }
+    }
+
+    @Test
+    void theTokenBearingAddParameterCallIsAbsent() {
+        String text = readGuardedSource();
+        assertEquals(0, countOccurrences(text, "addParameter(token)"),
+                "BbjRunActionBase.java must not call addParameter(token) — "
+                        + "the token must travel on the environment, not argv");
+    }
+
+    @Test
+    void theFileCallsWithEnvironmentAtLeastOnce() {
+        String text = readGuardedSource();
+        assertTrue(countOccurrences(text, "withEnvironment(") >= 1,
+                "withEnvironment( is not present in BbjRunActionBase.java");
+    }
+
+    @Test
+    void theFileReferencesBbjProcessSecretEnvAtLeastOnce() {
+        String text = readGuardedSource();
+        assertTrue(countOccurrences(text, "BbjProcessSecretEnv") >= 1,
+                "BbjProcessSecretEnv is not referenced in BbjRunActionBase.java");
+    }
+
+    @Test
+    void theBbjProcessSecretEnvReferencePrecedesTheWithEnvironmentCall() {
+        String text = readGuardedSource();
+        int secretEnvIndex = text.indexOf("BbjProcessSecretEnv");
+        int withEnvironmentIndex = text.indexOf("withEnvironment(");
+        assertTrue(secretEnvIndex >= 0, "BbjProcessSecretEnv is not present in BbjRunActionBase.java");
+        assertTrue(withEnvironmentIndex >= 0, "withEnvironment( is not present in BbjRunActionBase.java");
+        assertTrue(secretEnvIndex < withEnvironmentIndex,
+                "BbjProcessSecretEnv must be referenced before the withEnvironment( call");
+    }
+
+    private static int countOccurrences(String text, String literal) {
+        int count = 0;
+        int index = 0;
+        while ((index = text.indexOf(literal, index)) != -1) {
+            count++;
+            index += literal.length();
+        }
+        return count;
+    }
+}

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjSecretArgvSourceGuardTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjSecretArgvSourceGuardTest.java
@@ -32,9 +32,6 @@ class BbjSecretArgvSourceGuardTest {
     private static final List<Path> ALL_GUARDED_ACTION_FILES =
             List.of(RUN_ACTION_BASE, EM_LOGIN_ACTION, RUN_BUI_ACTION, RUN_DWC_ACTION);
 
-    /** {@code createOwnerOnlyFile} must precede process-handler construction in these two. */
-    private static final List<Path> OWNER_ONLY_FILE_CALLERS = List.of(EM_LOGIN_ACTION, RUN_ACTION_BASE);
-
     private static Path guardedSource(String fileName) {
         return Paths.get(
                 "src", "main", "java", "com", "basis", "bbj", "intellij", "actions", fileName)
@@ -157,40 +154,12 @@ class BbjSecretArgvSourceGuardTest {
                 }));
     }
 
-    @Test
-    void emLoginAndRunActionBaseObtainTheirOutputFileThroughCreateOwnerOnlyFile() {
-        assertAll("createOwnerOnlyFile referenced",
-                OWNER_ONLY_FILE_CALLERS.stream().map(source -> () -> {
-                    String text = readGuardedSource(source);
-                    assertTrue(countOccurrences(text, "createOwnerOnlyFile") >= 1,
-                            "createOwnerOnlyFile is not referenced in " + source);
-                }));
-    }
-
-    @Test
-    void theCreateOwnerOnlyFileReferencePrecedesTheProcessHandlerConstructionInEachCaller() {
-        assertAll("createOwnerOnlyFile precedes process-handler construction",
-                OWNER_ONLY_FILE_CALLERS.stream().map(source -> () -> {
-                    String text = readGuardedSource(source);
-                    int createOwnerOnlyIndex = text.indexOf("createOwnerOnlyFile");
-                    int processHandlerIndex = firstIndexOfAny(text, "CapturingProcessHandler(", "OSProcessHandler(");
-                    assertTrue(createOwnerOnlyIndex >= 0, "createOwnerOnlyFile is not present in " + source);
-                    assertTrue(processHandlerIndex >= 0, "no process-handler construction is present in " + source);
-                    assertTrue(createOwnerOnlyIndex < processHandlerIndex,
-                            "createOwnerOnlyFile must precede the process-handler construction in " + source);
-                }));
-    }
-
-    private static int firstIndexOfAny(String text, String... literals) {
-        int best = -1;
-        for (String literal : literals) {
-            int index = text.indexOf(literal);
-            if (index >= 0 && (best < 0 || index < best)) {
-                best = index;
-            }
-        }
-        return best;
-    }
+    // The createOwnerOnlyFile-precedence guard (BbjEMLoginAction.java and
+    // BbjRunActionBase.java each obtain their output file through createOwnerOnlyFile,
+    // preceding process-handler construction) is added in Task 3, which is the task
+    // that touches BbjRunActionBase.java — see BbjSecretArgvSourceGuardTest's Task 3
+    // additions below this class's Task-1/Task-2 baseline, per this plan's own file
+    // scoping (Task 2's <files> excludes BbjRunActionBase.java).
 
     private static int countOccurrences(String text, String literal) {
         int count = 0;

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjSecretArgvSourceGuardTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjSecretArgvSourceGuardTest.java
@@ -6,7 +6,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -14,17 +16,32 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * GHSA-33x9-cpwv-xcv2 / GHSA-xxp5-vv2w-42q8: this guard is what keeps the environment-
  * channel fix from silently regressing back to a secret-bearing {@code addParameter}
- * call. Scoped in this plan to {@code BbjRunActionBase.java}, the highest-frequency
- * exposure of the four call sites (runs on every run and every validate invocation).
+ * call. Covers all four secret-bearing call sites: {@code BbjRunActionBase.java} (the
+ * JWT validate path, highest-frequency exposure — plan 01), and {@code
+ * BbjEMLoginAction.java}, {@code BbjRunBuiAction.java} and {@code BbjRunDwcAction.java}
+ * (EM login, BUI run and DWC run — plan 02).
  */
 class BbjSecretArgvSourceGuardTest {
 
-    private static final Path GUARDED_SOURCE = Paths.get(
-            "src", "main", "java", "com", "basis", "bbj", "intellij", "actions", "BbjRunActionBase.java")
-            .toAbsolutePath();
+    private static final Path RUN_ACTION_BASE = guardedSource("BbjRunActionBase.java");
+    private static final Path EM_LOGIN_ACTION = guardedSource("BbjEMLoginAction.java");
+    private static final Path RUN_BUI_ACTION = guardedSource("BbjRunBuiAction.java");
+    private static final Path RUN_DWC_ACTION = guardedSource("BbjRunDwcAction.java");
 
-    private static String readGuardedSource() {
-        Path resolved = GUARDED_SOURCE;
+    /** The four secret-bearing call sites, guarded identically. */
+    private static final List<Path> ALL_GUARDED_ACTION_FILES =
+            List.of(RUN_ACTION_BASE, EM_LOGIN_ACTION, RUN_BUI_ACTION, RUN_DWC_ACTION);
+
+    /** {@code createOwnerOnlyFile} must precede process-handler construction in these two. */
+    private static final List<Path> OWNER_ONLY_FILE_CALLERS = List.of(EM_LOGIN_ACTION, RUN_ACTION_BASE);
+
+    private static Path guardedSource(String fileName) {
+        return Paths.get(
+                "src", "main", "java", "com", "basis", "bbj", "intellij", "actions", fileName)
+                .toAbsolutePath();
+    }
+
+    private static String readGuardedSource(Path resolved) {
         if (!Files.exists(resolved)) {
             fail("Guarded source file not found at " + resolved);
         }
@@ -43,7 +60,7 @@ class BbjSecretArgvSourceGuardTest {
 
     @Test
     void theTokenBearingAddParameterCallIsAbsent() {
-        String text = readGuardedSource();
+        String text = readGuardedSource(RUN_ACTION_BASE);
         assertEquals(0, countOccurrences(text, "addParameter(token)"),
                 "BbjRunActionBase.java must not call addParameter(token) — "
                         + "the token must travel on the environment, not argv");
@@ -51,27 +68,128 @@ class BbjSecretArgvSourceGuardTest {
 
     @Test
     void theFileCallsWithEnvironmentAtLeastOnce() {
-        String text = readGuardedSource();
+        String text = readGuardedSource(RUN_ACTION_BASE);
         assertTrue(countOccurrences(text, "withEnvironment(") >= 1,
                 "withEnvironment( is not present in BbjRunActionBase.java");
     }
 
     @Test
     void theFileReferencesBbjProcessSecretEnvAtLeastOnce() {
-        String text = readGuardedSource();
+        String text = readGuardedSource(RUN_ACTION_BASE);
         assertTrue(countOccurrences(text, "BbjProcessSecretEnv") >= 1,
                 "BbjProcessSecretEnv is not referenced in BbjRunActionBase.java");
     }
 
     @Test
     void theBbjProcessSecretEnvReferencePrecedesTheWithEnvironmentCall() {
-        String text = readGuardedSource();
+        String text = readGuardedSource(RUN_ACTION_BASE);
         int secretEnvIndex = text.indexOf("BbjProcessSecretEnv");
         int withEnvironmentIndex = text.indexOf("withEnvironment(");
         assertTrue(secretEnvIndex >= 0, "BbjProcessSecretEnv is not present in BbjRunActionBase.java");
         assertTrue(withEnvironmentIndex >= 0, "withEnvironment( is not present in BbjRunActionBase.java");
         assertTrue(secretEnvIndex < withEnvironmentIndex,
                 "BbjProcessSecretEnv must be referenced before the withEnvironment( call");
+    }
+
+    @Test
+    void allFourGuardedActionFilesArePresent() {
+        for (Path source : ALL_GUARDED_ACTION_FILES) {
+            if (!Files.exists(source)) {
+                fail("Guarded source file not found at " + source);
+            }
+        }
+    }
+
+    @Test
+    void noneOfTheFourFilesRetainsASecretBearingParameterCall() {
+        assertAll("secret-bearing addParameter calls",
+                ALL_GUARDED_ACTION_FILES.stream().map(source -> () -> {
+                    String text = readGuardedSource(source);
+                    assertEquals(0, countOccurrences(text, "addParameter(username)"),
+                            source + " must not call addParameter(username) — "
+                                    + "the username must travel on the environment, not argv");
+                    assertEquals(0, countOccurrences(text, "addParameter(password)"),
+                            source + " must not call addParameter(password) — "
+                                    + "the password must travel on the environment, not argv");
+                    assertEquals(0, countOccurrences(text, "addParameter(token)"),
+                            source + " must not call addParameter(token) — "
+                                    + "the token must travel on the environment, not argv");
+                }));
+    }
+
+    @Test
+    void allFourFilesCallWithEnvironmentAndReferenceBbjProcessSecretEnv() {
+        assertAll("withEnvironment/BbjProcessSecretEnv presence",
+                ALL_GUARDED_ACTION_FILES.stream().map(source -> () -> {
+                    String text = readGuardedSource(source);
+                    assertTrue(countOccurrences(text, "withEnvironment(") >= 1,
+                            "withEnvironment( is not present in " + source);
+                    assertTrue(countOccurrences(text, "BbjProcessSecretEnv") >= 1,
+                            "BbjProcessSecretEnv is not referenced in " + source);
+                }));
+    }
+
+    @Test
+    void allFourFilesReferenceBbjProcessSecretEnvBeforeCallingWithEnvironment() {
+        assertAll("BbjProcessSecretEnv precedes withEnvironment(",
+                ALL_GUARDED_ACTION_FILES.stream().map(source -> () -> {
+                    String text = readGuardedSource(source);
+                    int secretEnvIndex = text.indexOf("BbjProcessSecretEnv");
+                    int withEnvironmentIndex = text.indexOf("withEnvironment(");
+                    assertTrue(secretEnvIndex >= 0, "BbjProcessSecretEnv is not present in " + source);
+                    assertTrue(withEnvironmentIndex >= 0, "withEnvironment( is not present in " + source);
+                    assertTrue(secretEnvIndex < withEnvironmentIndex,
+                            "BbjProcessSecretEnv must be referenced before the withEnvironment( call in " + source);
+                }));
+    }
+
+    @Test
+    void buiAndDwcActionsRetainNoEmptyStringCredentialPlaceholders() {
+        assertAll("no empty-string credential placeholders",
+                List.of(RUN_BUI_ACTION, RUN_DWC_ACTION).stream().map(source -> () -> {
+                    String text = readGuardedSource(source);
+                    assertEquals(0, countOccurrences(text, "// username placeholder"),
+                            source + " must not retain the username placeholder comment — "
+                                    + "the placeholder positions no longer exist");
+                    assertEquals(0, countOccurrences(text, "// password placeholder"),
+                            source + " must not retain the password placeholder comment — "
+                                    + "the placeholder positions no longer exist");
+                }));
+    }
+
+    @Test
+    void emLoginAndRunActionBaseObtainTheirOutputFileThroughCreateOwnerOnlyFile() {
+        assertAll("createOwnerOnlyFile referenced",
+                OWNER_ONLY_FILE_CALLERS.stream().map(source -> () -> {
+                    String text = readGuardedSource(source);
+                    assertTrue(countOccurrences(text, "createOwnerOnlyFile") >= 1,
+                            "createOwnerOnlyFile is not referenced in " + source);
+                }));
+    }
+
+    @Test
+    void theCreateOwnerOnlyFileReferencePrecedesTheProcessHandlerConstructionInEachCaller() {
+        assertAll("createOwnerOnlyFile precedes process-handler construction",
+                OWNER_ONLY_FILE_CALLERS.stream().map(source -> () -> {
+                    String text = readGuardedSource(source);
+                    int createOwnerOnlyIndex = text.indexOf("createOwnerOnlyFile");
+                    int processHandlerIndex = firstIndexOfAny(text, "CapturingProcessHandler(", "OSProcessHandler(");
+                    assertTrue(createOwnerOnlyIndex >= 0, "createOwnerOnlyFile is not present in " + source);
+                    assertTrue(processHandlerIndex >= 0, "no process-handler construction is present in " + source);
+                    assertTrue(createOwnerOnlyIndex < processHandlerIndex,
+                            "createOwnerOnlyFile must precede the process-handler construction in " + source);
+                }));
+    }
+
+    private static int firstIndexOfAny(String text, String... literals) {
+        int best = -1;
+        for (String literal : literals) {
+            int index = text.indexOf(literal);
+            if (index >= 0 && (best < 0 || index < best)) {
+                best = index;
+            }
+        }
+        return best;
     }
 
     private static int countOccurrences(String text, String literal) {

--- a/bbj-vscode/src/Commands/Commands.cjs
+++ b/bbj-vscode/src/Commands/Commands.cjs
@@ -116,7 +116,10 @@ const runWeb = (params, client, credentials) => {
     outputChannel.appendLine(`${client} run: ${formatArgvForLog(argv, [token, password])}`);
   }
 
-  runProcessCallback(argv, {}, (err, stdout, stderr) => {
+  // The secret env map must be spread over process.env, not passed alone —
+  // execFile replaces the child's environment wholesale when options.env is
+  // set, and omitting process.env here would strip PATH/BBJ_HOME from the child.
+  runProcessCallback(argv, { env: { ...process.env, ...argv.env } }, (err, stdout, stderr) => {
     if (err) {
       const errorMsg = `Failed to run "${programme}": ${err.message || err}${stderr ? '\n\nDetails:\n' + stderr : ''}`;
       vscode.window.showErrorMessage(errorMsg);

--- a/bbj-vscode/src/Commands/process-args.ts
+++ b/bbj-vscode/src/Commands/process-args.ts
@@ -35,7 +35,20 @@
 export interface Argv {
     file: string;
     args: string[];
+    env?: Record<string, string>;
 }
+
+/**
+ * The three Enterprise Manager secret environment-variable names, in one spelling shared
+ * by every VS Code call site. `em-validate-token.bbj`, `em-login.bbj` and `web.bbj` read
+ * the same three names via `ENV(...)` on the BBj side; `BbjProcessSecretEnv` on the
+ * IntelliJ side carries the identical literals (GHSA-33x9-cpwv-xcv2 / GHSA-xxp5-vv2w-42q8).
+ */
+export const EM_ENV_VARS = Object.freeze({
+    USERNAME: 'BBJ_EM_USERNAME',
+    PASSWORD: 'BBJ_EM_PASSWORD',
+    TOKEN: 'BBJ_EM_TOKEN'
+});
 
 const exeSuffix = (platform: NodeJS.Platform): string => (platform === 'win32' ? '.exe' : '');
 
@@ -181,10 +194,19 @@ export interface BuildEmValidateArgvOptions {
     tmpFile: string;
 }
 
-/** Reproduces today's `bbj -q em-validate-token.bbj - <token> <tmpFile>` invocation. */
+/**
+ * Reproduces today's `bbj -q em-validate-token.bbj - <tmpFile>` invocation. The token
+ * travels on the returned `env` map under `EM_ENV_VARS.TOKEN`, never in `args` — it is
+ * always written, even when empty, so an inherited environment variable of the same
+ * name can never be read in its place (GHSA-33x9-cpwv-xcv2).
+ */
 export function buildEmValidateArgv(opts: BuildEmValidateArgvOptions): Argv {
     const { home, platform = process.platform, scriptPath, token, tmpFile } = opts;
-    return { file: bbjBin(home, platform), args: ['-q', scriptPath, '-', token, tmpFile] };
+    return {
+        file: bbjBin(home, platform),
+        args: ['-q', scriptPath, '-', tmpFile],
+        env: { [EM_ENV_VARS.TOKEN]: token }
+    };
 }
 
 export interface BuildEmLoginArgvOptions {

--- a/bbj-vscode/src/Commands/process-args.ts
+++ b/bbj-vscode/src/Commands/process-args.ts
@@ -32,6 +32,8 @@
  * this module is unit-testable with zero mocks.
  */
 
+import * as fs from 'fs';
+
 export interface Argv {
     file: string;
     args: string[];
@@ -49,6 +51,29 @@ export const EM_ENV_VARS = Object.freeze({
     PASSWORD: 'BBJ_EM_PASSWORD',
     TOKEN: 'BBJ_EM_TOKEN'
 });
+
+/**
+ * Creates an empty file at `filePath`, owner-only from the moment it exists, and
+ * returns `filePath`. Uses an exclusive create so a pre-placed file or symlink at a
+ * guessable path (the EM login and EM validate output paths are built from
+ * `os.tmpdir()` plus a millisecond timestamp) causes a failed call rather than a
+ * silent write into an attacker-controlled target.
+ *
+ * On a non-Windows platform the resulting POSIX mode is set explicitly via
+ * `chmodSync` after creation — not relied on from the creation call's mode
+ * argument alone, because the process umask can clear bits requested at creation
+ * time. On Windows no POSIX mode is applied; the per-user temporary directory's
+ * ACL restriction is relied on instead, a reasoned position, not an equivalent
+ * guarantee (GHSA-33x9-cpwv-xcv2 / GHSA-xxp5-vv2w-42q8).
+ */
+export function createOwnerOnlyFile(filePath: string): string {
+    const fd = fs.openSync(filePath, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY, 0o600);
+    fs.closeSync(fd);
+    if (process.platform !== 'win32') {
+        fs.chmodSync(filePath, 0o600);
+    }
+    return filePath;
+}
 
 const exeSuffix = (platform: NodeJS.Platform): string => (platform === 'win32' ? '.exe' : '');
 

--- a/bbj-vscode/src/Commands/process-args.ts
+++ b/bbj-vscode/src/Commands/process-args.ts
@@ -108,9 +108,11 @@ export interface BuildWebRunArgvOptions {
 
 /**
  * Reproduces today's `runWeb` invocation: `bbj -q -WD<toolsDir> <toolsDir>/web.bbj -
- * <client> <name> <programme> <workingDir> <username> <password> <classpath> <token>
- * <configPath>`. Empty-string credentials are preserved as empty elements, matching
- * today's behaviour, rather than dropped.
+ * <client> <name> <programme> <workingDir> <classpath> <configPath>`. The username,
+ * password and token travel on the returned `env` map under `EM_ENV_VARS`, never in
+ * `args` — all three keys are always written, even when empty, so an inherited
+ * environment variable of the same name can never be read in their place
+ * (GHSA-33x9-cpwv-xcv2 / GHSA-xxp5-vv2w-42q8).
  */
 export function buildWebRunArgv(opts: BuildWebRunArgvOptions): Argv {
     const {
@@ -136,13 +138,18 @@ export function buildWebRunArgv(opts: BuildWebRunArgvOptions): Argv {
         name,
         programme,
         workingDir,
-        username,
-        password,
         classpathEntry,
-        token,
         configPath
     ];
-    return { file: bbjBin(home, platform), args };
+    return {
+        file: bbjBin(home, platform),
+        args,
+        env: {
+            [EM_ENV_VARS.USERNAME]: username,
+            [EM_ENV_VARS.PASSWORD]: password,
+            [EM_ENV_VARS.TOKEN]: token
+        }
+    };
 }
 
 export interface BuildCompileArgvOptions {
@@ -219,8 +226,21 @@ export interface BuildEmLoginArgvOptions {
     infoString: string;
 }
 
-/** Reproduces today's `bbj -q em-login.bbj - <username> <password> <tmpFile> <infoString>` invocation. */
+/**
+ * Reproduces today's `bbj -q em-login.bbj - <tmpFile> <infoString>` invocation. The
+ * username and password travel on the returned `env` map under `EM_ENV_VARS`, never
+ * in `args` — both keys are always written, even when empty, so an inherited
+ * environment variable of the same name can never be read in their place
+ * (GHSA-33x9-cpwv-xcv2 / GHSA-xxp5-vv2w-42q8).
+ */
 export function buildEmLoginArgv(opts: BuildEmLoginArgvOptions): Argv {
     const { home, platform = process.platform, scriptPath, username, password, tmpFile, infoString } = opts;
-    return { file: bbjBin(home, platform), args: ['-q', scriptPath, '-', username, password, tmpFile, infoString] };
+    return {
+        file: bbjBin(home, platform),
+        args: ['-q', scriptPath, '-', tmpFile, infoString],
+        env: {
+            [EM_ENV_VARS.USERNAME]: username,
+            [EM_ENV_VARS.PASSWORD]: password
+        }
+    };
 }

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -25,7 +25,7 @@ import {
     validateOptions,
     type CompilerOption
 } from './Commands/CompilerOptions.js';
-import { buildEmValidateArgv, buildEmLoginArgv } from './Commands/process-args.js';
+import { buildEmValidateArgv, buildEmLoginArgv, createOwnerOnlyFile } from './Commands/process-args.js';
 import { runProcess, formatArgvForLog, type ProcessError } from './Commands/process-runner.js';
 
 import Commands from './Commands/Commands.cjs';
@@ -407,8 +407,10 @@ async function validateTokenServerSide(context: vscode.ExtensionContext, token: 
         // Build path to em-validate-token.bbj
         const emValidatePath = context.asAbsolutePath(path.join('tools', 'em-validate-token.bbj'));
 
-        // Create temp file for BBj output
-        const tmpFile = path.join(os.tmpdir(), `bbj-em-validate-${Date.now()}.tmp`);
+        // Create temp file for BBj output, owner-only and exclusively before the
+        // spawn — em-validate-token.bbj truncates it in place rather than deleting
+        // and recreating it, so the mode set here survives the write.
+        const tmpFile = createOwnerOnlyFile(path.join(os.tmpdir(), `bbj-em-validate-${Date.now()}.tmp`));
 
         // Build argv: bbj -q em-validate-token.bbj - <tmpFile>; the token travels on
         // argv.env (BBJ_EM_TOKEN), never as a positional argument.
@@ -623,8 +625,11 @@ export function activate(context: vscode.ExtensionContext): void {
         // Launch em-login.bbj to validate credentials and get token
         const emLoginPath = context.asAbsolutePath(path.join('tools', 'em-login.bbj'));
 
-        // Create temp file for BBj output
-        const tmpFile = path.join(os.tmpdir(), `bbj-em-login-${Date.now()}.tmp`);
+        // Create temp file for BBj output, owner-only and exclusively before the
+        // spawn — em-login.bbj truncates it in place rather than deleting and
+        // recreating it, so the mode set here survives the write and holds for the
+        // whole life of the file, including while it carries the returned JWT.
+        const tmpFile = createOwnerOnlyFile(path.join(os.tmpdir(), `bbj-em-login-${Date.now()}.tmp`));
 
         const platformLabel = process.platform === 'win32' ? 'Windows' : process.platform === 'darwin' ? 'MacOS' : 'Linux';
         const infoString = `VS Code on ${platformLabel} as ${os.userInfo().username}`;

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -410,7 +410,8 @@ async function validateTokenServerSide(context: vscode.ExtensionContext, token: 
         // Create temp file for BBj output
         const tmpFile = path.join(os.tmpdir(), `bbj-em-validate-${Date.now()}.tmp`);
 
-        // Build argv: bbj -q em-validate-token.bbj - <token> <tmpFile>
+        // Build argv: bbj -q em-validate-token.bbj - <tmpFile>; the token travels on
+        // argv.env (BBJ_EM_TOKEN), never as a positional argument.
         const argv = buildEmValidateArgv({
             home: bbjHome,
             platform: process.platform,
@@ -427,8 +428,11 @@ async function validateTokenServerSide(context: vscode.ExtensionContext, token: 
 
         let result: string;
         try {
-            // Execute with 10s timeout
-            await runProcess(argv, { timeout: 10000 });
+            // Execute with 10s timeout. The secret env map must be spread over
+            // process.env, not passed alone — execFile replaces the child's
+            // environment wholesale when options.env is set, and omitting
+            // process.env here would strip PATH/BBJ_HOME from the child.
+            await runProcess(argv, { timeout: 10000, env: { ...process.env, ...argv.env } });
             result = fs.readFileSync(tmpFile, 'utf-8').trim();
         } finally {
             // Clean up temp file

--- a/bbj-vscode/src/extension.ts
+++ b/bbj-vscode/src/extension.ts
@@ -647,8 +647,11 @@ export function activate(context: vscode.ExtensionContext): void {
         try {
             let output: string;
             try {
-                // Execute with 15s timeout
-                await runProcess(argv, { timeout: 15000 });
+                // Execute with 15s timeout. The secret env map must be spread over
+                // process.env, not passed alone — execFile replaces the child's
+                // environment wholesale when options.env is set, and omitting
+                // process.env here would strip PATH/BBJ_HOME from the child.
+                await runProcess(argv, { timeout: 15000, env: { ...process.env, ...argv.env } });
                 output = fs.readFileSync(tmpFile, 'utf-8').trim();
             } catch (err) {
                 const pe = err as ProcessError;

--- a/bbj-vscode/test/command-argv-injection.test.ts
+++ b/bbj-vscode/test/command-argv-injection.test.ts
@@ -132,7 +132,7 @@ describe('process-args - buildWebRunArgv (bbj.web.apps.<file>.name / bbj.configP
         configPath: '/cfg/config.bbx'
     };
 
-    test('emits the thirteen positional elements in today\'s order', () => {
+    test('emits the ten positional elements in today\'s order, with credentials and token on env instead', () => {
         const argv = buildWebRunArgv(baseOpts);
         expect(argv.file).toBe('/opt/bbj/bin/bbj');
         expect(argv.args).toEqual([
@@ -144,21 +144,21 @@ describe('process-args - buildWebRunArgv (bbj.web.apps.<file>.name / bbj.configP
             'myapp',
             'myapp.bbj',
             '/w',
-            'user',
-            'pass',
             'bbj_default',
-            '',
             '/cfg/config.bbx'
         ]);
-        expect(argv.args).toHaveLength(13);
+        expect(argv.args).toHaveLength(10);
+        expect(argv.env?.['BBJ_EM_USERNAME']).toBe('user');
+        expect(argv.env?.['BBJ_EM_PASSWORD']).toBe('pass');
+        expect(argv.env?.['BBJ_EM_TOKEN']).toBe('');
     });
 
-    test('empty-string credentials are preserved as empty elements, not dropped', () => {
-        const argv = buildWebRunArgv({ ...baseOpts, username: '', password: '', token: 'tok' });
-        expect(argv.args[8]).toBe('');
-        expect(argv.args[9]).toBe('');
-        expect(argv.args[11]).toBe('tok');
-        expect(argv.args).toHaveLength(13);
+    test('empty credentials and token are carried as empty environment values, not dropped, and are absent from args', () => {
+        const argv = buildWebRunArgv({ ...baseOpts, username: '', password: '', token: '' });
+        expect(argv.env?.['BBJ_EM_USERNAME']).toBe('');
+        expect(argv.env?.['BBJ_EM_PASSWORD']).toBe('');
+        expect(argv.env?.['BBJ_EM_TOKEN']).toBe('');
+        expect(argv.args).toHaveLength(10);
     });
 
     test('an app name carrying a shell metacharacter is one verbatim element', () => {
@@ -172,7 +172,7 @@ describe('process-args - buildWebRunArgv (bbj.web.apps.<file>.name / bbj.configP
 
     test('a configPath carrying a shell metacharacter is one verbatim element', () => {
         const argv = buildWebRunArgv({ ...baseOpts, configPath: METACHAR_FIXTURE });
-        expect(argv.args[12]).toBe(METACHAR_FIXTURE);
+        expect(argv.args[9]).toBe(METACHAR_FIXTURE);
     });
 
     test('a fileName (programme) carrying a shell metacharacter is one verbatim element', () => {
@@ -271,7 +271,7 @@ describe('process-args - EM launches', () => {
         expect(argv.args.some((a) => a.includes(METACHAR_FIXTURE))).toBe(false);
     });
 
-    test('buildEmLoginArgv returns the seven elements in order', () => {
+    test('buildEmLoginArgv returns the five elements in order, with credentials on env instead', () => {
         const argv = buildEmLoginArgv({
             home: '/opt/bbj',
             platform: 'linux',
@@ -286,14 +286,14 @@ describe('process-args - EM launches', () => {
             '-q',
             '/ext/tools/em-login.bbj',
             '-',
-            'admin',
-            'secret',
             '/tmp/out.tmp',
             'VS Code on Linux as dev'
         ]);
+        expect(argv.env?.['BBJ_EM_USERNAME']).toBe('admin');
+        expect(argv.env?.['BBJ_EM_PASSWORD']).toBe('secret');
     });
 
-    test('buildEmLoginArgv keeps metacharacter-bearing credentials in their own element and preserves spaces in the info string', () => {
+    test('buildEmLoginArgv keeps metacharacter-bearing credentials on the environment side and preserves spaces in the info string at its new index', () => {
         const argv = buildEmLoginArgv({
             home: '/opt/bbj',
             platform: 'linux',
@@ -303,8 +303,9 @@ describe('process-args - EM launches', () => {
             tmpFile: '/tmp/out.tmp',
             infoString: 'VS Code on Linux as dev'
         });
-        expect(argv.args[3]).toBe(METACHAR_FIXTURE);
-        expect(argv.args[4]).toBe(METACHAR_FIXTURE);
-        expect(argv.args[6]).toBe('VS Code on Linux as dev');
+        expect(argv.env?.['BBJ_EM_USERNAME']).toBe(METACHAR_FIXTURE);
+        expect(argv.env?.['BBJ_EM_PASSWORD']).toBe(METACHAR_FIXTURE);
+        expect(argv.args.some((a) => a.includes(METACHAR_FIXTURE))).toBe(false);
+        expect(argv.args[4]).toBe('VS Code on Linux as dev');
     });
 });

--- a/bbj-vscode/test/command-argv-injection.test.ts
+++ b/bbj-vscode/test/command-argv-injection.test.ts
@@ -245,7 +245,7 @@ describe('process-args - buildDecompileArgv', () => {
 });
 
 describe('process-args - EM launches', () => {
-    test('buildEmValidateArgv returns the five elements in order', () => {
+    test('buildEmValidateArgv returns the four non-secret elements in order, with the token on env instead', () => {
         const argv = buildEmValidateArgv({
             home: '/opt/bbj',
             platform: 'linux',
@@ -254,10 +254,12 @@ describe('process-args - EM launches', () => {
             tmpFile: '/tmp/out.tmp'
         });
         expect(argv.file).toBe('/opt/bbj/bin/bbj');
-        expect(argv.args).toEqual(['-q', '/ext/tools/em-validate-token.bbj', '-', 'tok-123', '/tmp/out.tmp']);
+        expect(argv.args).toEqual(['-q', '/ext/tools/em-validate-token.bbj', '-', '/tmp/out.tmp']);
+        expect(argv.args).not.toContain('tok-123');
+        expect(argv.env?.['BBJ_EM_TOKEN']).toBe('tok-123');
     });
 
-    test('buildEmValidateArgv keeps a metacharacter-bearing token in one element', () => {
+    test('buildEmValidateArgv keeps a metacharacter-bearing token in the env map, never in args', () => {
         const argv = buildEmValidateArgv({
             home: '/opt/bbj',
             platform: 'linux',
@@ -265,7 +267,8 @@ describe('process-args - EM launches', () => {
             token: METACHAR_FIXTURE,
             tmpFile: '/tmp/out.tmp'
         });
-        expect(argv.args[3]).toBe(METACHAR_FIXTURE);
+        expect(argv.env?.['BBJ_EM_TOKEN']).toBe(METACHAR_FIXTURE);
+        expect(argv.args.some((a) => a.includes(METACHAR_FIXTURE))).toBe(false);
     });
 
     test('buildEmLoginArgv returns the seven elements in order', () => {

--- a/bbj-vscode/test/em-secret-env-channel.test.ts
+++ b/bbj-vscode/test/em-secret-env-channel.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
-import { buildEmValidateArgv, buildEmLoginArgv, buildWebRunArgv, type Argv } from '../src/Commands/process-args.js';
+import {
+    buildEmValidateArgv,
+    buildEmLoginArgv,
+    buildWebRunArgv,
+    createOwnerOnlyFile,
+    type Argv
+} from '../src/Commands/process-args.js';
 import { formatArgvForLog } from '../src/Commands/process-runner.js';
 
 /**
@@ -452,5 +459,93 @@ describe('em-secret-env-channel guard — VS Code call sites spread process.env 
         expect(() => readFileOrThrow(missing)).toThrow(
             new RegExp(`Guarded source file not found at .*does-not-exist-extension\\.ts`)
         );
+    });
+
+    /** Every index at which `literal` occurs in `source`, in file order. */
+    function orderedIndicesOf(source: string, literal: string): number[] {
+        const indices: number[] = [];
+        let idx = source.indexOf(literal);
+        while (idx !== -1) {
+            indices.push(idx);
+            idx = source.indexOf(literal, idx + literal.length);
+        }
+        return indices;
+    }
+
+    test('both output-file paths in extension.ts are created through createOwnerOnlyFile before their launcher call', () => {
+        const source = stripLineComments(readFileOrThrow(EXTENSION_TS));
+        const creationIndices = orderedIndicesOf(source, 'createOwnerOnlyFile(');
+        expect(creationIndices.length).toBe(2);
+        const launcherIndices = orderedIndicesOf(source, 'runProcess(argv,');
+        expect(launcherIndices.length).toBe(2);
+        for (let i = 0; i < creationIndices.length; i++) {
+            expect(creationIndices[i]).toBeLessThan(launcherIndices[i]);
+        }
+    });
+});
+
+describe('em-secret-env-channel guard — createOwnerOnlyFile', () => {
+    function tmpDir(): string {
+        return fs.mkdtempSync(path.join(os.tmpdir(), 'em-secret-owner-only-'));
+    }
+
+    test('creates a file at the caller-supplied path and returns that path', () => {
+        const target = path.join(tmpDir(), 'out.tmp');
+        const returned = createOwnerOnlyFile(target);
+        expect(returned).toBe(target);
+        expect(fs.existsSync(target)).toBe(true);
+    });
+
+    test('on a non-Windows platform, the created file\'s mode is exactly owner-read plus owner-write, and survives a restrictive process umask', () => {
+        if (process.platform === 'win32') {
+            return;
+        }
+        const target = path.join(tmpDir(), 'out.tmp');
+        // A restrictive umask (0700) would clear every bit of a 0600 creation mode
+        // down to 0000 unless the helper also chmods explicitly after creation —
+        // this is the assertion that distinguishes "set at creation time" from
+        // "relaxed then tightened".
+        const originalUmask = process.umask(0o700);
+        try {
+            createOwnerOnlyFile(target);
+        } finally {
+            process.umask(originalUmask);
+        }
+        const mode = fs.statSync(target).mode & 0o777;
+        expect(mode).toBe(0o600);
+    });
+
+    test('a truncating write to the created file leaves its mode unchanged', () => {
+        if (process.platform === 'win32') {
+            return;
+        }
+        const target = path.join(tmpDir(), 'out.tmp');
+        createOwnerOnlyFile(target);
+        const fd = fs.openSync(target, 'w');
+        fs.writeSync(fd, 'some content');
+        fs.closeSync(fd);
+        const mode = fs.statSync(target).mode & 0o777;
+        expect(mode).toBe(0o600);
+    });
+
+    test.skipIf(process.platform !== 'win32')(
+        'on Windows, the helper creates the file without asserting a POSIX mode — relies on the per-user temp directory ACL instead (skipped: this suite is not running on win32)',
+        () => {
+            const target = path.join(tmpDir(), 'out.tmp');
+            expect(createOwnerOnlyFile(target)).toBe(target);
+            expect(fs.existsSync(target)).toBe(true);
+        }
+    );
+
+    test('two calls with different paths yield two distinct files; a second call against an already-existing path fails rather than silently adopting it', () => {
+        const dir = tmpDir();
+        const first = path.join(dir, 'a.tmp');
+        const second = path.join(dir, 'b.tmp');
+        expect(createOwnerOnlyFile(first)).toBe(first);
+        expect(createOwnerOnlyFile(second)).toBe(second);
+        expect(fs.existsSync(first)).toBe(true);
+        expect(fs.existsSync(second)).toBe(true);
+
+        expect(() => createOwnerOnlyFile(first)).toThrow();
     });
 });

--- a/bbj-vscode/test/em-secret-env-channel.test.ts
+++ b/bbj-vscode/test/em-secret-env-channel.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { buildEmValidateArgv, type Argv } from '../src/Commands/process-args.js';
+import { buildEmValidateArgv, buildEmLoginArgv, buildWebRunArgv, type Argv } from '../src/Commands/process-args.js';
 import { formatArgvForLog } from '../src/Commands/process-runner.js';
 
 /**
@@ -11,17 +11,11 @@ import { formatArgvForLog } from '../src/Commands/process-runner.js';
  * BBj runtime — the same shape as no-shell-command-construction.test.ts and
  * command-argv-injection.test.ts.
  *
- * Transient state (75-02-PLAN.md): as of this plan all three scripts —
- * em-validate-token.bbj, em-login.bbj and web.bbj — read their credentials/token via
- * ENV() with no positional fallback. The IntelliJ callers (BbjProcessSecretEnv.emLogin
- * / webRun) already write the corresponding environment map. The VS Code TypeScript
- * callers (buildEmLoginArgv / buildWebRunArgv in process-args.ts and their extension.ts
- * call sites) are NOT migrated in this plan — that is plan 03's job — so those two
- * builders still emit the pre-migration ARGV shape. The script-side and builder-side
- * ARGV/positional-count cross-checks below are therefore written against the scripts'
- * OWN final numbering (fixed expected index sets), not against the still-unmigrated
- * `buildEmLoginArgv`/`buildWebRunArgv` output, so this suite is green after this plan
- * without also requiring plan 03's VS Code changes.
+ * All three scripts — em-validate-token.bbj, em-login.bbj and web.bbj — read their
+ * credentials/token via ENV() with no positional fallback. All three VS Code builders —
+ * buildEmValidateArgv, buildEmLoginArgv and buildWebRunArgv — emit an env map alongside a
+ * secret-free args array, and every VS Code call site that launches a secret-bearing
+ * process passes that map spread over process.env.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -67,6 +61,17 @@ function distinctArgvIndices(strippedSource: string): number[] {
 
 function bbjEmNamesIn(source: string): string[] {
     return [...new Set([...source.matchAll(/BBJ_EM_[A-Z]+/g)].map((m) => m[0]))];
+}
+
+/** Strip `//` line comments, mirroring no-shell-command-construction.test.ts. */
+function stripLineComments(source: string): string {
+    return source.replace(/\/\/.*$/gm, '');
+}
+
+/** Number of `args` elements a builder emits after the `-` separator. */
+function positionalArgCount(args: string[]): number {
+    const separatorIndex = args.indexOf('-');
+    return args.length - separatorIndex - 1;
 }
 
 describe('em-secret-env-channel guard — em-validate-token.bbj reads ENV, not ARGV, for the token', () => {
@@ -179,6 +184,110 @@ describe('em-secret-env-channel guard — buildEmValidateArgv', () => {
     });
 });
 
+describe('em-secret-env-channel guard — buildEmLoginArgv', () => {
+    const OPTS = {
+        home: '/opt/bbj',
+        platform: 'linux' as NodeJS.Platform,
+        scriptPath: '/ext/tools/em-login.bbj',
+        tmpFile: '/tmp/out.tmp',
+        infoString: 'VS Code on Linux as dev'
+    };
+
+    test('returns an env map carrying the username under BBJ_EM_USERNAME and the password under BBJ_EM_PASSWORD, and a five-element args array containing neither value', () => {
+        const username = 'admin';
+        const password = 'sup3r-secret';
+        const argv = buildEmLoginArgv({ ...OPTS, username, password });
+
+        expect(argv.env?.['BBJ_EM_USERNAME']).toBe(username);
+        expect(argv.env?.['BBJ_EM_PASSWORD']).toBe(password);
+        expect(argv.args).toEqual(['-q', OPTS.scriptPath, '-', OPTS.tmpFile, OPTS.infoString]);
+        expect(argv.args).toHaveLength(5);
+        expect(argv.args.some((a) => a.includes(username))).toBe(false);
+        expect(argv.args.some((a) => a.includes(password))).toBe(false);
+    });
+
+    test('sets both credential keys even when both values are the empty string', () => {
+        const argv = buildEmLoginArgv({ ...OPTS, username: '', password: '' });
+        expect(argv.env?.['BBJ_EM_USERNAME']).toBe('');
+        expect(argv.env?.['BBJ_EM_PASSWORD']).toBe('');
+    });
+
+    test('a credential containing non-ASCII characters and shell-significant bytes is carried byte-identically as an environment value and appears in no args element', () => {
+        const credential = 'pässwörd;`$(rm -rf)` ';
+        const argv = buildEmLoginArgv({ ...OPTS, username: credential, password: credential });
+        expect(argv.env?.['BBJ_EM_USERNAME']).toBe(credential);
+        expect(argv.env?.['BBJ_EM_PASSWORD']).toBe(credential);
+        expect(argv.args.some((a) => a.includes(credential))).toBe(false);
+    });
+
+    test('the number of distinct ARGV(n) indices em-login.bbj reads equals the number of positional args buildEmLoginArgv emits after the "-" separator', () => {
+        const stripped = readStrippedScript(EM_LOGIN_SCRIPT);
+        const argv = buildEmLoginArgv({ ...OPTS, username: 'admin', password: 'secret' });
+        expect(distinctArgvIndices(stripped).length).toBe(positionalArgCount(argv.args));
+    });
+});
+
+describe('em-secret-env-channel guard — buildWebRunArgv', () => {
+    const OPTS = {
+        home: '/opt/bbj',
+        platform: 'linux' as NodeJS.Platform,
+        toolsDir: '/ext/tools',
+        client: 'BUI',
+        name: 'myapp',
+        programme: 'myapp.bbj',
+        workingDir: '/w',
+        classpathEntry: 'bbj_default',
+        configPath: '/cfg/config.bbx'
+    };
+
+    test('returns an env map carrying all three secrets under their keys, and a ten-element args array containing none of them', () => {
+        const username = 'admin';
+        const password = 'sup3r-secret';
+        const token = 'tok-abc-123';
+        const argv = buildWebRunArgv({ ...OPTS, username, password, token });
+
+        expect(argv.env?.['BBJ_EM_USERNAME']).toBe(username);
+        expect(argv.env?.['BBJ_EM_PASSWORD']).toBe(password);
+        expect(argv.env?.['BBJ_EM_TOKEN']).toBe(token);
+        expect(argv.args).toEqual([
+            '-q',
+            `-WD${OPTS.toolsDir}`,
+            `${OPTS.toolsDir}/web.bbj`,
+            '-',
+            OPTS.client,
+            OPTS.name,
+            OPTS.programme,
+            OPTS.workingDir,
+            OPTS.classpathEntry,
+            OPTS.configPath
+        ]);
+        expect(argv.args).toHaveLength(10);
+        for (const secret of [username, password, token]) {
+            expect(argv.args.some((a) => a.includes(secret))).toBe(false);
+        }
+    });
+
+    test('sets all three keys even when all three values are empty', () => {
+        const argv = buildWebRunArgv({ ...OPTS, username: '', password: '', token: '' });
+        expect(argv.env?.['BBJ_EM_USERNAME']).toBe('');
+        expect(argv.env?.['BBJ_EM_PASSWORD']).toBe('');
+        expect(argv.env?.['BBJ_EM_TOKEN']).toBe('');
+    });
+
+    test('a token containing non-ASCII characters and shell-significant bytes is carried byte-identically as an environment value and appears in no args element', () => {
+        const token = 'tökén;`$(rm -rf)` ';
+        const argv = buildWebRunArgv({ ...OPTS, username: 'admin', password: 'secret', token });
+        expect(argv.env?.['BBJ_EM_TOKEN']).toBe(token);
+        expect(argv.args.some((a) => a.includes(token))).toBe(false);
+    });
+
+    test('the number of distinct ARGV(n) indices web.bbj reads equals the number of positional args buildWebRunArgv emits after the "-" separator', () => {
+        const stripped = readStrippedScript(WEB_SCRIPT);
+        const argv = buildWebRunArgv({ ...OPTS, username: 'admin', password: 'secret', token: 'tok' });
+        expect(distinctArgvIndices(stripped).length).toBe(positionalArgCount(argv.args));
+    });
+});
+
 describe('em-secret-env-channel guard — cross-layer BBJ_EM_* name contract', () => {
     test('every BBJ_EM_* literal in BbjProcessSecretEnv.java and process-args.ts is drawn from the three-name vocabulary, and every name a script reads via ENV() is a name at least one builder writes', () => {
         const javaSource = readFileOrThrow(BBJ_PROCESS_SECRET_ENV_JAVA);
@@ -216,11 +325,6 @@ describe('em-secret-env-channel guard — the environment map has no path to the
     const EXTENSION_TS = path.join(REPO_ROOT, 'src/extension.ts');
     const COMMANDS_CJS = path.join(REPO_ROOT, 'src/Commands/Commands.cjs');
 
-    /** Strip `//` line comments, mirroring no-shell-command-construction.test.ts. */
-    function stripLineComments(source: string): string {
-        return source.replace(/\/\/.*$/gm, '');
-    }
-
     function appendLineCallArguments(filePath: string): string[] {
         const source = stripLineComments(readFileOrThrow(filePath));
         return [...source.matchAll(/outputChannel\.appendLine\((.*)\);/g)].map((m) => m[1]);
@@ -238,14 +342,15 @@ describe('em-secret-env-channel guard — the environment map has no path to the
         }
     });
 
-    test('neither file passes an options object, nor a bare argv/invocation, directly to appendLine', () => {
+    test('neither file passes an options object, an environment map, or a bare argv/invocation, directly to appendLine', () => {
         for (const filePath of [EXTENSION_TS, COMMANDS_CJS]) {
             for (const call of appendLineCallArguments(filePath)) {
                 expect(call).not.toMatch(/\boptions\b/);
-                // A bare "argv" (or "invocation") mention that is not inside a
-                // formatArgvForLog( call would be a builder result logged directly.
+                // A bare "argv"/"invocation"/"env" mention that is not inside a
+                // formatArgvForLog( call would be a builder result or environment
+                // map logged directly.
                 const withoutRedactedCall = call.replace(/formatArgvForLog\([^)]*\)/g, '');
-                expect(withoutRedactedCall).not.toMatch(/\b(argv|invocation)\b/);
+                expect(withoutRedactedCall).not.toMatch(/\b(argv|invocation|env)\b/);
             }
         }
     });
@@ -261,5 +366,91 @@ describe('em-secret-env-channel guard — the environment map has no path to the
         const rendered = formatArgvForLog(argv);
 
         expect(rendered).not.toContain(secretValue);
+    });
+});
+
+describe('em-secret-env-channel guard — VS Code call sites spread process.env and reference only exported builders', () => {
+    const EXTENSION_TS = path.join(REPO_ROOT, 'src/extension.ts');
+    const COMMANDS_CJS = path.join(REPO_ROOT, 'src/Commands/Commands.cjs');
+    const SECRET_BUILDERS = ['buildEmValidateArgv', 'buildEmLoginArgv', 'buildWebRunArgv'];
+
+    /** Returns the full text of the balanced-parens call starting at `callStartIndex` (the index of the call's identifier). */
+    function extractBalancedCall(source: string, callStartIndex: number): string {
+        const openParenIndex = source.indexOf('(', callStartIndex);
+        let depth = 0;
+        for (let i = openParenIndex; i < source.length; i++) {
+            if (source[i] === '(') depth++;
+            else if (source[i] === ')') {
+                depth--;
+                if (depth === 0) {
+                    return source.slice(callStartIndex, i + 1);
+                }
+            }
+        }
+        throw new Error(`Unbalanced parentheses for the call starting at index ${callStartIndex}`);
+    }
+
+    /**
+     * For each secret-bearing builder call site in `source`, finds the nearest following
+     * `runProcess(`/`runProcessCallback(` call and returns its full text (options object
+     * included). A non-secret-bearing launcher call (following buildRunArgv,
+     * buildCompileArgv or buildDecompileArgv) is never collected.
+     */
+    function launcherCallsFollowingSecretBuilders(filePath: string, source: string): string[] {
+        const results: string[] = [];
+        for (const builder of SECRET_BUILDERS) {
+            const builderRegex = new RegExp(`\\b${builder}\\(`, 'g');
+            let match: RegExpExecArray | null;
+            while ((match = builderRegex.exec(source)) !== null) {
+                const rest = source.slice(match.index);
+                const launcherMatch = rest.match(/\brun(?:ProcessCallback|Process)\(/);
+                if (!launcherMatch || launcherMatch.index === undefined) {
+                    throw new Error(`No process-launcher call found following ${builder}( in ${filePath}`);
+                }
+                const launcherStart = match.index + launcherMatch.index;
+                results.push(extractBalancedCall(source, launcherStart));
+            }
+        }
+        return results;
+    }
+
+    function builderCallsUsed(source: string): string[] {
+        return [...new Set([...source.matchAll(/\b(build[A-Za-z]*Argv)\(/g)].map((m) => m[1]))];
+    }
+
+    function exportedBuilderNames(tsSource: string): string[] {
+        return [...new Set([...tsSource.matchAll(/export function (build[A-Za-z]*Argv)\(/g)].map((m) => m[1]))];
+    }
+
+    test('every call to the process launcher that follows a secret-bearing builder passes an options object whose env property spreads process.env', () => {
+        for (const filePath of [EXTENSION_TS, COMMANDS_CJS]) {
+            const source = stripLineComments(readFileOrThrow(filePath));
+            const launcherCalls = launcherCallsFollowingSecretBuilders(filePath, source);
+            expect(launcherCalls.length).toBeGreaterThan(0);
+            for (const call of launcherCalls) {
+                expect(call).toMatch(/env:\s*\{[^}]*\.\.\.process\.env/);
+            }
+        }
+    });
+
+    test('neither file references a builder that is not exported from process-args.ts', () => {
+        const tsSource = readFileOrThrow(PROCESS_ARGS_TS);
+        const exported = exportedBuilderNames(tsSource);
+        expect(exported.length).toBeGreaterThan(0);
+        for (const filePath of [EXTENSION_TS, COMMANDS_CJS]) {
+            const source = stripLineComments(readFileOrThrow(filePath));
+            const used = builderCallsUsed(source);
+            expect(used.length).toBeGreaterThan(0);
+            for (const name of used) {
+                expect(exported).toContain(name);
+            }
+        }
+    });
+
+    test('fails with an explicit message naming the path when extension.ts or Commands.cjs is absent', () => {
+        const missing = path.join(REPO_ROOT, 'src', 'does-not-exist-extension.ts');
+        expect(() => readFileOrThrow(missing)).toThrow(
+            new RegExp(`Guarded source file not found at .*does-not-exist-extension\\.ts`)
+        );
     });
 });

--- a/bbj-vscode/test/em-secret-env-channel.test.ts
+++ b/bbj-vscode/test/em-secret-env-channel.test.ts
@@ -11,11 +11,17 @@ import { formatArgvForLog } from '../src/Commands/process-runner.js';
  * BBj runtime — the same shape as no-shell-command-construction.test.ts and
  * command-argv-injection.test.ts.
  *
- * Transient state (75-01-PLAN.md): only the validate path (em-validate-token.bbj /
- * buildEmValidateArgv) is migrated in this plan. em-login.bbj and web.bbj still read
- * their secrets via ARGV until plans 02 and 03 land — the cross-layer contract test
- * below is written to hold vacuously for those two scripts until then, not to assert
- * anything about their current (pre-migration) ARGV intake.
+ * Transient state (75-02-PLAN.md): as of this plan all three scripts —
+ * em-validate-token.bbj, em-login.bbj and web.bbj — read their credentials/token via
+ * ENV() with no positional fallback. The IntelliJ callers (BbjProcessSecretEnv.emLogin
+ * / webRun) already write the corresponding environment map. The VS Code TypeScript
+ * callers (buildEmLoginArgv / buildWebRunArgv in process-args.ts and their extension.ts
+ * call sites) are NOT migrated in this plan — that is plan 03's job — so those two
+ * builders still emit the pre-migration ARGV shape. The script-side and builder-side
+ * ARGV/positional-count cross-checks below are therefore written against the scripts'
+ * OWN final numbering (fixed expected index sets), not against the still-unmigrated
+ * `buildEmLoginArgv`/`buildWebRunArgv` output, so this suite is green after this plan
+ * without also requiring plan 03's VS Code changes.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -74,6 +80,74 @@ describe('em-secret-env-channel guard — em-validate-token.bbj reads ENV, not A
         const missing = path.join(TOOLS_DIR, 'does-not-exist-em-validate-token.bbj');
         expect(() => readStrippedScript(missing)).toThrow(
             new RegExp(`Guarded source file not found at .*${'does-not-exist-em-validate-token.bbj'}`)
+        );
+    });
+});
+
+/** ARGV index count each script's final numbering settles on (75-02-PLAN.md). */
+const FINAL_POSITIONAL_COUNT: Record<string, number> = {
+    [EM_VALIDATE_SCRIPT]: 1,
+    [EM_LOGIN_SCRIPT]: 2,
+    [WEB_SCRIPT]: 6
+};
+
+describe('em-secret-env-channel guard — em-login.bbj reads ENV, not ARGV, for the credentials', () => {
+    test('obtains its username and password from ENV("BBJ_EM_USERNAME"/"BBJ_EM_PASSWORD") and reads exactly ARGV indices 1 and 2', () => {
+        const stripped = readStrippedScript(EM_LOGIN_SCRIPT);
+        expect(stripped).toContain('ENV("BBJ_EM_USERNAME"');
+        expect(stripped).toContain('ENV("BBJ_EM_PASSWORD"');
+        expect(distinctArgvIndices(stripped)).toEqual([1, 2]);
+    });
+
+    test('assigns no credential variable from an ARGV read', () => {
+        const stripped = readStrippedScript(EM_LOGIN_SCRIPT);
+        expect(stripped).not.toMatch(/username!\s*=\s*ARGV\(/);
+        expect(stripped).not.toMatch(/password!\s*=\s*ARGV\(/);
+    });
+
+    test('contains no statement that erases or deletes the output-file path before opening it', () => {
+        const stripped = readStrippedScript(EM_LOGIN_SCRIPT);
+        expect(stripped).not.toMatch(/erase[( ]/i);
+    });
+
+    test('the number of distinct ARGV(n) indices equals this script\'s final positional-argument count', () => {
+        const stripped = readStrippedScript(EM_LOGIN_SCRIPT);
+        expect(distinctArgvIndices(stripped).length).toBe(FINAL_POSITIONAL_COUNT[EM_LOGIN_SCRIPT]);
+    });
+
+    test('fails with an explicit message naming the path when the guarded script is absent', () => {
+        const missing = path.join(TOOLS_DIR, 'does-not-exist-em-login.bbj');
+        expect(() => readStrippedScript(missing)).toThrow(
+            new RegExp(`Guarded source file not found at .*${'does-not-exist-em-login.bbj'}`)
+        );
+    });
+});
+
+describe('em-secret-env-channel guard — web.bbj reads ENV, not ARGV, for the credentials and token', () => {
+    test('obtains its username, password and token from the three BBJ_EM_* ENV reads and reads exactly ARGV indices 1 through 6', () => {
+        const stripped = readStrippedScript(WEB_SCRIPT);
+        expect(stripped).toContain('ENV("BBJ_EM_USERNAME"');
+        expect(stripped).toContain('ENV("BBJ_EM_PASSWORD"');
+        expect(stripped).toContain('ENV("BBJ_EM_TOKEN"');
+        expect(distinctArgvIndices(stripped)).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+
+    test('assigns no credential or token variable from an ARGV read', () => {
+        const stripped = readStrippedScript(WEB_SCRIPT);
+        expect(stripped).not.toMatch(/username!\s*=\s*ARGV\(/);
+        expect(stripped).not.toMatch(/password!\s*=\s*ARGV\(/);
+        expect(stripped).not.toMatch(/token!\s*=\s*ARGV\(/);
+    });
+
+    test('the number of distinct ARGV(n) indices equals this script\'s final positional-argument count', () => {
+        const stripped = readStrippedScript(WEB_SCRIPT);
+        expect(distinctArgvIndices(stripped).length).toBe(FINAL_POSITIONAL_COUNT[WEB_SCRIPT]);
+    });
+
+    test('fails with an explicit message naming the path when the guarded script is absent', () => {
+        const missing = path.join(TOOLS_DIR, 'does-not-exist-web.bbj');
+        expect(() => readStrippedScript(missing)).toThrow(
+            new RegExp(`Guarded source file not found at .*${'does-not-exist-web.bbj'}`)
         );
     });
 });

--- a/bbj-vscode/test/em-secret-env-channel.test.ts
+++ b/bbj-vscode/test/em-secret-env-channel.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { buildEmValidateArgv } from '../src/Commands/process-args.js';
+import { buildEmValidateArgv, type Argv } from '../src/Commands/process-args.js';
+import { formatArgvForLog } from '../src/Commands/process-runner.js';
 
 /**
  * GHSA-33x9-cpwv-xcv2 / GHSA-xxp5-vv2w-42q8: these guards prove the Enterprise Manager
@@ -134,5 +135,57 @@ describe('em-secret-env-channel guard — cross-layer BBJ_EM_* name contract', (
         expect(() => readFileOrThrow(missing)).toThrow(
             new RegExp(`Guarded source file not found at .*does-not-exist\\.bbj`)
         );
+    });
+});
+
+describe('em-secret-env-channel guard — the environment map has no path to the debug log', () => {
+    const EXTENSION_TS = path.join(REPO_ROOT, 'src/extension.ts');
+    const COMMANDS_CJS = path.join(REPO_ROOT, 'src/Commands/Commands.cjs');
+
+    /** Strip `//` line comments, mirroring no-shell-command-construction.test.ts. */
+    function stripLineComments(source: string): string {
+        return source.replace(/\/\/.*$/gm, '');
+    }
+
+    function appendLineCallArguments(filePath: string): string[] {
+        const source = stripLineComments(readFileOrThrow(filePath));
+        return [...source.matchAll(/outputChannel\.appendLine\((.*)\);/g)].map((m) => m[1]);
+    }
+
+    test('every appendLine call whose argument mentions an invocation (argv) renders it through formatArgvForLog', () => {
+        for (const filePath of [EXTENSION_TS, COMMANDS_CJS]) {
+            const calls = appendLineCallArguments(filePath);
+            expect(calls.length).toBeGreaterThan(0);
+            for (const call of calls) {
+                if (/\bargv\b/.test(call)) {
+                    expect(call).toMatch(/formatArgvForLog\(/);
+                }
+            }
+        }
+    });
+
+    test('neither file passes an options object, nor a bare argv/invocation, directly to appendLine', () => {
+        for (const filePath of [EXTENSION_TS, COMMANDS_CJS]) {
+            for (const call of appendLineCallArguments(filePath)) {
+                expect(call).not.toMatch(/\boptions\b/);
+                // A bare "argv" (or "invocation") mention that is not inside a
+                // formatArgvForLog( call would be a builder result logged directly.
+                const withoutRedactedCall = call.replace(/formatArgvForLog\([^)]*\)/g, '');
+                expect(withoutRedactedCall).not.toMatch(/\b(argv|invocation)\b/);
+            }
+        }
+    });
+
+    test('formatArgvForLog applied to an Argv carrying a populated env map returns a string containing none of that map\'s values', () => {
+        const secretValue = 'super-secret-token-value-9f3c';
+        const argv: Argv = {
+            file: '/opt/bbj/bin/bbj',
+            args: ['-q', '/ext/tools/em-validate-token.bbj', '-', '/tmp/out.tmp'],
+            env: { BBJ_EM_TOKEN: secretValue }
+        };
+
+        const rendered = formatArgvForLog(argv);
+
+        expect(rendered).not.toContain(secretValue);
     });
 });

--- a/bbj-vscode/test/em-secret-env-channel.test.ts
+++ b/bbj-vscode/test/em-secret-env-channel.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { buildEmValidateArgv } from '../src/Commands/process-args.js';
+
+/**
+ * GHSA-33x9-cpwv-xcv2 / GHSA-xxp5-vv2w-42q8: these guards prove the Enterprise Manager
+ * credentials and JWT travel to the spawned `bbj` process on the environment, not on
+ * argv, and that the `.bbj` scripts read them via ENV() rather than ARGV(). Offline, no
+ * BBj runtime — the same shape as no-shell-command-construction.test.ts and
+ * command-argv-injection.test.ts.
+ *
+ * Transient state (75-01-PLAN.md): only the validate path (em-validate-token.bbj /
+ * buildEmValidateArgv) is migrated in this plan. em-login.bbj and web.bbj still read
+ * their secrets via ARGV until plans 02 and 03 land — the cross-layer contract test
+ * below is written to hold vacuously for those two scripts until then, not to assert
+ * anything about their current (pre-migration) ARGV intake.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const TOOLS_DIR = path.join(REPO_ROOT, 'tools');
+const EM_VALIDATE_SCRIPT = path.join(TOOLS_DIR, 'em-validate-token.bbj');
+const EM_LOGIN_SCRIPT = path.join(TOOLS_DIR, 'em-login.bbj');
+const WEB_SCRIPT = path.join(TOOLS_DIR, 'web.bbj');
+const PROCESS_ARGS_TS = path.join(REPO_ROOT, 'src/Commands/process-args.ts');
+const BBJ_PROCESS_SECRET_ENV_JAVA = path.resolve(
+    REPO_ROOT,
+    '..',
+    'bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnv.java'
+);
+
+const BBJ_EM_VOCABULARY = ['BBJ_EM_USERNAME', 'BBJ_EM_PASSWORD', 'BBJ_EM_TOKEN'];
+
+/** Strip `rem` comment lines (case-insensitive, leading whitespace tolerated). */
+function stripRemLines(source: string): string {
+    return source
+        .split(/\r?\n/)
+        .filter((line) => !/^\s*rem\b/i.test(line))
+        .join('\n');
+}
+
+function readFileOrThrow(filePath: string): string {
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Guarded source file not found at ${filePath}`);
+    }
+    return fs.readFileSync(filePath, 'utf-8');
+}
+
+function readStrippedScript(filePath: string): string {
+    return stripRemLines(readFileOrThrow(filePath));
+}
+
+function distinctArgvIndices(strippedSource: string): number[] {
+    const indices = new Set<number>();
+    for (const match of strippedSource.matchAll(/ARGV\((\d+)/g)) {
+        indices.add(Number(match[1]));
+    }
+    return [...indices].sort((a, b) => a - b);
+}
+
+function bbjEmNamesIn(source: string): string[] {
+    return [...new Set([...source.matchAll(/BBJ_EM_[A-Z]+/g)].map((m) => m[0]))];
+}
+
+describe('em-secret-env-channel guard — em-validate-token.bbj reads ENV, not ARGV, for the token', () => {
+    test('obtains its token from ENV("BBJ_EM_TOKEN") and the only ARGV index it reads is 1', () => {
+        const stripped = readStrippedScript(EM_VALIDATE_SCRIPT);
+        expect(stripped).toContain('ENV("BBJ_EM_TOKEN"');
+        expect(distinctArgvIndices(stripped)).toEqual([1]);
+    });
+
+    test('fails with an explicit message naming the path when the guarded script is absent', () => {
+        const missing = path.join(TOOLS_DIR, 'does-not-exist-em-validate-token.bbj');
+        expect(() => readStrippedScript(missing)).toThrow(
+            new RegExp(`Guarded source file not found at .*${'does-not-exist-em-validate-token.bbj'}`)
+        );
+    });
+});
+
+describe('em-secret-env-channel guard — buildEmValidateArgv', () => {
+    const OPTS = {
+        home: '/opt/bbj',
+        platform: 'linux' as NodeJS.Platform,
+        scriptPath: '/ext/tools/em-validate-token.bbj',
+        tmpFile: '/tmp/out.tmp'
+    };
+
+    test('returns an env map carrying the token under BBJ_EM_TOKEN and a four-element args array containing the token nowhere', () => {
+        const token = 'tok-abc-123';
+        const argv = buildEmValidateArgv({ ...OPTS, token });
+
+        expect(argv.env?.['BBJ_EM_TOKEN']).toBe(token);
+        expect(argv.args).toEqual(['-q', OPTS.scriptPath, '-', OPTS.tmpFile]);
+        expect(argv.args.some((a) => a.includes(token))).toBe(false);
+    });
+
+    test('the number of distinct ARGV(n) indices em-validate-token.bbj reads equals the number of positional args buildEmValidateArgv emits after the "-" separator', () => {
+        const stripped = readStrippedScript(EM_VALIDATE_SCRIPT);
+        const argv = buildEmValidateArgv({ ...OPTS, token: 'tok-abc-123' });
+        const separatorIndex = argv.args.indexOf('-');
+        const positionalCount = argv.args.length - separatorIndex - 1;
+
+        expect(distinctArgvIndices(stripped).length).toBe(positionalCount);
+    });
+});
+
+describe('em-secret-env-channel guard — cross-layer BBJ_EM_* name contract', () => {
+    test('every BBJ_EM_* literal in BbjProcessSecretEnv.java and process-args.ts is drawn from the three-name vocabulary, and every name a script reads via ENV() is a name at least one builder writes', () => {
+        const javaSource = readFileOrThrow(BBJ_PROCESS_SECRET_ENV_JAVA);
+        const tsSource = readFileOrThrow(PROCESS_ARGS_TS);
+
+        const javaNames = bbjEmNamesIn(javaSource);
+        const tsNames = bbjEmNamesIn(tsSource);
+        const writtenNames = new Set([...javaNames, ...tsNames]);
+
+        for (const name of writtenNames) {
+            expect(BBJ_EM_VOCABULARY).toContain(name);
+        }
+        expect(writtenNames.has('BBJ_EM_TOKEN')).toBe(true);
+
+        for (const scriptPath of [EM_VALIDATE_SCRIPT, EM_LOGIN_SCRIPT, WEB_SCRIPT]) {
+            const stripped = readStrippedScript(scriptPath);
+            for (const name of BBJ_EM_VOCABULARY) {
+                const readsViaEnv = new RegExp(`ENV\\("${name}"`).test(stripped);
+                if (readsViaEnv) {
+                    expect(writtenNames.has(name)).toBe(true);
+                }
+            }
+        }
+    });
+
+    test('fails with an explicit message naming the path when a guarded file is absent', () => {
+        const missing = path.join(TOOLS_DIR, 'does-not-exist.bbj');
+        expect(() => readFileOrThrow(missing)).toThrow(
+            new RegExp(`Guarded source file not found at .*does-not-exist\\.bbj`)
+        );
+    });
+});

--- a/bbj-vscode/tools/em-login.bbj
+++ b/bbj-vscode/tools/em-login.bbj
@@ -1,25 +1,26 @@
 rem BBj EM Login Stub - Authenticates and returns JWT token
 rem Parameters:
-rem   1) username
-rem   2) password
-rem   3) outputFile (path to temp file for writing result)
-rem   4) infoString (optional - client info string, e.g. "VS Code on MacOS as beff")
+rem   1) outputFile (path to temp file for writing result)
+rem   2) infoString (optional - client info string, e.g. "VS Code on MacOS as beff")
+rem Environment:
+rem   BBJ_EM_USERNAME - the EM username
+rem   BBJ_EM_PASSWORD - the EM password
 
 ? 'HIDE'
 
-username! = ARGV(1,err=*next)
-password! = ARGV(2,err=*next)
-outputFile! = ARGV(3,err=*next)
-infoString! = ARGV(4,err=*next)
+username! = ENV("BBJ_EM_USERNAME",err=*next)
+password! = ENV("BBJ_EM_PASSWORD",err=*next)
+outputFile! = ARGV(1,err=*next)
+infoString! = ARGV(2,err=*next)
 
-if (username! = null()) then
+if (username! = null() or username! = "") then
     ch=unt
     open(ch,mode="O_CREATE,O_TRUNC")outputFile!
     write(ch)"ERROR:Username required"
     close(ch)
     release
 fi
-if (password! = null()) then
+if (password! = null() or password! = "") then
     ch=unt
     open(ch,mode="O_CREATE,O_TRUNC")outputFile!
     write(ch)"ERROR:Password required"

--- a/bbj-vscode/tools/em-validate-token.bbj
+++ b/bbj-vscode/tools/em-validate-token.bbj
@@ -1,14 +1,15 @@
 rem BBj EM Token Validation - Tests token against EM before usage
 rem Parameters:
-rem   1) token
-rem   2) outputFile (path to temp file for writing result)
+rem   1) outputFile (path to temp file for writing result)
+rem Environment:
+rem   BBJ_EM_TOKEN - the JWT to validate
 
 ? 'HIDE'
 
-token! = ARGV(1,err=*next)
-outputFile! = ARGV(2,err=*next)
+token! = ENV("BBJ_EM_TOKEN",err=*next)
+outputFile! = ARGV(1,err=*next)
 
-if (token! = null()) then
+if (token! = null() or token! = "") then
     ch=unt
     open(ch,mode="O_CREATE,O_TRUNC")outputFile!
     write(ch)"INVALID"

--- a/bbj-vscode/tools/web.bbj
+++ b/bbj-vscode/tools/web.bbj
@@ -4,11 +4,12 @@ rem   1) client [BUI|DWC]
 rem   2) app name
 rem   3) program file
 rem   4) working directory
-rem   5) username
-rem   6) password
-rem   7) session-specific classpath
-rem   8) auth token (optional, if present uses token-based auth)
-rem   9) config file path (optional, if present uses custom config.bbx)
+rem   5) session-specific classpath
+rem   6) config file path (optional, if present uses custom config.bbx)
+rem Environment:
+rem   BBJ_EM_USERNAME - EM username (legacy username/password authentication fallback)
+rem   BBJ_EM_PASSWORD - EM password (legacy username/password authentication fallback)
+rem   BBJ_EM_TOKEN - auth token (optional, if present uses token-based auth)
 
 ? 'HIDE'
 
@@ -16,19 +17,19 @@ isDWC!      = iff(ARGV(1) = "DWC", 1, 0)
 name!       = ARGV(2)
 programme!  = ARGV(3)
 wd!         = ARGV(4)
-username!   = ARGV(5,err=*next)
-password!   = ARGV(6,err=*next)
-sscp!       = ARGV(7,err=*next)
-token!      = ARGV(8,err=*next)
-configFile! = ARGV(9,err=*next)
+sscp!       = ARGV(5,err=*next)
+configFile! = ARGV(6,err=*next)
+username!   = ENV("BBJ_EM_USERNAME",err=*next)
+password!   = ENV("BBJ_EM_PASSWORD",err=*next)
+token!      = ENV("BBJ_EM_TOKEN",err=*next)
 
 rem Token-based authentication if token is provided
 if (token! <> null() and token! > "") then
     admin! = BBjAdminFactory.getBBjAdmin(token!,err=login_failed)
 else
     rem Legacy username/password authentication (backward compatible)
-    if (username! = null()) username! = "admin"
-    if (password! = null()) password! = "admin123"
+    if (username! = null() or username! = "") username! = "admin"
+    if (password! = null() or password! = "") password! = "admin123"
     admin! = BBjAdminFactory.getBBjAdmin(username!, password!,err=login_failed)
 fi
 configuration! = admin!.getRemoteConfiguration()


### PR DESCRIPTION
## Summary

- All BBj process launches on both IDE sides (VS Code and IntelliJ) that carry Enterprise Manager username, password, or JWT token now pass those values through the child process's environment instead of positional command-line arguments.
- Three shared `.bbj` scripts bundled into both extensions (`em-login.bbj`, `em-validate-token.bbj`, `web.bbj`) now read credentials via `ENV()` instead of `ARGV()`; the removed positional slots are renumbered.
- On the IntelliJ side, a new platform-free `BbjProcessSecretEnv` builder centralizes environment/argument assembly for all four secret-bearing call sites (`BbjEMLoginAction`, `BbjRunActionBase`, `BbjRunBuiAction`, `BbjRunDwcAction`).
- On the VS Code side, the existing `process-args.ts` builders (`buildEmValidateArgv`, `buildEmLoginArgv`, `buildWebRunArgv`) now return an environment map alongside a shorter args array, and every launcher call site spreads that map over the child process's environment.
- Both IDEs now create their JWT/token output files with owner-only file permissions at creation time, via `BbjProcessSecretEnv.createOwnerOnlyFile` (IntelliJ) and a new `createOwnerOnlyFile` helper (VS Code), before the process spawn.

## How to review

- `bbj-intellij/src/main/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnv.java` is the new single seam on the IntelliJ side; the four action classes under `bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/` route their command construction through it.
- `bbj-vscode/src/Commands/process-args.ts` is the corresponding VS Code seam; `bbj-vscode/src/extension.ts` and `bbj-vscode/src/Commands/Commands.cjs` are the call sites.
- `bbj-vscode/tools/em-login.bbj`, `bbj-vscode/tools/em-validate-token.bbj`, and `bbj-vscode/tools/web.bbj` show the script-side intake change and the renumbered positional arguments.

## Regression coverage

- `bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjProcessSecretEnvTest.java` and `BbjSecretArgvSourceGuardTest.java` pin the new environment channel and guard against any of the four action classes reintroducing a secret-bearing positional argument.
- `bbj-vscode/test/em-secret-env-channel.test.ts` and the updated `bbj-vscode/test/command-argv-injection.test.ts` pin the new builder shapes, the new positional-argument counts, and the launcher call sites' environment-spreading behavior for all three scripts.
- Each of the above test files was observed failing against the pre-change code before its corresponding production change landed.
