### PR TITLE
fix: EM login and Run BUI/DWC failing on macOS (ENV() vs CLIENTENV())

### DIFF
--- a/bbj-vscode/test/em-clientenv-guard.test.ts
+++ b/bbj-vscode/test/em-clientenv-guard.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { shouldRunBBjTests } from './test-helper.js';
+
+/**
+ * Regression guard for the macOS Enterprise Manager login/run-action failure
+ * live in released `0.12.21`/`0.12.22`: `em-login.bbj` writes
+ * `ERROR:Username required`, meaning its username read back empty.
+ *
+ * Root cause (confirmed by direct experiment on two platforms, same script,
+ * same `bbj -q <script> - <outputFile>` invocation shape the extension uses,
+ * one variable `BBJ_PROBE_VAR=HELLO` set on the spawning process):
+ *
+ *   Linux (dev container, /opt/bbx):  ENV=[HELLO] CLIENTENV=[HELLO] SERVERENV=[HELLO]
+ *   macOS (user's machine, ~/bbx):    ENV=[null]  CLIENTENV=[HELLO] SERVERENV=[null]
+ *
+ * `ENV()` does not see the spawning process's environment on macOS.
+ * `CLIENTENV()` does, on both platforms tested. Phase 75
+ * (GHSA-33x9-cpwv-xcv2 / GHSA-xxp5-vv2w-42q8) moved the EM secrets off the
+ * command line onto the child process environment and read them back with
+ * `ENV()` — correct on Linux (where every automated test in this phase ran),
+ * silently broken on macOS (where nothing in this repository's CI or test
+ * suite runs BBj at all).
+ *
+ * The fix reads `CLIENTENV()` first and falls back to `ENV()` only when
+ * `CLIENTENV()` reads back empty. Windows was NOT tested at merge time —
+ * only Linux and macOS were probed. If Windows turns out to be the mirror
+ * image (`CLIENTENV()` blind, `ENV()` populated), the fallback still works
+ * there; a `CLIENTENV()`-only fix would not have, and would have shipped a
+ * second platform-specific break.
+ *
+ * ## What this guard proves, and what it does not
+ *
+ * (a) Below is a **source-text** guard: it asserts every `BBJ_EM_*` secret
+ *     in the three affected scripts is read via `CLIENTENV(` at least once
+ *     (with `ENV(`, when present for the same variable, appearing only
+ *     later in the source, i.e. as a fallback read after the `CLIENTENV()`
+ *     read — never as the sole or first read). This is the check that
+ *     actually would have caught the regression before release — it fails
+ *     against the pre-fix scripts, which read `BBJ_EM_*` exclusively via
+ *     bare `ENV(` with no `CLIENTENV(` anywhere (RED, captured verbatim in
+ *     the accompanying commit/SUMMARY). The regex is anchored on `\bENV\(`/
+ *     `\bCLIENTENV\(` rather than "does the string ENV( appear" — a plain
+ *     substring check is wrong here, since `CLIENTENV(` itself contains the
+ *     substring `ENV(` (that exact trap already produced one wrong verdict
+ *     during this investigation). It proves the *accessor choice* is
+ *     correct. It does NOT prove `CLIENTENV()` or the fallback behave
+ *     identically to `ENV()` at runtime on any platform, and it does NOT
+ *     prove anything about macOS or Windows, because no macOS or Windows
+ *     runner exists in this container or in CI.
+ *
+ * (b) Further below is a **behavioral** test, gated behind the project's
+ *     standard `RUN_BBJ_TESTS` convention (`test:bbj` / a reachable BBj
+ *     instance), that spawns `em-login.bbj` for real against this
+ *     container's live BBjServices instance with synthetic credentials on
+ *     the environment. It asserts the output is the authentication-failure
+ *     path (`ERROR:Authentication failed...`), not `ERROR:Username
+ *     required` — proving the credentials *arrived* at the script. This
+ *     test passes on Linux **even against the pre-fix `ENV()`-only
+ *     scripts**, because `ENV()` does see the spawning process's
+ *     environment on Linux. It is a guard for the *callers* (argv/env
+ *     wiring reaching the child process correctly), not for the *accessor
+ *     choice* — only guard (a) above is specific to this regression. Do not
+ *     read a pass here as proof the macOS bug is fixed; only (a) and a real
+ *     macOS run can prove that.
+ */
+
+const TOOLS_DIR = path.resolve(__dirname, '..', 'tools');
+
+const SCRIPTS_WITH_SECRETS: Record<string, string[]> = {
+    'em-login.bbj': ['BBJ_EM_USERNAME', 'BBJ_EM_PASSWORD'],
+    'em-validate-token.bbj': ['BBJ_EM_TOKEN'],
+    'web.bbj': ['BBJ_EM_USERNAME', 'BBJ_EM_PASSWORD', 'BBJ_EM_TOKEN']
+};
+
+describe('EM secret reads use CLIENTENV(), not bare ENV() -- ENV() does not see the spawning process environment on macOS', () => {
+    for (const [scriptName, vars] of Object.entries(SCRIPTS_WITH_SECRETS)) {
+        const scriptPath = path.join(TOOLS_DIR, scriptName);
+
+        describe(scriptName, () => {
+            const source = fs.readFileSync(scriptPath, 'utf-8');
+
+            for (const varName of vars) {
+                test(`${varName} is read via CLIENTENV() first; a bare ENV() read, if present, is only a later fallback`, () => {
+                    // \b before ENV( does NOT match inside CLIENTENV( -- "T" and "E" are both
+                    // word characters, so there is no word boundary between them. This is a
+                    // tokenized/anchored check, not a plain substring search for "ENV(" --
+                    // CLIENTENV( contains that substring, and a naive check on it already
+                    // produced one wrong verdict during this investigation.
+                    const bareEnvPattern = new RegExp(`\\bENV\\(\\s*["']${varName}["']`);
+                    const clientEnvPattern = new RegExp(`\\bCLIENTENV\\(\\s*["']${varName}["']`);
+
+                    // Must fail against the pre-fix scripts: they have no CLIENTENV( read at
+                    // all, only a bare ENV( read. This assertion is what actually goes RED.
+                    const clientEnvMatch = source.match(clientEnvPattern);
+                    expect(clientEnvMatch).not.toBeNull();
+
+                    // A fallback ENV( read, if present, must come strictly after the
+                    // CLIENTENV( read that takes priority over it -- never before or instead.
+                    const bareEnvMatch = source.match(bareEnvPattern);
+                    if (bareEnvMatch) {
+                        expect(bareEnvMatch.index!).toBeGreaterThan(clientEnvMatch!.index!);
+                    }
+                });
+            }
+        });
+    }
+});
+
+describe('em-login.bbj behavioral check against a live BBjServices instance', async () => {
+    const BBJ_BIN = '/opt/bbx/bin/bbj';
+    const EM_LOGIN_SCRIPT = path.join(TOOLS_DIR, 'em-login.bbj');
+    const run = (await shouldRunBBjTests()) && fs.existsSync(BBJ_BIN);
+
+    // See the file-level comment above: this test passes on Linux against BOTH
+    // the pre-fix ENV() scripts and the post-fix CLIENTENV() scripts. It proves
+    // the callers wire the secret onto the child environment correctly; it does
+    // NOT distinguish ENV() from CLIENTENV(), and does NOT cover macOS. Only
+    // guard (a) above catches this specific regression.
+    test.runIf(run)(
+        'synthetic non-real credentials on the environment reach the script -- output is the authentication-failure path, never "Username required"',
+        () => {
+            const tmpFile = path.join(
+                os.tmpdir(),
+                `em-login-clientenv-verify-${process.pid}-${Date.now()}.tmp`
+            );
+            try {
+                execFileSync(
+                    BBJ_BIN,
+                    ['-q', EM_LOGIN_SCRIPT, '-', tmpFile, 'clientenv-guard-behavioral-test'],
+                    {
+                        env: {
+                            ...process.env,
+                            BBJ_EM_USERNAME: 'synthetic-clientenv-guard-user-DO-NOT-USE',
+                            BBJ_EM_PASSWORD: 'synthetic-clientenv-guard-pw-DO-NOT-USE-9f3a'
+                        },
+                        timeout: 30000
+                    }
+                );
+                const output = fs.readFileSync(tmpFile, 'utf-8').trim();
+                expect(output).not.toBe('ERROR:Username required');
+                expect(output).toContain('ERROR:Authentication failed');
+            } finally {
+                fs.rmSync(tmpFile, { force: true });
+            }
+        },
+        60000
+    );
+});

--- a/bbj-vscode/tools/em-login.bbj
+++ b/bbj-vscode/tools/em-login.bbj
@@ -8,8 +8,15 @@ rem   BBJ_EM_PASSWORD - the EM password
 
 ? 'HIDE'
 
-username! = ENV("BBJ_EM_USERNAME",err=*next)
-password! = ENV("BBJ_EM_PASSWORD",err=*next)
+rem CLIENTENV() reads the spawning process's environment; ENV() does not on
+rem macOS (confirmed by direct probe: ENV() reads back null there while
+rem CLIENTENV() sees the same value). Read CLIENTENV() first and fall back to
+rem ENV() only if it comes back empty, in case a platform not yet tested
+rem (e.g. Windows) turns out to be the mirror image.
+username! = CLIENTENV("BBJ_EM_USERNAME",err=*next)
+if (username! = null() or username! = "") then username! = ENV("BBJ_EM_USERNAME",err=*next)
+password! = CLIENTENV("BBJ_EM_PASSWORD",err=*next)
+if (password! = null() or password! = "") then password! = ENV("BBJ_EM_PASSWORD",err=*next)
 outputFile! = ARGV(1,err=*next)
 infoString! = ARGV(2,err=*next)
 

--- a/bbj-vscode/tools/em-validate-token.bbj
+++ b/bbj-vscode/tools/em-validate-token.bbj
@@ -6,7 +6,13 @@ rem   BBJ_EM_TOKEN - the JWT to validate
 
 ? 'HIDE'
 
-token! = ENV("BBJ_EM_TOKEN",err=*next)
+rem CLIENTENV() reads the spawning process's environment; ENV() does not on
+rem macOS (confirmed by direct probe: ENV() reads back null there while
+rem CLIENTENV() sees the same value). Read CLIENTENV() first and fall back to
+rem ENV() only if it comes back empty, in case a platform not yet tested
+rem (e.g. Windows) turns out to be the mirror image.
+token! = CLIENTENV("BBJ_EM_TOKEN",err=*next)
+if (token! = null() or token! = "") then token! = ENV("BBJ_EM_TOKEN",err=*next)
 outputFile! = ARGV(1,err=*next)
 
 if (token! = null() or token! = "") then

--- a/bbj-vscode/tools/web.bbj
+++ b/bbj-vscode/tools/web.bbj
@@ -19,9 +19,17 @@ programme!  = ARGV(3)
 wd!         = ARGV(4)
 sscp!       = ARGV(5,err=*next)
 configFile! = ARGV(6,err=*next)
-username!   = ENV("BBJ_EM_USERNAME",err=*next)
-password!   = ENV("BBJ_EM_PASSWORD",err=*next)
-token!      = ENV("BBJ_EM_TOKEN",err=*next)
+rem CLIENTENV() reads the spawning process's environment; ENV() does not on
+rem macOS (confirmed by direct probe: ENV() reads back null there while
+rem CLIENTENV() sees the same value). Read CLIENTENV() first and fall back to
+rem ENV() only if it comes back empty, in case a platform not yet tested
+rem (e.g. Windows) turns out to be the mirror image.
+username!   = CLIENTENV("BBJ_EM_USERNAME",err=*next)
+if (username! = null() or username! = "") then username! = ENV("BBJ_EM_USERNAME",err=*next)
+password!   = CLIENTENV("BBJ_EM_PASSWORD",err=*next)
+if (password! = null() or password! = "") then password! = ENV("BBJ_EM_PASSWORD",err=*next)
+token!      = CLIENTENV("BBJ_EM_TOKEN",err=*next)
+if (token! = null() or token! = "") then token! = ENV("BBJ_EM_TOKEN",err=*next)
 
 rem Token-based authentication if token is provided
 if (token! <> null() and token! > "") then


### PR DESCRIPTION
## Summary

Fixes Enterprise Manager login, Run BUI, and Run DWC failing on macOS in the currently released VS Code and IntelliJ builds. On macOS, `ENV()` in a BBj script does not read the spawning process's environment; `CLIENTENV()` does. The EM secrets (`BBJ_EM_USERNAME`, `BBJ_EM_PASSWORD`, `BBJ_EM_TOKEN`) are passed to the three shared BBj launcher scripts (`em-login.bbj`, `em-validate-token.bbj`, `web.bbj`) on the spawned process's environment, and all three read them back with `ENV()` -- correct on Linux, silently broken on macOS, where nothing in this repository's CI or automated test suite runs BBj at all.

Confirmed by direct experiment on both platforms, same script, same `bbj -q <script> - <outputFile>` invocation shape the extension uses, one variable `BBJ_PROBE_VAR=HELLO` set on the spawning process:

```
Linux (dev container, /opt/bbx):  ENV=[HELLO] CLIENTENV=[HELLO] SERVERENV=[HELLO]
macOS (user's machine, ~/bbx):    ENV=[null]  CLIENTENV=[HELLO] SERVERENV=[null]
```

## Fix

All three scripts now read each `BBJ_EM_*` secret via `CLIENTENV()` first, falling back to `ENV()` only if `CLIENTENV()` reads back empty -- not a straight `CLIENTENV()`-only swap. Windows was not tested at merge time (only Linux and macOS were probed); the fallback behaves correctly on all three platforms regardless of which way Windows turns out to go, whereas a `CLIENTENV()`-only fix would risk shipping a second platform-specific break if Windows turns out to be the mirror image of macOS.

No argument positions changed, and the existing `err=*next` handling and null/empty guards are unchanged.

## Testing

- New regression guard (`bbj-vscode/test/em-clientenv-guard.test.ts`): a source-text check asserting every `BBJ_EM_*` read uses `CLIENTENV()` (with any `ENV()` read of the same variable appearing only as a later fallback), observed failing against the pre-fix scripts and passing after the fix. Also includes a behavioral test (gated behind the existing `RUN_BBJ_TESTS` convention) spawning `em-login.bbj` against a live BBjServices instance with synthetic credentials, confirming the credentials reach the script.
- Manual end-to-end re-check on Linux with the fix applied: reaches `ERROR:Authentication failed - invalid credentials or EM not available`, not `ERROR:Username required` -- `CLIENTENV()` does not regress Linux.
- Whole-suite vitest: `numFailedTests: 0`.
- `npm run build` and `npm run lint` clean.

## Test plan

- [x] Regression guard observed RED against pre-fix scripts, GREEN after the fix
- [x] Manual Linux end-to-end check confirms no regression
- [x] Whole-suite vitest clean (`numFailedTests: 0`)
- [x] Build and lint clean
- [ ] CI green on this PR