### PR TITLE
fix: non-vacuous EM guard assertion + move EM login/validate network calls off the IntelliJ EDT

### DIFF
--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjEMLoginAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjEMLoginAction.java
@@ -8,6 +8,7 @@ import com.intellij.execution.process.ProcessOutput;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ApplicationNamesInfo;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
@@ -33,12 +34,24 @@ public final class BbjEMLoginAction extends AnAction {
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        performLogin(e.getProject());
+        Project project = e.getProject();
+        // Off EDT: performLogin() performs a blocking EM login network call (up to 15s,
+        // CapturingProcessHandler.runProcess) and must not run on the EDT (CR-02). Its own
+        // credential/result dialogs are individually routed back to the EDT (see
+        // showErrorOnEdt/showInfoOnEdt/promptUsername/promptPassword below).
+        ApplicationManager.getApplication().executeOnPooledThread(() -> performLogin(project));
     }
 
     /**
      * Performs the EM login flow programmatically.
      * Shows credential dialog, launches em-login.bbj, stores token.
+     *
+     * <p>Must be called off the EDT (see {@link #actionPerformed} and the BUI/DWC run
+     * actions' {@code buildCommandLine()} callers, both of which now dispatch to a pooled
+     * thread) -- the blocking network call this method makes (up to 15s) would otherwise
+     * freeze the IDE (CR-02). Each dialog this method shows is individually routed back to
+     * the EDT via {@code invokeAndWait}.
+     *
      * @param project current project (can be null)
      * @return true if login succeeded and token was stored, false if cancelled or failed
      */
@@ -46,7 +59,7 @@ public final class BbjEMLoginAction extends AnAction {
         BbjSettings.State state = BbjSettings.getInstance().getState();
         String bbjHome = state.bbjHomePath;
         if (bbjHome == null || bbjHome.isEmpty()) {
-            Messages.showErrorDialog(
+            showErrorOnEdt(
                 "Please configure BBj Home in Settings > Languages & Frameworks > BBj",
                 "BBj Home Not Set"
             );
@@ -54,25 +67,16 @@ public final class BbjEMLoginAction extends AnAction {
         }
 
         // Prompt for credentials
-        String username = Messages.showInputDialog(
-            "Enter EM username:",
-            "Enterprise Manager Login",
-            null,
-            "admin",
-            null
-        );
+        String username = promptUsername();
         if (username == null || username.isEmpty()) return false;
 
-        String password = Messages.showPasswordDialog(
-            "Enter EM password:",
-            "Enterprise Manager Login"
-        );
+        String password = promptPassword();
         if (password == null) return false;
 
         // Find em-login.bbj in plugin bundle
         String emLoginPath = getEMLoginBbjPath();
         if (emLoginPath == null) {
-            Messages.showErrorDialog(
+            showErrorOnEdt(
                 "em-login.bbj not found in plugin bundle",
                 "Login Failed"
             );
@@ -87,16 +91,25 @@ public final class BbjEMLoginAction extends AnAction {
         try { bbjPath = bbjPath.toRealPath(); } catch (Exception ignored) {}
 
         if (!Files.isExecutable(bbjPath)) {
-            Messages.showErrorDialog("BBj executable not found: " + bbjBin, "Login Failed");
+            showErrorOnEdt("BBj executable not found: " + bbjBin, "Login Failed");
             return false;
         }
 
-        // Launch em-login.bbj
+        // Launch em-login.bbj. The temp file is created owner-only before the try block so
+        // its cleanup in `finally` covers the entire launch -- process-handler construction
+        // and runProcess() included -- matching validateTokenServerSide's shape (WR-02: a
+        // finally scoped only around the file read left the file leaked on disk whenever
+        // construction/launch itself threw).
+        Path tmpFile;
         try {
             // Create temp file for BBj output, owner-only for its whole life: em-login.bbj
             // truncates and writes in place, which preserves the mode set here.
-            Path tmpFile = BbjProcessSecretEnv.createOwnerOnlyFile("bbj-em-login-", ".tmp");
-
+            tmpFile = BbjProcessSecretEnv.createOwnerOnlyFile("bbj-em-login-", ".tmp");
+        } catch (Exception ex) {
+            showErrorOnEdt("Login failed: " + ex.getMessage(), "EM Login Failed");
+            return false;
+        }
+        try {
             // Client info for EM token payload
             String platform;
             if (os.contains("win")) platform = "Windows";
@@ -117,20 +130,15 @@ public final class BbjEMLoginAction extends AnAction {
             ProcessOutput output = handler.runProcess(15000); // 15s timeout
 
             // Read result from temp file
-            String stdout = "";
-            try {
-                stdout = Files.readString(tmpFile).trim();
-            } finally {
-                Files.deleteIfExists(tmpFile);
-            }
+            String stdout = Files.readString(tmpFile).trim();
 
             if (stdout.startsWith("ERROR:")) {
-                Messages.showErrorDialog(stdout.substring(6), "EM Login Failed");
+                showErrorOnEdt(stdout.substring(6), "EM Login Failed");
                 return false;
             }
 
             if (stdout.isEmpty()) {
-                Messages.showErrorDialog(
+                showErrorOnEdt(
                     "No token received from EM login",
                     "EM Login Failed"
                 );
@@ -139,18 +147,57 @@ public final class BbjEMLoginAction extends AnAction {
 
             // Store JWT securely
             BbjEMTokenStore.storeToken(stdout);
-            Messages.showInfoMessage(
+            showInfoOnEdt(
                 "Successfully logged in to Enterprise Manager",
                 "EM Login"
             );
             return true;
         } catch (Exception ex) {
-            Messages.showErrorDialog(
+            showErrorOnEdt(
                 "Login failed: " + ex.getMessage(),
                 "EM Login Failed"
             );
             return false;
+        } finally {
+            try { Files.deleteIfExists(tmpFile); } catch (Exception ignored) {}
         }
+    }
+
+    /** Routes a blocking username prompt to the EDT and returns the result to the calling thread. */
+    @Nullable
+    private static String promptUsername() {
+        String[] holder = new String[1];
+        ApplicationManager.getApplication().invokeAndWait(() ->
+                holder[0] = Messages.showInputDialog(
+                        "Enter EM username:",
+                        "Enterprise Manager Login",
+                        null,
+                        "admin",
+                        null
+                ));
+        return holder[0];
+    }
+
+    /** Routes a blocking password prompt to the EDT and returns the result to the calling thread. */
+    @Nullable
+    private static String promptPassword() {
+        String[] holder = new String[1];
+        ApplicationManager.getApplication().invokeAndWait(() ->
+                holder[0] = Messages.showPasswordDialog(
+                        "Enter EM password:",
+                        "Enterprise Manager Login"
+                ));
+        return holder[0];
+    }
+
+    /** Shows a modal error dialog on the EDT, blocking the calling (pooled) thread until dismissed. */
+    private static void showErrorOnEdt(String message, String title) {
+        ApplicationManager.getApplication().invokeAndWait(() -> Messages.showErrorDialog(message, title));
+    }
+
+    /** Shows a modal info dialog on the EDT, blocking the calling (pooled) thread until dismissed. */
+    private static void showInfoOnEdt(String message, String title) {
+        ApplicationManager.getApplication().invokeAndWait(() -> Messages.showInfoMessage(message, title));
     }
 
     /**

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunActionBase.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunActionBase.java
@@ -57,15 +57,17 @@ public abstract class BbjRunActionBase extends AnAction {
             return;
         }
 
-        // Build command line (subclass responsibility)
-        GeneralCommandLine cmd = buildCommandLine(file, project);
-        if (cmd == null) {
-            // Error already shown by subclass
-            return;
-        }
-
-        // Execute the command off EDT to avoid UI freezing
+        // Build the command line and launch it off EDT to avoid UI freezing.
+        // buildCommandLine() (subclass responsibility) may perform blocking EM token
+        // server-side validation (validateTokenServerSide, up to 10s) and/or EM login
+        // (BbjEMLoginAction.performLogin, up to 15s) -- both are synchronous network I/O
+        // and must not run on the EDT (CR-02).
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            GeneralCommandLine cmd = buildCommandLine(file, project);
+            if (cmd == null) {
+                // Error already shown by subclass
+                return;
+            }
             try {
                 OSProcessHandler handler = new OSProcessHandler(cmd);
 

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunBuiAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunBuiAction.java
@@ -4,6 +4,7 @@ import com.basis.bbj.intellij.BbjIcons;
 import com.basis.bbj.intellij.BbjSettings;
 import com.basis.bbj.intellij.lsp.BbjProcessSecretEnv;
 import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -54,11 +55,10 @@ public final class BbjRunBuiAction extends BbjRunActionBase {
         // Get token from PasswordSafe, auto-prompt login if not stored
         String token = BbjEMTokenStore.getToken();
         if (token == null || token.isEmpty()) {
-            int result = Messages.showYesNoDialog(
+            int result = showYesNoOnEdt(
                 project,
                 "EM login required for BUI. Login now?",
-                "Enterprise Manager Login Required",
-                Messages.getQuestionIcon()
+                "Enterprise Manager Login Required"
             );
             if (result == Messages.YES) {
                 boolean loginOk = BbjEMLoginAction.performLogin(project);
@@ -86,11 +86,10 @@ public final class BbjRunBuiAction extends BbjRunActionBase {
 
         // If token was invalidated, re-prompt login
         if (token == null) {
-            int result = Messages.showYesNoDialog(
+            int result = showYesNoOnEdt(
                 project,
                 "EM token expired or invalid. Login again?",
-                "Enterprise Manager Token Invalid",
-                Messages.getQuestionIcon()
+                "Enterprise Manager Token Invalid"
             );
             if (result == Messages.YES) {
                 boolean loginOk = BbjEMLoginAction.performLogin(project);
@@ -130,5 +129,19 @@ public final class BbjRunBuiAction extends BbjRunActionBase {
     @NotNull
     protected String getRunMode() {
         return "BUI";
+    }
+
+    /**
+     * Routes a blocking yes/no prompt to the EDT and returns the result to the calling
+     * thread. {@code buildCommandLine()} now runs off the EDT (CR-02, see
+     * {@code BbjRunActionBase.actionPerformed}), so this dialog -- like every other
+     * {@code Messages.*} call reachable from here -- must be explicitly dispatched back to
+     * the EDT rather than shown directly from a pooled thread.
+     */
+    private static int showYesNoOnEdt(@Nullable Project project, String message, String title) {
+        int[] holder = new int[1];
+        ApplicationManager.getApplication().invokeAndWait(() ->
+                holder[0] = Messages.showYesNoDialog(project, message, title, Messages.getQuestionIcon()));
+        return holder[0];
     }
 }

--- a/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunDwcAction.java
+++ b/bbj-intellij/src/main/java/com/basis/bbj/intellij/actions/BbjRunDwcAction.java
@@ -4,6 +4,7 @@ import com.basis.bbj.intellij.BbjIcons;
 import com.basis.bbj.intellij.BbjSettings;
 import com.basis.bbj.intellij.lsp.BbjProcessSecretEnv;
 import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -54,11 +55,10 @@ public final class BbjRunDwcAction extends BbjRunActionBase {
         // Get token from PasswordSafe, auto-prompt login if not stored
         String token = BbjEMTokenStore.getToken();
         if (token == null || token.isEmpty()) {
-            int result = Messages.showYesNoDialog(
+            int result = showYesNoOnEdt(
                 project,
                 "EM login required for DWC. Login now?",
-                "Enterprise Manager Login Required",
-                Messages.getQuestionIcon()
+                "Enterprise Manager Login Required"
             );
             if (result == Messages.YES) {
                 boolean loginOk = BbjEMLoginAction.performLogin(project);
@@ -86,11 +86,10 @@ public final class BbjRunDwcAction extends BbjRunActionBase {
 
         // If token was invalidated, re-prompt login
         if (token == null) {
-            int result = Messages.showYesNoDialog(
+            int result = showYesNoOnEdt(
                 project,
                 "EM token expired or invalid. Login again?",
-                "Enterprise Manager Token Invalid",
-                Messages.getQuestionIcon()
+                "Enterprise Manager Token Invalid"
             );
             if (result == Messages.YES) {
                 boolean loginOk = BbjEMLoginAction.performLogin(project);
@@ -130,5 +129,19 @@ public final class BbjRunDwcAction extends BbjRunActionBase {
     @NotNull
     protected String getRunMode() {
         return "DWC";
+    }
+
+    /**
+     * Routes a blocking yes/no prompt to the EDT and returns the result to the calling
+     * thread. {@code buildCommandLine()} now runs off the EDT (CR-02, see
+     * {@code BbjRunActionBase.actionPerformed}), so this dialog -- like every other
+     * {@code Messages.*} call reachable from here -- must be explicitly dispatched back to
+     * the EDT rather than shown directly from a pooled thread.
+     */
+    private static int showYesNoOnEdt(@Nullable Project project, String message, String title) {
+        int[] holder = new int[1];
+        ApplicationManager.getApplication().invokeAndWait(() ->
+                holder[0] = Messages.showYesNoDialog(project, message, title, Messages.getQuestionIcon()));
+        return holder[0];
     }
 }

--- a/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjSecretArgvSourceGuardTest.java
+++ b/bbj-intellij/src/test/java/com/basis/bbj/intellij/lsp/BbjSecretArgvSourceGuardTest.java
@@ -7,6 +7,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -84,15 +86,21 @@ class BbjSecretArgvSourceGuardTest {
                 "BbjProcessSecretEnv is not referenced in BbjRunActionBase.java");
     }
 
+    /**
+     * CR-01 / phase-75 gap fix: a source-ordering check ({@code indexOf("BbjProcessSecretEnv")
+     * < indexOf("withEnvironment(")}) is vacuous by construction, because
+     * {@code import ...BbjProcessSecretEnv;} is necessarily the first occurrence of that
+     * literal in any valid Java file — the check would pass for a regression where
+     * {@code withEnvironment(...)} receives an unrelated, independently-built map sitting
+     * anywhere after that import. This asserts the actual data-flow connection instead:
+     * the argument passed to {@code withEnvironment(...)} must be the specific
+     * {@code Invocation}'s own {@code .environment()} map, not merely textually present
+     * somewhere after an unrelated import.
+     */
     @Test
-    void theBbjProcessSecretEnvReferencePrecedesTheWithEnvironmentCall() {
+    void theWithEnvironmentCallArgumentIsTheInvocationsEnvironmentMap() {
         String text = readGuardedSource(RUN_ACTION_BASE);
-        int secretEnvIndex = text.indexOf("BbjProcessSecretEnv");
-        int withEnvironmentIndex = text.indexOf("withEnvironment(");
-        assertTrue(secretEnvIndex >= 0, "BbjProcessSecretEnv is not present in BbjRunActionBase.java");
-        assertTrue(withEnvironmentIndex >= 0, "withEnvironment( is not present in BbjRunActionBase.java");
-        assertTrue(secretEnvIndex < withEnvironmentIndex,
-                "BbjProcessSecretEnv must be referenced before the withEnvironment( call");
+        assertWithEnvironmentArgumentIsInvocationEnvironment(text, RUN_ACTION_BASE.toString());
     }
 
     @Test
@@ -133,18 +141,70 @@ class BbjSecretArgvSourceGuardTest {
                 }));
     }
 
+    /** Same CR-01 fix as {@link #theWithEnvironmentCallArgumentIsTheInvocationsEnvironmentMap()}, across all four call sites. */
     @Test
-    void allFourFilesReferenceBbjProcessSecretEnvBeforeCallingWithEnvironment() {
-        assertAll("BbjProcessSecretEnv precedes withEnvironment(",
+    void allFourFilesPassTheInvocationsEnvironmentMapToWithEnvironment() {
+        assertAll("withEnvironment( argument is the Invocation's own environment() map",
                 ALL_GUARDED_ACTION_FILES.stream().map(source -> () -> {
                     String text = readGuardedSource(source);
-                    int secretEnvIndex = text.indexOf("BbjProcessSecretEnv");
-                    int withEnvironmentIndex = text.indexOf("withEnvironment(");
-                    assertTrue(secretEnvIndex >= 0, "BbjProcessSecretEnv is not present in " + source);
-                    assertTrue(withEnvironmentIndex >= 0, "withEnvironment( is not present in " + source);
-                    assertTrue(secretEnvIndex < withEnvironmentIndex,
-                            "BbjProcessSecretEnv must be referenced before the withEnvironment( call in " + source);
+                    assertWithEnvironmentArgumentIsInvocationEnvironment(text, source.toString());
                 }));
+    }
+
+    /**
+     * Extracts the exact argument text passed to {@code withEnvironment(...)} (balanced-
+     * parenthesis scan, so a nested call like {@code invocation.environment()} is captured
+     * whole) and asserts it is exactly {@code "<var>.environment()"} where {@code <var>} is
+     * the local variable the file itself declared via
+     * {@code BbjProcessSecretEnv.Invocation <var> = BbjProcessSecretEnv.xxx(...)}. This is a
+     * genuine data-flow assertion, not a token-ordering one: a regression where
+     * {@code withEnvironment(...)} receives an independently-built map (e.g.
+     * {@code withEnvironment(Map.of())}) — even sitting textually after the
+     * {@code BbjProcessSecretEnv} import and reachable via a bare {@code withEnvironment(}
+     * substring search — fails this assertion because the extracted argument no longer
+     * equals {@code invocation.environment()}.
+     */
+    private static void assertWithEnvironmentArgumentIsInvocationEnvironment(String text, String sourceLabel) {
+        String invocationVar = extractInvocationVariableName(text);
+        assertTrue(invocationVar != null,
+                "No \"BbjProcessSecretEnv.Invocation <var> = ...\" declaration found in " + sourceLabel);
+        String argument = extractBalancedCallArgument(text, "withEnvironment(");
+        assertTrue(argument != null, "No withEnvironment( call found in " + sourceLabel);
+        assertEquals(invocationVar + ".environment()", argument,
+                "withEnvironment( must be called with the Invocation's own environment() map ("
+                        + invocationVar + ".environment()) -- not an independently constructed value -- in "
+                        + sourceLabel + "; found: withEnvironment(" + argument + ")");
+    }
+
+    private static String extractInvocationVariableName(String text) {
+        Matcher m = Pattern.compile("BbjProcessSecretEnv\\.Invocation\\s+(\\w+)\\s*=").matcher(text);
+        return m.find() ? m.group(1) : null;
+    }
+
+    /** Scans forward from the end of {@code callPrefix} (which must end in "(") to the matching close paren. */
+    private static String extractBalancedCallArgument(String text, String callPrefix) {
+        int start = text.indexOf(callPrefix);
+        if (start < 0) {
+            return null;
+        }
+        int argsStart = start + callPrefix.length();
+        int depth = 1;
+        int i = argsStart;
+        while (i < text.length() && depth > 0) {
+            char c = text.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+            }
+            if (depth > 0) {
+                i++;
+            }
+        }
+        if (depth != 0) {
+            return null;
+        }
+        return text.substring(argsStart, i).trim();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two independent fixes, both authorized directly (no PLAN.md, scoped gap closure inside phase 75):

1. **Test-quality fix**: `BbjSecretArgvSourceGuardTest`'s two ordering assertions
   (`indexOf("BbjProcessSecretEnv") < indexOf("withEnvironment(")`) could never fail, since
   `import ...BbjProcessSecretEnv;` is necessarily the first occurrence of that literal in
   any valid Java file. Replaced with a genuine data-flow assertion: the `withEnvironment(...)`
   call's argument must equal `<var>.environment()`, where `<var>` is the file's own declared
   `Invocation` variable. Verified non-vacuous with a scratch mutant (not committed): the OLD
   assertion still passes when `withEnvironment(...)` is changed to receive an unrelated
   `Map.of()`; the NEW assertion correctly fails.

2. **IDE responsiveness fix**: `buildCommandLine()` on IntelliJ's BUI/DWC run actions, and the
   standalone EM login action, performed blocking network calls (EM token server-side
   validation up to 10s, EM login up to 15s) synchronously on the Event Dispatch Thread,
   freezing the whole IDE for up to ~25s. Moved this work off the EDT (buildCommandLine now
   runs inside the existing pooled-thread dispatch; performLogin's own dialogs are
   individually routed back to the EDT via `invokeAndWait`). This appears pre-existing rather
   than introduced by phase 75 -- phase 75 changed only how the secret reaches the child
   process, not this threading pattern.

   While in the same method for the EDT fix, also closed a temp-file leak
   (`BbjEMLoginAction.performLogin`'s cleanup `finally` was scoped only around the file read,
   so the owner-only output file leaked on disk whenever process construction/launch itself
   threw -- widened to match the sibling `validateTokenServerSide`'s shape).

Neither fix references any security advisory (per the standing no-CVE-during-remediation
decision) -- this is a test-quality and UI-responsiveness fix.

## Not included

A related finding (missing `"--"` EM-Config-sentinel strip in `getConfigPathArg`) is
deliberately **not** fixed here -- tracked as a todo for separate handling.

## Test plan

- [x] `./gradlew test` (bbj-intellij) -- full JUnit suite green
- [x] `./gradlew buildPlugin` (bbj-intellij) -- green
- [x] `npx vitest run` (bbj-vscode) -- `numFailedTests: 0` (1137 total)
- [x] `npm run lint` (bbj-vscode) -- clean
- [ ] **Manual QA required before/after merge**: the EDT restructuring changes threading with
      no automated IntelliJ UI test coverage in this repo. EM login and all three run actions
      (GUI/BUI/DWC) need a live functional check in the actual IDE.