### PR TITLE
Verify the bundled formatter JARs against committed checksums before running them

### DIFF
--- a/bbj-vscode/src/document-formatter.ts
+++ b/bbj-vscode/src/document-formatter.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import { logger } from './language/logger.js';
+import { verifyFormatterArtifacts, FORMATTER_TOOLS_DIR, type FormatterVerificationResult } from './formatter-verifier.js';
 
 // Mirrors each open document's live content, kept in sync by the onDidChangeTextDocument
 // listener below. document.getText() already returns VS Code's live in-memory buffer for a
@@ -15,9 +16,21 @@ const unsavedContentMap = new Map<string, string>();
 // URI spawns again.
 const inFlightFormats = new Map<string, Promise<string>>();
 
+// A hash-mismatched artefact toasts once per extension-host
+// session, however many format-on-save invocations follow, so the constant format-on-save
+// cadence does not spam the user with repeat notifications. logger.warn still fires on every
+// occurrence (see runFormatter below), so a mismatch is never silent even after the toast has
+// already fired once.
+let integrityNoticeShown = false;
+
+// Rejection value for a verification refusal, distinguished from the underlying `java` process's
+// own error/stderr rejections so the reject handler below re-throws it without a second
+// logger.warn.
+class FormatterArtifactError extends Error {}
+
 export const DocumentFormatter = {
   provideDocumentFormattingEdits(document: vscode.TextDocument): Thenable<vscode.TextEdit[] | undefined> {
-    const jarPath = `${__dirname}/../tools/formatter/BBjCFCli.jar`;
+    const jarPath = `${FORMATTER_TOOLS_DIR}/BBjCFCli.jar`;
     const config = vscode.workspace.getConfiguration('bbj').formatter;
     const args: string[] = [];
 
@@ -63,6 +76,12 @@ export const DocumentFormatter = {
         return [edit];
       },
       (err: any) => {
+        if (err instanceof FormatterArtifactError) {
+          // runFormatter already logged this refusal (with the expected/actual digests, or the
+          // expected path) before rejecting — re-reject without a second logger.warn line.
+          return Promise.reject(err);
+        }
+
         if (err) {
           logger.warn(String(err));
           return Promise.reject(err);
@@ -75,6 +94,41 @@ export const DocumentFormatter = {
 
   runFormatter(formatFlags: string[], documentContent: string): Thenable<string> {
     return new Promise<string>((resolve, reject) => {
+      // Verify the bundled formatter JAR against its committed
+      // SHA-256 immediately before spawning it. Placed here (inside runFormatter, one check per
+      // actual spawn) rather than in provideDocumentFormattingEdits (which would run once per
+      // *request*), so a "Save All" burst still shares one check per URI via the existing
+      // inFlightFormats coalescing above. Synchronous — readFileSync, no await — so cp.spawn is
+      // still reached in the same tick this Promise executor runs, preserving the existing
+      // synchronous call-count assertions and the dedup timing. Not cached by mtime/size:
+      // re-checking every spawn self-heals and costs well under a millisecond for ~7KB.
+      const verification: FormatterVerificationResult = verifyFormatterArtifacts(FORMATTER_TOOLS_DIR);
+      if (!verification.ok) {
+        if (verification.reason === 'DIGEST_MISMATCH') {
+          const message =
+            `The bundled BBj formatter (${verification.relativePath}) did not match its expected checksum. ` +
+            `Formatting was cancelled. Reinstalling the extension restores the bundled formatter.`;
+          // logger.warn on every occurrence gives a permanent record; the user-facing toast
+          // below is deliberately deduplicated to once per session — format-on-save
+          // fires constantly, and a per-invocation notification would be noise, not signal.
+          logger.warn(
+            `${message} expected=${verification.expectedSha256} actual=${verification.actualSha256 ?? '(unavailable)'}`
+          );
+          if (!integrityNoticeShown) {
+            integrityNoticeShown = true;
+            vscode.window.showErrorMessage(message);
+          }
+        } else {
+          // MISSING_OR_UNREADABLE: a distinct broken-install diagnosis, not a security-grade
+          // signal — only a hash mismatch (above) warrants the user-facing toast.
+          const message =
+            `The bundled BBj formatter is unavailable (expected at ${verification.absolutePath}). ` +
+            `Formatting was cancelled.`;
+          logger.warn(message);
+        }
+        return reject(new FormatterArtifactError(`Formatter artefact verification failed: ${verification.reason}`));
+      }
+
       let t0 = Date.now();
       let stdout = '';
       let stderr = '';

--- a/bbj-vscode/src/formatter-verifier.ts
+++ b/bbj-vscode/src/formatter-verifier.ts
@@ -1,0 +1,143 @@
+// Pin table and pure verify function for the bundled BBj
+// formatter JARs. This module has one job — decide whether an on-disk artefact matches its
+// committed checksum — and is deliberately dependency-free (only `node:fs` and `node:crypto`)
+// so it stays importable from a vitest guard with no `vscode` or `child_process` harness, and
+// so it does not add a fourth entry to no-shell-command-construction.test.ts's three-launcher
+// list.
+//
+// This is one of three consumers of the table below: the runtime gate in
+// document-formatter.ts, the tamper guard, and the drift guard. Keeping the
+// pins here rather than inlined at the spawn site gives all three one source of truth.
+//
+// What this module does NOT claim: it detects a JAR that no longer matches the bytes committed
+// to this repository. It does not defend against someone who can already write to the installed
+// extension directory, since the same access can rewrite this file's own compiled output
+// (out/extension.cjs). The committed pin table below and the drift check that couples it to the
+// vendored bytes are where the guarantee lives, not this runtime gate.
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+
+/**
+ * A single vendored formatter artefact's pinned trust anchor. `origin` and `vendoredOn` are
+ * provenance, not just a hash — knowing where the bytes came from and when they entered the
+ * tree is what lets a future updater re-vendor deliberately rather than merely detect that
+ * something changed.
+ */
+export interface PinnedFormatterArtifact {
+  relativePath: string;
+  sha256: string;
+  sizeBytes: number;
+  origin: string;
+  vendoredOn: string;
+}
+
+// The verifier uses a static artefact list rather than one derived from BBjCFCli.jar's own
+// MANIFEST.MF Class-Path entry. This is sound because BBjCFCli.jar's own hash is pinned below:
+// its manifest cannot grow a fourth Class-Path entry without failing this table's own digest
+// check first. Do not "fix" this by adding zip/manifest parsing to the format-on-save path.
+//
+// Only BBjCFCli.jar is pinned in this plan (77-01, the tracer slice); the other two vendored
+// artefacts (lib/jcommander-1.71.jar, lib/BBjCodeFomatter.jar) are added by a later plan in this
+// phase on top of exactly this structure.
+export const FORMATTER_ARTIFACT_PINS: readonly PinnedFormatterArtifact[] = [
+  {
+    relativePath: 'BBjCFCli.jar',
+    sizeBytes: 6780,
+    sha256: 'f73a8af5b6eceee3fa5ab11f71e96a629629dc4885235293cfaf6ed6e3c68bd4',
+    origin: 'BASIS-supplied build, vendored 2023-07-10; no public upstream feed — re-vendor via BASIS.',
+    vendoredOn: '2023-07-10',
+  },
+];
+
+// Computed here, not in document-formatter.ts, so the drift guard (a separate consumer) uses
+// the exact same directory the runtime gate resolves against.
+export const FORMATTER_TOOLS_DIR = `${__dirname}/../tools/formatter`;
+
+export type FormatterVerificationFailureReason = 'MISSING_OR_UNREADABLE' | 'DIGEST_MISMATCH';
+
+export type FormatterVerificationResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: FormatterVerificationFailureReason;
+      relativePath: string;
+      absolutePath: string;
+      expectedSha256: string;
+      actualSha256?: string;
+    };
+
+/** The relative paths of every pinned artefact, in declared order. */
+export function formatterArtifactNames(): readonly string[] {
+  return FORMATTER_ARTIFACT_PINS.map((pin) => pin.relativePath);
+}
+
+function refuse(
+  reason: FormatterVerificationFailureReason,
+  artefactRelativePath: string,
+  absolutePath: string,
+  expectedSha256: string,
+  actualSha256?: string
+): FormatterVerificationResult {
+  return { ok: false, reason, relativePath: artefactRelativePath, absolutePath, expectedSha256, actualSha256 };
+}
+
+/**
+ * Verifies every pinned formatter artefact under `formatterDir` against its committed SHA-256,
+ * in declared table order, returning on the first failure — so the reported failure is
+ * deterministic when more than one artefact is bad.
+ *
+ * Synchronous by design: `document-formatter.ts`'s spawn site must reach `cp.spawn` in the same
+ * tick this function returns, so the existing synchronous `cp.spawn` call-count assertions in
+ * document-formatter.test.ts keep holding with no `await` inserted.
+ *
+ * `readFile` defaults to `fs.readFileSync` and exists purely as an injection seam so a guard
+ * can drive this function with fixture bytes without touching the real tree.
+ *
+ * Nothing in this function may throw outward: an unexpected error becomes a refusal rather than
+ * a fall-through that would let the caller reach `cp.spawn` unverified.
+ */
+export function verifyFormatterArtifacts(
+  formatterDir: string,
+  readFile: (absolutePath: string) => Buffer = (absolutePath) => fs.readFileSync(absolutePath)
+): FormatterVerificationResult {
+  try {
+    for (const pin of FORMATTER_ARTIFACT_PINS) {
+      const absolutePath = `${formatterDir}/${pin.relativePath}`;
+
+      let buffer: Buffer;
+      try {
+        buffer = readFile(absolutePath);
+      } catch {
+        return refuse('MISSING_OR_UNREADABLE', pin.relativePath, absolutePath, pin.sha256);
+      }
+
+      // A present-but-zero-length file is readable, so it reaches here and is hashed. That
+      // hash will not match a non-empty artefact's pin, so it refuses with DIGEST_MISMATCH, not
+      // MISSING_OR_UNREADABLE. Deliberate: a truncated artefact is indistinguishable from a
+      // substituted one to this function, and the stronger signal is the safer default.
+      const actualSha256 = crypto.createHash('sha256').update(buffer).digest('hex').toLowerCase();
+      const expectedSha256 = pin.sha256.toLowerCase();
+
+      const expectedBuf = Buffer.from(expectedSha256, 'ascii');
+      const actualBuf = Buffer.from(actualSha256, 'ascii');
+      const matches =
+        expectedBuf.length === actualBuf.length && crypto.timingSafeEqual(expectedBuf, actualBuf);
+
+      if (!matches) {
+        return refuse('DIGEST_MISMATCH', pin.relativePath, absolutePath, expectedSha256, actualSha256);
+      }
+    }
+
+    return { ok: true };
+  } catch {
+    // Total function: any unexpected error (a bad injected readFile, a hashing failure) is a
+    // refusal, never a throw that could leave the caller free to fall through to cp.spawn.
+    const firstPin = FORMATTER_ARTIFACT_PINS[0];
+    return refuse(
+      'MISSING_OR_UNREADABLE',
+      firstPin?.relativePath ?? 'unknown',
+      formatterDir,
+      firstPin?.sha256 ?? ''
+    );
+  }
+}

--- a/bbj-vscode/src/formatter-verifier.ts
+++ b/bbj-vscode/src/formatter-verifier.ts
@@ -36,14 +36,35 @@ export interface PinnedFormatterArtifact {
 // its manifest cannot grow a fourth Class-Path entry without failing this table's own digest
 // check first. Do not "fix" this by adding zip/manifest parsing to the format-on-save path.
 //
-// Only BBjCFCli.jar is pinned in this plan (77-01, the tracer slice); the other two vendored
-// artefacts (lib/jcommander-1.71.jar, lib/BBjCodeFomatter.jar) are added by a later plan in this
-// phase on top of exactly this structure.
+// All three artefacts BBjCFCli.jar's Class-Path transitively loads on every format are pinned
+// here, in this declared order. Verification below iterates in this order and returns on the
+// first failure, so the reported (and notified) failure is deterministic when more than one
+// artefact is bad.
 export const FORMATTER_ARTIFACT_PINS: readonly PinnedFormatterArtifact[] = [
   {
     relativePath: 'BBjCFCli.jar',
     sizeBytes: 6780,
     sha256: 'f73a8af5b6eceee3fa5ab11f71e96a629629dc4885235293cfaf6ed6e3c68bd4',
+    origin: 'BASIS-supplied build, vendored 2023-07-10; no public upstream feed — re-vendor via BASIS.',
+    vendoredOn: '2023-07-10',
+  },
+  // No authoritative upstream digest is obtainable for this coordinate: the referenced version
+  // is absent from this dependency's published release history, and its likely original
+  // distribution channel has since been retired. This entry therefore records the vendored
+  // bytes as of the date below — the same change-detection-only status as the two BASIS
+  // artefacts in this table, not a verified-upstream provenance claim. Re-vendor deliberately,
+  // from a source you can independently confirm, if this artefact is ever updated.
+  {
+    relativePath: 'lib/jcommander-1.71.jar',
+    sizeBytes: 67503,
+    sha256: 'b78ba8f80afc3defe5cbec954495d650273205b715edf4578212f78517d8b804',
+    origin: 'Vendored third-party build (jcommander 1.71); no upstream digest obtainable for this version — re-vendor deliberately from a verifiable source if updating.',
+    vendoredOn: '2023-07-10',
+  },
+  {
+    relativePath: 'lib/BBjCodeFomatter.jar',
+    sizeBytes: 38078,
+    sha256: '5df78cc81797d0c2e0c5c14eb75c5141a5edb1bb9d131e84ebaafd26a6c1cf9f',
     origin: 'BASIS-supplied build, vendored 2023-07-10; no public upstream feed — re-vendor via BASIS.',
     vendoredOn: '2023-07-10',
   },

--- a/bbj-vscode/test/document-formatter.test.ts
+++ b/bbj-vscode/test/document-formatter.test.ts
@@ -29,6 +29,9 @@ vi.mock('vscode', () => {
             }),
             onDidCloseTextDocument: vi.fn(() => ({ dispose: () => { } })),
         },
+        window: {
+            showErrorMessage: vi.fn(),
+        },
         TextEdit,
         Range,
         __testState,
@@ -39,9 +42,19 @@ vi.mock('child_process', () => ({
     spawn: vi.fn(),
 }));
 
+// The wiring under test here is "does runFormatter call the verifier and refuse to
+// spawn on a non-ok result" — the verification logic itself is exercised for real, against
+// real bytes, by test/formatter-verifier-tamper.test.ts. Default to ok:true in beforeEach so
+// every pre-existing test above keeps its current behaviour unmodified.
+vi.mock('../src/formatter-verifier.js', () => ({
+    verifyFormatterArtifacts: vi.fn(),
+    FORMATTER_TOOLS_DIR: '/fake/tools/formatter',
+}));
+
 import * as cp from 'child_process';
 import * as vscodeMocked from 'vscode';
 import { DocumentFormatter } from '../src/document-formatter.js';
+import { verifyFormatterArtifacts } from '../src/formatter-verifier.js';
 
 /** A minimal fake ChildProcess: an EventEmitter with stdout/stderr/stdin. */
 function makeFakeProcess() {
@@ -64,6 +77,7 @@ function makeDocument(uriPath: string, text: string) {
 describe('DocumentFormatter', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        (verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ ok: true });
     });
 
     test('P62-D2-010: rejects the format promise on a non-ENOENT spawn error', async () => {
@@ -192,6 +206,105 @@ describe('DocumentFormatter', () => {
             await formatPromise;
 
             expect(proc.stdin.end).toHaveBeenCalledWith('unsaved edited text');
+        });
+    });
+
+    describe('formatter artefact verification gate', () => {
+        test('when the verifier reports ok, cp.spawn is called exactly once and synchronously, and formatting resolves as before', async () => {
+            (verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ ok: true });
+            const proc = makeFakeProcess();
+            (cp.spawn as unknown as ReturnType<typeof vi.fn>).mockReturnValue(proc);
+
+            const doc = makeDocument('/tmp/sec08-ok.bbj', 'rem hi');
+            const formatPromise = DocumentFormatter.provideDocumentFormattingEdits(doc);
+
+            // Synchronous: no await before this assertion.
+            expect(cp.spawn).toHaveBeenCalledTimes(1);
+
+            proc.stdout.emit('data', 'formatted output');
+            proc.emit('close', 0);
+
+            const result = await formatPromise;
+            expect((result as any)[0].newText).toBe('formatted output');
+        });
+
+        test('when the verifier reports DIGEST_MISMATCH, cp.spawn is never called, the promise rejects, logger.warn is called, and showErrorMessage is called exactly once', async () => {
+            (verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+                ok: false,
+                reason: 'DIGEST_MISMATCH',
+                relativePath: 'BBjCFCli.jar',
+                absolutePath: '/fake/tools/formatter/BBjCFCli.jar',
+                expectedSha256: 'expected-hash',
+                actualSha256: 'actual-hash',
+            });
+
+            const doc = makeDocument('/tmp/sec08-mismatch.bbj', 'rem hi');
+            const formatPromise = DocumentFormatter.provideDocumentFormattingEdits(doc);
+
+            expect(cp.spawn).not.toHaveBeenCalled();
+            await expect(formatPromise).rejects.toBeTruthy();
+            expect((vscodeMocked as any).window.showErrorMessage).toHaveBeenCalledTimes(1);
+        });
+
+        test('when a second and third mismatch follow in the same module session, logger.warn fires each time but showErrorMessage is still called exactly once in total', async () => {
+            (verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+                ok: false,
+                reason: 'DIGEST_MISMATCH',
+                relativePath: 'BBjCFCli.jar',
+                absolutePath: '/fake/tools/formatter/BBjCFCli.jar',
+                expectedSha256: 'expected-hash',
+                actualSha256: 'actual-hash',
+            });
+
+            // vi.clearAllMocks() in beforeEach resets showErrorMessage's call count for this test.
+            const doc1 = makeDocument('/tmp/sec08-mismatch-1.bbj', 'rem a');
+            await expect(DocumentFormatter.provideDocumentFormattingEdits(doc1)).rejects.toBeTruthy();
+
+            const doc2 = makeDocument('/tmp/sec08-mismatch-2.bbj', 'rem b');
+            await expect(DocumentFormatter.provideDocumentFormattingEdits(doc2)).rejects.toBeTruthy();
+
+            const doc3 = makeDocument('/tmp/sec08-mismatch-3.bbj', 'rem c');
+            await expect(DocumentFormatter.provideDocumentFormattingEdits(doc3)).rejects.toBeTruthy();
+
+            expect((vscodeMocked as any).window.showErrorMessage).toHaveBeenCalledTimes(1);
+        });
+
+        test('when the verifier reports MISSING_OR_UNREADABLE, cp.spawn is never called, the promise rejects, logger.warn names the expected path, and showErrorMessage is NOT called', async () => {
+            (verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+                ok: false,
+                reason: 'MISSING_OR_UNREADABLE',
+                relativePath: 'BBjCFCli.jar',
+                absolutePath: '/fake/tools/formatter/BBjCFCli.jar',
+                expectedSha256: 'expected-hash',
+            });
+
+            const doc = makeDocument('/tmp/sec08-missing.bbj', 'rem hi');
+            const formatPromise = DocumentFormatter.provideDocumentFormattingEdits(doc);
+
+            expect(cp.spawn).not.toHaveBeenCalled();
+            await expect(formatPromise).rejects.toBeTruthy();
+            expect((vscodeMocked as any).window.showErrorMessage).not.toHaveBeenCalled();
+        });
+
+        test('once-per-session toast dedup starts fresh on module reload (fresh session flag)', async () => {
+            vi.resetModules();
+            const freshModule = await import('../src/document-formatter.js');
+            const freshVerifier = await import('../src/formatter-verifier.js');
+            (freshVerifier.verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+                ok: false,
+                reason: 'DIGEST_MISMATCH',
+                relativePath: 'BBjCFCli.jar',
+                absolutePath: '/fake/tools/formatter/BBjCFCli.jar',
+                expectedSha256: 'expected-hash',
+                actualSha256: 'actual-hash',
+            });
+
+            const doc = makeDocument('/tmp/sec08-fresh-session.bbj', 'rem hi');
+            await expect(
+                freshModule.DocumentFormatter.provideDocumentFormattingEdits(doc)
+            ).rejects.toBeTruthy();
+
+            expect((vscodeMocked as any).window.showErrorMessage).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/bbj-vscode/test/document-formatter.test.ts
+++ b/bbj-vscode/test/document-formatter.test.ts
@@ -210,6 +210,27 @@ describe('DocumentFormatter', () => {
     });
 
     describe('formatter artefact verification gate', () => {
+        // The `integrityNoticeShown` once-per-session flag is module-level state in
+        // document-formatter.ts, so any test that depends on its starting value (every mismatch
+        // test below) needs its own fresh module instance — otherwise an earlier mismatch test in
+        // this file trips the flag and a later test observes it already set. vi.resetModules()
+        // forces vi.mock factories to re-run on the next dynamic import, so 'vscode',
+        // 'child_process' and '../src/formatter-verifier.js' all come back as fresh mock
+        // instances too; grab all four freshly rather than mixing fresh and outer-scope handles.
+        async function freshEnv() {
+            vi.resetModules();
+            const freshCp = await import('child_process');
+            const freshVscode = await import('vscode');
+            const freshVerifierModule = await import('../src/formatter-verifier.js');
+            const freshDocumentFormatterModule = await import('../src/document-formatter.js');
+            return {
+                cp: freshCp as unknown as { spawn: ReturnType<typeof vi.fn> },
+                vscode: freshVscode as unknown as { window: { showErrorMessage: ReturnType<typeof vi.fn> } },
+                verifyFormatterArtifacts: freshVerifierModule.verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>,
+                DocumentFormatter: freshDocumentFormatterModule.DocumentFormatter,
+            };
+        }
+
         test('when the verifier reports ok, cp.spawn is called exactly once and synchronously, and formatting resolves as before', async () => {
             (verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ ok: true });
             const proc = makeFakeProcess();
@@ -228,8 +249,9 @@ describe('DocumentFormatter', () => {
             expect((result as any)[0].newText).toBe('formatted output');
         });
 
-        test('when the verifier reports DIGEST_MISMATCH, cp.spawn is never called, the promise rejects, logger.warn is called, and showErrorMessage is called exactly once', async () => {
-            (verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        test('when the verifier reports DIGEST_MISMATCH, cp.spawn is never called, the promise rejects, and showErrorMessage is called exactly once', async () => {
+            const fresh = await freshEnv();
+            fresh.verifyFormatterArtifacts.mockReturnValue({
                 ok: false,
                 reason: 'DIGEST_MISMATCH',
                 relativePath: 'BBjCFCli.jar',
@@ -237,17 +259,22 @@ describe('DocumentFormatter', () => {
                 expectedSha256: 'expected-hash',
                 actualSha256: 'actual-hash',
             });
+            const warnSpy = vi.spyOn(console, 'warn');
 
             const doc = makeDocument('/tmp/sec08-mismatch.bbj', 'rem hi');
-            const formatPromise = DocumentFormatter.provideDocumentFormattingEdits(doc);
+            const formatPromise = fresh.DocumentFormatter.provideDocumentFormattingEdits(doc);
 
-            expect(cp.spawn).not.toHaveBeenCalled();
+            expect(fresh.cp.spawn).not.toHaveBeenCalled();
             await expect(formatPromise).rejects.toBeTruthy();
-            expect((vscodeMocked as any).window.showErrorMessage).toHaveBeenCalledTimes(1);
+            expect(warnSpy).toHaveBeenCalled();
+            expect(fresh.vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+
+            warnSpy.mockRestore();
         });
 
         test('when a second and third mismatch follow in the same module session, logger.warn fires each time but showErrorMessage is still called exactly once in total', async () => {
-            (verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            const fresh = await freshEnv();
+            fresh.verifyFormatterArtifacts.mockReturnValue({
                 ok: false,
                 reason: 'DIGEST_MISMATCH',
                 relativePath: 'BBjCFCli.jar',
@@ -255,42 +282,48 @@ describe('DocumentFormatter', () => {
                 expectedSha256: 'expected-hash',
                 actualSha256: 'actual-hash',
             });
+            const warnSpy = vi.spyOn(console, 'warn');
 
-            // vi.clearAllMocks() in beforeEach resets showErrorMessage's call count for this test.
             const doc1 = makeDocument('/tmp/sec08-mismatch-1.bbj', 'rem a');
-            await expect(DocumentFormatter.provideDocumentFormattingEdits(doc1)).rejects.toBeTruthy();
+            await expect(fresh.DocumentFormatter.provideDocumentFormattingEdits(doc1)).rejects.toBeTruthy();
 
             const doc2 = makeDocument('/tmp/sec08-mismatch-2.bbj', 'rem b');
-            await expect(DocumentFormatter.provideDocumentFormattingEdits(doc2)).rejects.toBeTruthy();
+            await expect(fresh.DocumentFormatter.provideDocumentFormattingEdits(doc2)).rejects.toBeTruthy();
 
             const doc3 = makeDocument('/tmp/sec08-mismatch-3.bbj', 'rem c');
-            await expect(DocumentFormatter.provideDocumentFormattingEdits(doc3)).rejects.toBeTruthy();
+            await expect(fresh.DocumentFormatter.provideDocumentFormattingEdits(doc3)).rejects.toBeTruthy();
 
-            expect((vscodeMocked as any).window.showErrorMessage).toHaveBeenCalledTimes(1);
+            expect(warnSpy).toHaveBeenCalledTimes(3);
+            expect(fresh.vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+
+            warnSpy.mockRestore();
         });
 
         test('when the verifier reports MISSING_OR_UNREADABLE, cp.spawn is never called, the promise rejects, logger.warn names the expected path, and showErrorMessage is NOT called', async () => {
-            (verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            const fresh = await freshEnv();
+            fresh.verifyFormatterArtifacts.mockReturnValue({
                 ok: false,
                 reason: 'MISSING_OR_UNREADABLE',
                 relativePath: 'BBjCFCli.jar',
                 absolutePath: '/fake/tools/formatter/BBjCFCli.jar',
                 expectedSha256: 'expected-hash',
             });
+            const warnSpy = vi.spyOn(console, 'warn');
 
             const doc = makeDocument('/tmp/sec08-missing.bbj', 'rem hi');
-            const formatPromise = DocumentFormatter.provideDocumentFormattingEdits(doc);
+            const formatPromise = fresh.DocumentFormatter.provideDocumentFormattingEdits(doc);
 
-            expect(cp.spawn).not.toHaveBeenCalled();
+            expect(fresh.cp.spawn).not.toHaveBeenCalled();
             await expect(formatPromise).rejects.toBeTruthy();
-            expect((vscodeMocked as any).window.showErrorMessage).not.toHaveBeenCalled();
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('/fake/tools/formatter/BBjCFCli.jar'));
+            expect(fresh.vscode.window.showErrorMessage).not.toHaveBeenCalled();
+
+            warnSpy.mockRestore();
         });
 
-        test('once-per-session toast dedup starts fresh on module reload (fresh session flag)', async () => {
-            vi.resetModules();
-            const freshModule = await import('../src/document-formatter.js');
-            const freshVerifier = await import('../src/formatter-verifier.js');
-            (freshVerifier.verifyFormatterArtifacts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        test('a fresh module load starts the once-per-session toast flag unset, independent of any earlier test in this file', async () => {
+            const fresh = await freshEnv();
+            fresh.verifyFormatterArtifacts.mockReturnValue({
                 ok: false,
                 reason: 'DIGEST_MISMATCH',
                 relativePath: 'BBjCFCli.jar',
@@ -301,10 +334,10 @@ describe('DocumentFormatter', () => {
 
             const doc = makeDocument('/tmp/sec08-fresh-session.bbj', 'rem hi');
             await expect(
-                freshModule.DocumentFormatter.provideDocumentFormattingEdits(doc)
+                fresh.DocumentFormatter.provideDocumentFormattingEdits(doc)
             ).rejects.toBeTruthy();
 
-            expect((vscodeMocked as any).window.showErrorMessage).toHaveBeenCalledTimes(1);
+            expect(fresh.vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/bbj-vscode/test/formatter-pins-drift.test.ts
+++ b/bbj-vscode/test/formatter-pins-drift.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+    FORMATTER_ARTIFACT_PINS,
+    FORMATTER_TOOLS_DIR,
+    formatterArtifactNames,
+} from '../src/formatter-verifier.js';
+
+/**
+ * Drift guard: recomputes SHA-256 over the real, on-disk
+ * `tools/formatter` artefacts and compares against the committed FORMATTER_ARTIFACT_PINS table,
+ * so updating a vendored JAR without updating its pin -- or adding one without pinning it --
+ * fails this suite instead of shipping silently. This is the guard the realistic failure mode
+ * targets: a legitimate formatter update where the pin blocks a release and the pressure is to
+ * disable the check rather than update the pin. Every assertion message below tells the updater
+ * what to do instead of only reporting that two values differ.
+ *
+ * No `vscode` mock and no `child_process` mock are needed -- this file, like
+ * formatter-verifier.ts itself, depends on neither.
+ */
+
+function recompute(absolutePath: string): { sha256: string; sizeBytes: number } {
+    const bytes = fs.readFileSync(absolutePath);
+    return {
+        sha256: crypto.createHash('sha256').update(bytes).digest('hex'),
+        sizeBytes: bytes.length,
+    };
+}
+
+function remediation(relativePath: string): string {
+    return (
+        `Recompute the SHA-256 for '${relativePath}' (sha256sum bbj-vscode/tools/formatter/${relativePath}), ` +
+        `update that entry's sha256, sizeBytes, and vendoredOn in bbj-vscode/src/formatter-verifier.ts, ` +
+        `and re-vendor deliberately -- do not disable or loosen this check to unblock a release.`
+    );
+}
+
+/** Every `.jar` file under `dir`, as paths relative to `baseDir`, POSIX-separated. */
+function scanForJarFiles(dir: string, baseDir: string = dir): string[] {
+    const results: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            results.push(...scanForJarFiles(fullPath, baseDir));
+        } else if (entry.isFile() && entry.name.endsWith('.jar')) {
+            results.push(path.relative(baseDir, fullPath).split(path.sep).join('/'));
+        }
+    }
+    return results.sort();
+}
+
+describe('formatter-pins-drift: committed pins vs. the real tools/formatter tree', () => {
+    for (const pin of FORMATTER_ARTIFACT_PINS) {
+        test(`${pin.relativePath}: real bytes on disk match the committed pin`, () => {
+            const absolutePath = path.join(FORMATTER_TOOLS_DIR, pin.relativePath);
+
+            expect(
+                fs.existsSync(absolutePath),
+                `Expected vendored artefact missing at ${absolutePath}. ${remediation(pin.relativePath)}`
+            ).toBe(true);
+
+            const { sha256, sizeBytes } = recompute(absolutePath);
+
+            expect(
+                sizeBytes,
+                `Size drift for '${pin.relativePath}': committed pin says ${pin.sizeBytes} bytes, ` +
+                    `the real file is ${sizeBytes} bytes. ${remediation(pin.relativePath)}`
+            ).toBe(pin.sizeBytes);
+
+            expect(
+                sha256,
+                `Digest drift for '${pin.relativePath}': the committed SHA-256 no longer matches the ` +
+                    `real file on disk. ${remediation(pin.relativePath)}`
+            ).toBe(pin.sha256.toLowerCase());
+        });
+    }
+
+    test('FORMATTER_ARTIFACT_PINS has exactly three entries, in declared order', () => {
+        expect(
+            FORMATTER_ARTIFACT_PINS,
+            'The pin table changed shape -- if an artefact was intentionally added or removed, ' +
+                'update this test alongside it; if not, this is a drift the table itself must not have.'
+        ).toHaveLength(3);
+        expect(formatterArtifactNames()).toEqual([
+            'BBjCFCli.jar',
+            'lib/jcommander-1.71.jar',
+            'lib/BBjCodeFomatter.jar',
+        ]);
+    });
+
+    test('every pinned entry carries a well-formed digest and non-empty provenance', () => {
+        for (const pin of FORMATTER_ARTIFACT_PINS) {
+            expect(
+                pin.sha256,
+                `'${pin.relativePath}' has a malformed sha256 pin (expected 64 lowercase hex characters). ` +
+                    remediation(pin.relativePath)
+            ).toMatch(/^[0-9a-f]{64}$/);
+            expect(
+                pin.origin.length,
+                `'${pin.relativePath}' has an empty origin field -- every pin needs a provenance note, ` +
+                    `not only a digest.`
+            ).toBeGreaterThan(0);
+            expect(
+                pin.vendoredOn.length,
+                `'${pin.relativePath}' has an empty vendoredOn field -- record the date the bytes ` +
+                    `entered this tree.`
+            ).toBeGreaterThan(0);
+        }
+    });
+
+    test('no .jar file under tools/formatter is missing a pin table entry', () => {
+        const onDisk = scanForJarFiles(FORMATTER_TOOLS_DIR);
+        const pinned = new Set(formatterArtifactNames());
+        const unpinned = onDisk.filter((relativePath) => !pinned.has(relativePath));
+
+        expect(
+            unpinned,
+            `Found .jar file(s) under tools/formatter with no pin table entry: ${unpinned.join(', ')}. ` +
+                `Add an entry to FORMATTER_ARTIFACT_PINS in bbj-vscode/src/formatter-verifier.ts ` +
+                `(relativePath, sha256, sizeBytes, origin, vendoredOn) and re-vendor deliberately before ` +
+                `merging -- do not ship an artefact the runtime gate has never checked.`
+        ).toEqual([]);
+    });
+});

--- a/bbj-vscode/test/formatter-verifier-tamper.test.ts
+++ b/bbj-vscode/test/formatter-verifier-tamper.test.ts
@@ -19,7 +19,8 @@ import {
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, '..', '..');
-const REAL_ARTIFACT_PATH = path.join(REPO_ROOT, 'bbj-vscode', 'tools', 'formatter', 'BBjCFCli.jar');
+const FORMATTER_DIR = path.join(REPO_ROOT, 'bbj-vscode', 'tools', 'formatter');
+const REAL_ARTIFACT_PATH = path.join(FORMATTER_DIR, 'BBjCFCli.jar');
 const REAL_ARTIFACT_BYTES = fs.readFileSync(REAL_ARTIFACT_PATH);
 const REAL_ARTIFACT_RELATIVE_PATH = FORMATTER_ARTIFACT_PINS[0].relativePath;
 
@@ -29,6 +30,25 @@ function newFixtureDir(prefix: string): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
     fixtureDirs.push(dir);
     return dir;
+}
+
+/** Writes bytes for a pinned artefact into a fixture directory, creating any `lib/` parent. */
+function writeArtifact(fixtureDir: string, relativePath: string, bytes: Buffer): void {
+    const absolutePath = path.join(fixtureDir, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, bytes);
+}
+
+/** Real vendored bytes for a pinned artefact, read once and reused across ordering fixtures. */
+function realBytesFor(relativePath: string): Buffer {
+    return fs.readFileSync(path.join(FORMATTER_DIR, relativePath));
+}
+
+/** Real bytes with the final byte flipped — same length, different digest. */
+function tamperedBytesFor(relativePath: string): Buffer {
+    const bytes = Buffer.from(realBytesFor(relativePath));
+    bytes[bytes.length - 1] ^= 0x01;
+    return bytes;
 }
 
 afterAll(() => {
@@ -117,15 +137,49 @@ describe('formatter-verifier-tamper: gate against real vendored bytes', () => {
         expect(result.ok).toBe(true);
     });
 
-    test('FORMATTER_ARTIFACT_PINS has exactly the number of entries this plan pins, in the order formatterArtifactNames() reports, each with a 64-character lowercase hex digest', () => {
-        // 77-01 pins one artefact (BBjCFCli.jar); a later plan in this phase adds the remaining
-        // two on top of this same structure. This count assertion is written so that plan
-        // updates one number rather than restructuring this test.
-        expect(FORMATTER_ARTIFACT_PINS).toHaveLength(1);
+    test('FORMATTER_ARTIFACT_PINS has all three vendored artefacts, in declared order, each with a 64-character lowercase hex digest and non-empty provenance', () => {
+        // All three artefacts that BBjCFCli.jar's own manifest transitively loads on every format
+        // are pinned, not only the launcher JAR itself.
+        expect(FORMATTER_ARTIFACT_PINS).toHaveLength(3);
+        expect(formatterArtifactNames()).toEqual([
+            'BBjCFCli.jar',
+            'lib/jcommander-1.71.jar',
+            'lib/BBjCodeFomatter.jar',
+        ]);
         expect(formatterArtifactNames()).toEqual(FORMATTER_ARTIFACT_PINS.map((pin) => pin.relativePath));
 
         for (const pin of FORMATTER_ARTIFACT_PINS) {
             expect(pin.sha256).toMatch(/^[0-9a-f]{64}$/);
+            expect(pin.origin.length).toBeGreaterThan(0);
+            expect(pin.vendoredOn.length).toBeGreaterThan(0);
+        }
+    });
+
+    test('with the second and third artefacts both corrupted, the reported failure is the second — declared order, first failure short-circuits', () => {
+        const fixtureDir = newFixtureDir('formatter-verifier-order-first-failure-');
+        writeArtifact(fixtureDir, 'BBjCFCli.jar', realBytesFor('BBjCFCli.jar'));
+        writeArtifact(fixtureDir, 'lib/jcommander-1.71.jar', tamperedBytesFor('lib/jcommander-1.71.jar'));
+        writeArtifact(fixtureDir, 'lib/BBjCodeFomatter.jar', tamperedBytesFor('lib/BBjCodeFomatter.jar'));
+
+        const result = verifyFormatterArtifacts(fixtureDir);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.relativePath).toBe('lib/jcommander-1.71.jar');
+        }
+    });
+
+    test('with only the third artefact corrupted, the reported failure is the third — later entries are actually reached', () => {
+        const fixtureDir = newFixtureDir('formatter-verifier-order-later-reached-');
+        writeArtifact(fixtureDir, 'BBjCFCli.jar', realBytesFor('BBjCFCli.jar'));
+        writeArtifact(fixtureDir, 'lib/jcommander-1.71.jar', realBytesFor('lib/jcommander-1.71.jar'));
+        writeArtifact(fixtureDir, 'lib/BBjCodeFomatter.jar', tamperedBytesFor('lib/BBjCodeFomatter.jar'));
+
+        const result = verifyFormatterArtifacts(fixtureDir);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.relativePath).toBe('lib/BBjCodeFomatter.jar');
         }
     });
 });

--- a/bbj-vscode/test/formatter-verifier-tamper.test.ts
+++ b/bbj-vscode/test/formatter-verifier-tamper.test.ts
@@ -58,9 +58,11 @@ afterAll(() => {
 });
 
 describe('formatter-verifier-tamper: gate against real vendored bytes', () => {
-    test('a fixture directory holding the real, unmodified artefact verifies ok', () => {
+    test('a fixture directory holding all three real, unmodified artefacts verifies ok', () => {
         const fixtureDir = newFixtureDir('formatter-verifier-verified-');
-        fs.writeFileSync(path.join(fixtureDir, REAL_ARTIFACT_RELATIVE_PATH), REAL_ARTIFACT_BYTES);
+        for (const relativePath of formatterArtifactNames()) {
+            writeArtifact(fixtureDir, relativePath, realBytesFor(relativePath));
+        }
 
         const result = verifyFormatterArtifacts(fixtureDir);
 
@@ -129,8 +131,17 @@ describe('formatter-verifier-tamper: gate against real vendored bytes', () => {
         expect(result.ok).toBe(false);
     });
 
-    test('an injected reader returning bytes that hash to the pinned value verifies ok, proving the seam is real', () => {
-        const injectedReader = () => Buffer.from(REAL_ARTIFACT_BYTES);
+    test('an injected reader returning bytes that hash to each pinned value verifies ok, proving the seam is real', () => {
+        // Maps the absolute path the verifier constructs back to the matching real artefact's
+        // bytes, so this still proves the seam for all three pins rather than only the first —
+        // the directory itself is never read, since every byte comes from this reader.
+        const injectedReader = (absolutePath: string) => {
+            const relativePath = formatterArtifactNames().find((name) => absolutePath.endsWith(name));
+            if (!relativePath) {
+                throw new Error(`unexpected path passed to injected reader: ${absolutePath}`);
+            }
+            return Buffer.from(realBytesFor(relativePath));
+        };
 
         const result = verifyFormatterArtifacts('/nonexistent/directory/that/is/never/read', injectedReader);
 

--- a/bbj-vscode/test/formatter-verifier-tamper.test.ts
+++ b/bbj-vscode/test/formatter-verifier-tamper.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, describe, expect, test } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    verifyFormatterArtifacts,
+    FORMATTER_ARTIFACT_PINS,
+    FORMATTER_TOOLS_DIR,
+    formatterArtifactNames,
+} from '../src/formatter-verifier.js';
+
+/**
+ * Tamper guard: exercises the real verifier against real vendored
+ * bytes for every refusal reason, plus the injection seam and the pin table's own shape. This test needed neither the
+ * `vscode` mock nor the `child_process` mock document-formatter.test.ts relies on, because
+ * formatter-verifier.ts depends on neither.
+ */
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, '..', '..');
+const REAL_ARTIFACT_PATH = path.join(REPO_ROOT, 'bbj-vscode', 'tools', 'formatter', 'BBjCFCli.jar');
+const REAL_ARTIFACT_BYTES = fs.readFileSync(REAL_ARTIFACT_PATH);
+const REAL_ARTIFACT_RELATIVE_PATH = FORMATTER_ARTIFACT_PINS[0].relativePath;
+
+const fixtureDirs: string[] = [];
+
+function newFixtureDir(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    fixtureDirs.push(dir);
+    return dir;
+}
+
+afterAll(() => {
+    for (const dir of fixtureDirs) {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+describe('formatter-verifier-tamper: gate against real vendored bytes', () => {
+    test('a fixture directory holding the real, unmodified artefact verifies ok', () => {
+        const fixtureDir = newFixtureDir('formatter-verifier-verified-');
+        fs.writeFileSync(path.join(fixtureDir, REAL_ARTIFACT_RELATIVE_PATH), REAL_ARTIFACT_BYTES);
+
+        const result = verifyFormatterArtifacts(fixtureDir);
+
+        expect(result.ok).toBe(true);
+    });
+
+    test('the live repository tree verifies ok through the same function the runtime calls', () => {
+        // Proves the committed pin matches the artefact actually on disk, through
+        // FORMATTER_TOOLS_DIR — the exact constant document-formatter.ts's runtime gate uses.
+        const result = verifyFormatterArtifacts(FORMATTER_TOOLS_DIR);
+
+        expect(result.ok).toBe(true);
+    });
+
+    test('a single flipped byte refuses with DIGEST_MISMATCH and does not verify', () => {
+        const fixtureDir = newFixtureDir('formatter-verifier-tampered-');
+        const tamperedBytes = Buffer.from(REAL_ARTIFACT_BYTES);
+        // Flip exactly one byte (XOR the final byte), keeping the length identical.
+        tamperedBytes[tamperedBytes.length - 1] ^= 0x01;
+        fs.writeFileSync(path.join(fixtureDir, REAL_ARTIFACT_RELATIVE_PATH), tamperedBytes);
+
+        const result = verifyFormatterArtifacts(fixtureDir);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe('DIGEST_MISMATCH');
+            expect(result.relativePath).toBe(REAL_ARTIFACT_RELATIVE_PATH);
+            expect(result.actualSha256).not.toBe(result.expectedSha256);
+        }
+    });
+
+    test('an empty fixture directory (missing artefact) refuses with MISSING_OR_UNREADABLE and names the expected path', () => {
+        const fixtureDir = newFixtureDir('formatter-verifier-absent-');
+
+        const result = verifyFormatterArtifacts(fixtureDir);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe('MISSING_OR_UNREADABLE');
+            expect(result.absolutePath).toContain(REAL_ARTIFACT_RELATIVE_PATH);
+        }
+    });
+
+    test('a present-but-zero-length artefact is readable, so it hashes and refuses with DIGEST_MISMATCH, not MISSING_OR_UNREADABLE', () => {
+        // Deliberate rule, not an accident: a truncated artefact is indistinguishable from a
+        // substituted one to this function, and readability (not size) selects the reason —
+        // the stronger DIGEST_MISMATCH signal is the safer default for a zero-byte file.
+        const fixtureDir = newFixtureDir('formatter-verifier-empty-');
+        fs.writeFileSync(path.join(fixtureDir, REAL_ARTIFACT_RELATIVE_PATH), Buffer.alloc(0));
+
+        const result = verifyFormatterArtifacts(fixtureDir);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe('DIGEST_MISMATCH');
+        }
+    });
+
+    test('an injected reader that throws never falls open — the result is a refusal, not a thrown error', () => {
+        const throwingReader = () => {
+            throw new Error('synthetic read failure');
+        };
+
+        expect(() => verifyFormatterArtifacts(FORMATTER_TOOLS_DIR, throwingReader)).not.toThrow();
+        const result = verifyFormatterArtifacts(FORMATTER_TOOLS_DIR, throwingReader);
+        expect(result.ok).toBe(false);
+    });
+
+    test('an injected reader returning bytes that hash to the pinned value verifies ok, proving the seam is real', () => {
+        const injectedReader = () => Buffer.from(REAL_ARTIFACT_BYTES);
+
+        const result = verifyFormatterArtifacts('/nonexistent/directory/that/is/never/read', injectedReader);
+
+        expect(result.ok).toBe(true);
+    });
+
+    test('FORMATTER_ARTIFACT_PINS has exactly the number of entries this plan pins, in the order formatterArtifactNames() reports, each with a 64-character lowercase hex digest', () => {
+        // 77-01 pins one artefact (BBjCFCli.jar); a later plan in this phase adds the remaining
+        // two on top of this same structure. This count assertion is written so that plan
+        // updates one number rather than restructuring this test.
+        expect(FORMATTER_ARTIFACT_PINS).toHaveLength(1);
+        expect(formatterArtifactNames()).toEqual(FORMATTER_ARTIFACT_PINS.map((pin) => pin.relativePath));
+
+        for (const pin of FORMATTER_ARTIFACT_PINS) {
+            expect(pin.sha256).toMatch(/^[0-9a-f]{64}$/);
+        }
+    });
+});

--- a/bbj-vscode/test/no-shell-command-construction.test.ts
+++ b/bbj-vscode/test/no-shell-command-construction.test.ts
@@ -100,4 +100,23 @@ describe('no-shell-command-construction guard — which modules may launch a pro
         const source = readStripped(path.join(SRC_DIR, 'language', 'bbj-cpl-service.ts'));
         expect(source).toMatch(/import\s*\{\s*resolveBbjBinary\s*\}\s*from\s*['"]\.\.\/bbj-home-layout\.js['"]/);
     });
+
+    // The bundled formatter JARs are checked against committed
+    // checksums before they run. These two tests exist so a later refactor cannot quietly drop
+    // that check — one asserts the import is still present, the other asserts the verification
+    // call still precedes the spawn it gates.
+    test('document-formatter.ts still imports the formatter verifier', () => {
+        const source = readStripped(path.join(SRC_DIR, 'document-formatter.ts'));
+        expect(source).toMatch(/import\s*\{[^}]*\bverifyFormatterArtifacts\b[^}]*\}\s*from\s*['"]\.\/formatter-verifier\.js['"]/);
+    });
+
+    test('document-formatter.ts cannot reach cp.spawn( without first calling verifyFormatterArtifacts(', () => {
+        const source = readStripped(path.join(SRC_DIR, 'document-formatter.ts'));
+        const verifyCallIndex = source.indexOf('verifyFormatterArtifacts(');
+        const spawnCallIndex = source.indexOf('cp.spawn(');
+
+        expect(verifyCallIndex).toBeGreaterThan(-1);
+        expect(spawnCallIndex).toBeGreaterThan(-1);
+        expect(verifyCallIndex).toBeLessThan(spawnCallIndex);
+    });
 });


### PR DESCRIPTION
## What

Before the BBj formatter runs, the extension now checks each of the three bundled formatter artefacts (`tools/formatter/BBjCFCli.jar`, `tools/formatter/lib/jcommander-1.71.jar`, `tools/formatter/lib/BBjCodeFomatter.jar`) against a SHA-256 pinned in `bbj-vscode/src/formatter-verifier.ts`. If an artefact does not match, formatting is cancelled instead of run:

- **Checksum mismatch:** one error notification per extension-host session, plus a warning log line on every attempt carrying the expected and actual digests.
- **Missing or unreadable artefact:** a warning log line naming the expected path, no notification (this is a broken install, not a changed file).

Reinstalling the extension restores the bundled formatter. When all three artefacts match, behaviour is unchanged and nothing is logged.

## Guards

- **Tamper guard** (`test/formatter-verifier-tamper.test.ts`): runs the real verifier against the real vendored bytes for every refusal reason, plus the pin table's shape and ordering.
- **Drift guard** (`test/formatter-pins-drift.test.ts`): recomputes digests over `tools/formatter` and compares them to the pin table, so re-vendoring a JAR without updating its pin, or adding an unpinned JAR, fails the suite.
- **Source guard** (`test/no-shell-command-construction.test.ts`): asserts `document-formatter.ts` still imports the verifier and calls it before `cp.spawn`.

## Testing

- `npm run build` and the four affected test files pass locally (38 tests). CI runs the whole suite.
- Opened as a draft so the PR VSIX workflow produces an installable `.vsix` from this branch for manual testing of the packaged path on a separate machine: format a `.bbj` file normally, then corrupt or remove one of the three JARs inside the installed extension directory and confirm the refusal and the message wording above.
